### PR TITLE
Switch to versioning using CalVer instead of SemVer

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -2,20 +2,9 @@ name: bump version
 
 on:
   workflow_dispatch:
-    inputs:
-      level:
-        description: Bump level
-        required: true
-        type: choice
-        options:
-          - major
-          - minor
-          - patch
 
 jobs:
   bump_version:
     name: bump version
-    uses: EarthmanMuons/reusable-workflows/.github/workflows/bump-version-flutter.yml@main
-    with:
-      level: ${{ inputs.level }}
+    uses: EarthmanMuons/reusable-workflows/.github/workflows/bump-version-flutter-app.yml@main
     secrets: inherit


### PR DESCRIPTION
This makes more sense for a user-facing app that has no need for dependency contraints or metadata regarding version bumps.