### PR TITLE
Add script to automate bumping the pubspec.yaml version

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+	printf "ERROR: %s\n" "$*" >&2
+	exit 1
+}
+
+usage() {
+	cat >&2 <<'EOF'
+Usage:
+  bump-version (patch|minor|major|X.Y.Z)
+
+Behavior:
+  - Reads pubspec.yaml version: X.Y.Z+N
+  - If patch/minor/major: bumps that semver component, resets lower components to 0
+  - If exact version provided (X.Y.Z): sets semver to that X.Y.Z
+  - Always increments build number by 1 based on the current pubspec build number
+EOF
+	exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+arg="$1"
+
+repo_root=""
+if [[ -n ${GITHUB_WORKSPACE-} ]]; then
+	repo_root=$GITHUB_WORKSPACE
+else
+	if command -v git >/dev/null 2>&1; then
+		repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+	fi
+	if [[ -z $repo_root ]] && command -v jj >/dev/null 2>&1; then
+		repo_root="$(jj workspace root 2>/dev/null || true)"
+	fi
+fi
+[[ -n $repo_root ]] || die "Could not determine repo root (not in a Git work tree or jj workspace)."
+
+pubspec="$repo_root/pubspec.yaml"
+[[ -f $pubspec ]] || die "pubspec.yaml not found at: $pubspec"
+
+# ---- read current version line ----
+# Expect a line like: version: 0.8.0+1
+# We accept whitespace around ':' and strip trailing comments/spaces.
+version_line="$(grep -E '^[[:space:]]*version[[:space:]]*:' "$pubspec" | head -n 1 || true)"
+[[ -n $version_line ]] || die "Could not find a 'version:' line in pubspec.yaml"
+
+current_version="$(sed -E 's/^[[:space:]]*version[[:space:]]*:[[:space:]]*([^[:space:]#]+).*/\1/' <<<"$version_line")"
+
+# Validate current format strictly: X.Y.Z+N where all are non-negative integers.
+if [[ ! $current_version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)\+([0-9]+)$ ]]; then
+	die "Current pubspec version must match X.Y.Z+N (got: '$current_version')"
+fi
+
+cur_major="${BASH_REMATCH[1]}"
+cur_minor="${BASH_REMATCH[2]}"
+cur_patch="${BASH_REMATCH[3]}"
+cur_build="${BASH_REMATCH[4]}"
+
+next_build=$((cur_build + 1))
+
+new_major="$cur_major"
+new_minor="$cur_minor"
+new_patch="$cur_patch"
+
+# ---- compute new semver ----
+case "$arg" in
+patch)
+	new_patch=$((cur_patch + 1))
+	;;
+minor)
+	new_minor=$((cur_minor + 1))
+	new_patch=0
+	;;
+major)
+	new_major=$((cur_major + 1))
+	new_minor=0
+	new_patch=0
+	;;
+*)
+	# Exact version: X.Y.Z (build suffix not allowed because we always bump build from current)
+	if [[ $arg =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)\+([0-9]+)$ ]]; then
+		die "Do not include a build suffix (+N). Build numbers are bumped automatically from pubspec.yaml."
+	fi
+
+	if [[ $arg =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+		new_major="${BASH_REMATCH[1]}"
+		new_minor="${BASH_REMATCH[2]}"
+		new_patch="${BASH_REMATCH[3]}"
+	else
+		die "Invalid argument '$arg' (expected patch|minor|major|X.Y.Z)"
+	fi
+	;;
+esac
+
+new_version="${new_major}.${new_minor}.${new_patch}+${next_build}"
+
+# ---- update pubspec.yaml ----
+# Replace only the first version: line occurrence, preserving indentation, replacing token after ':'.
+tmp="$(mktemp)"
+awk -v newver="$new_version" '
+  BEGIN { done=0 }
+  {
+    if (!done && $0 ~ /^[[:space:]]*version[[:space:]]*:/) {
+      # Capture "version:   " prefix exactly (including indentation + spacing)
+      match($0, /^[[:space:]]*version[[:space:]]*:[[:space:]]*/)
+      prefix = substr($0, RSTART, RLENGTH)
+
+      # Remainder of the line after the prefix (may include inline comments)
+      rest = substr($0, RLENGTH + 1)
+
+      # Replace only the first token (up to whitespace or #), preserve trailing comment if present
+      sub(/^[^[:space:]#]+/, newver, rest)
+
+      print prefix rest
+      done=1
+      next
+    }
+    print
+  }
+  END { if (!done) exit 3 }
+' "$pubspec" >"$tmp" || {
+	rc=$?
+	[[ $rc -eq 3 ]] && die "Failed to update: no version line found during rewrite"
+	die "Failed to update pubspec.yaml (awk exit $rc)"
+}
+
+mv "$tmp" "$pubspec"
+
+echo "Updated pubspec.yaml:"
+echo "  $current_version  ->  $new_version"


### PR DESCRIPTION
Automatically handles the bumping of the monotonic versionCode and respects SemVer.