### PR TITLE
Check typos against all files, not just changed or added

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -44,8 +44,6 @@ jobs:
     needs: detect_changed_files
     if: needs.detect_changed_files.outputs.added_or_modified == 'true'
     uses: EarthmanMuons/reusable-workflows/.github/workflows/check-spelling.yml@main
-    with:
-      files: ${{ needs.detect_changed_files.outputs.added_or_modified_files }}
 
   ready_to_merge:
     name: ready to merge


### PR DESCRIPTION
This is a subtle issue, but you can't currently use the `--force-exclude` flag in the typos GitHub Action, so our excluded files in the configuration file will still cause the job to fail if we list them explicitly on the command line. While it makes logical sense that we'd only want to spell check files that changed in the PR, it doesn't actually save much time, and also hides typos in the project that may be uncovered by new releases of the typos project, but in files that we haven't touched. Removing the files input and just checking the whole repo matches the local behavior and should keep things more consistent overall.

See:
- https://github.com/crate-ci/typos/issues/1225