### PR TITLE
Direct people to email support if they don't have a GitHub account

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Email support (no GitHub account required)
+    url: mailto:support@earthmanmuons.com
+    about: >
+      If you don't have a GitHub account, or prefer email, you can contact us directly here.


### PR DESCRIPTION
Uses the Issue Forms configuration to present external contact info before the GitHub authentication request.

See:
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser