### PR TITLE
Use Bash repo_root structure consistently in scripts

### DIFF
--- a/bin/chord-debug
+++ b/bin/chord-debug
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root=""
-
-if command -v git >/dev/null 2>&1; then
-	repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-fi
-
-if [[ -z $repo_root ]] && command -v jj >/dev/null 2>&1; then
-	repo_root="$(jj workspace root 2>/dev/null || true)"
-fi
-
-if [[ -z $repo_root ]]; then
-	echo "Could not determine repo root (not in a Git work tree or jj workspace)." >&2
+die() {
+	printf "ERROR: %s\n" "$*" >&2
 	exit 1
+}
+
+repo_root=""
+if [[ -n ${GITHUB_WORKSPACE-} ]]; then
+	repo_root=$GITHUB_WORKSPACE
+else
+	if command -v git >/dev/null 2>&1; then
+		repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+	fi
+	if [[ -z $repo_root ]] && command -v jj >/dev/null 2>&1; then
+		repo_root="$(jj workspace root 2>/dev/null || true)"
+	fi
+fi
+if [[ -z $repo_root ]]; then
+	die "Could not determine repo root (not in a Git work tree or jj workspace)."
 fi
 
 exec dart run "$repo_root/tool/chord_debug.dart" "$@"

--- a/bin/stage-release-assets
+++ b/bin/stage-release-assets
@@ -3,7 +3,7 @@ set -euo pipefail
 
 die() {
 	printf "ERROR: %s\n" "$*" >&2
-	exit 2
+	exit 1
 }
 info() { printf "INFO: %s\n" "$*" >&2; }
 
@@ -66,20 +66,16 @@ else
 fi
 
 repo_root=""
-
-# In GitHub Actions, this is authoritative and already correct.
 if [[ -n ${GITHUB_WORKSPACE-} ]]; then
 	repo_root=$GITHUB_WORKSPACE
 else
 	if command -v git >/dev/null 2>&1; then
 		repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 	fi
-
 	if [[ -z $repo_root ]] && command -v jj >/dev/null 2>&1; then
 		repo_root="$(jj workspace root 2>/dev/null || true)"
 	fi
 fi
-
 if [[ -z $repo_root ]]; then
 	die "Could not determine repo root (not in a Git work tree or jj workspace)."
 fi


### PR DESCRIPTION
Since these scripts are not general tools, but used within this repository project specifically, using the Git tooling to determine and normalize our location is the safest route. Other methods have trade-offs.

See:
- https://mywiki.wooledge.org/BashFAQ/028