### PR TITLE
Document our usage of a pinned version of Flutter

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -137,14 +137,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.8"
   dbus:
     dependency: transitive
     description:
@@ -943,4 +935,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.4 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: "3.38.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ^3.10.4
+  # pinned version used for automated testing and releases
   flutter: 3.38.6
 
 dependencies:


### PR DESCRIPTION
This value is automatically parsed by our GitHub Actions setup to ensure consistency in test results and releases. We do not currently have any local environmental enforcement, and this value will need to be bumped manually upon new Flutter releases.