### PR TITLE
Add workflow for automatically drafting releases

### DIFF
--- a/.github/workflows/auto-draft-release.yml
+++ b/.github/workflows/auto-draft-release.yml
@@ -1,0 +1,15 @@
+name: auto-draft release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  draft_release:
+    name: draft release
+    permissions:
+      contents: write
+    uses: EarthmanMuons/reusable-workflows/.github/workflows/draft-release-flutter.yml@main
+    with:
+      slug: whatchord

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ migrate_working_dir/
 /build/
 /coverage/
 
+/dist/
 android/*.p12
 android/key.properties
 flutter_*.png

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: what_chord
 description: Real-time chord identification via Bluetooth MIDI.
 
 publish_to: none
-version: 1.0.0+1
+version: 0.8.0
 
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
I've taken our version back to 0.8.0 so we can do a bit more polishing and testing of the app and these workflows before cutting a real 1.0 release.