### PR TITLE
Add slight right padding to the app bar to avoid edge-cling

### DIFF
--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -57,7 +57,7 @@ class _HomePageState extends ConsumerState<HomePage> {
         final iconSize = isLandscape ? 20.0 : 24.0;
 
         final appBarPadLeft = isLandscape ? 24.0 : 16.0;
-        final appBarPadRight = isLandscape ? 16.0 : 0.0;
+        final appBarPadRight = isLandscape ? 16.0 : 4.0;
 
         const tonalityPadBase = 16.0;
         const tonalityPadCutout = 12.0;


### PR DESCRIPTION
This makes the spacing look even when in portrait orientation as well.