### PR TITLE
Keep a versionCode as a monotonic build counter

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: whatchord
 description: Real-time chord identification via Bluetooth MIDI.
 
 publish_to: none
-version: 0.8.0
+version: 0.8.0+1
 
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
I had previously removed this without understanding its uses across the Android ecosystem. It's broadly used as a monotonically increasing integer for the entire lifetime of the app, and does not reset on new versions. It's the only value Android cares about to determine upgrade/downgrade paths. We'll need to bump it each time we cut a release.

See:
- https://developer.android.com/studio/publish/versioning#versioningsettings