### PR TITLE
Add missing toolbox_envy_bins input for tagging workflow

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -26,4 +26,6 @@ jobs:
       needs.detect_changed_files.outputs.flutter == 'true'
       || github.event_name == 'workflow_dispatch'
     uses: EarthmanMuons/reusable-workflows/.github/workflows/tag-if-missing.yml@main
+    with:
+      toolbox_envy_bins: common,flutter
     secrets: inherit


### PR DESCRIPTION
This is required as it relies on the conventional script names used across ecosystems.