### PR TITLE
Add a SUPPORT.md document that can be linked to from our Issue Forms

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,30 @@
+# WhatChord Support
+
+If you've found a bug or have a question:
+
+## Option 1: GitHub Issues (preferred)
+
+If you have a GitHub account, please open a [new issue][1] so we can track it
+publicly.
+
+[1]: https://github.com/EarthmanMuons/whatchord/issues
+
+## Option 2: Email support (no GitHub account required)
+
+If you don't use GitHub, you can contact us directly:
+
+📧 [support@earthmanmuons.com][2]
+
+[2]: mailto:support@earthmanmuons.com
+
+Please include:
+
+- App version
+- Device and OS
+- A brief description of the problem
+
+## 🔍 Incorrect chord identification?
+
+If you think WhatChord has identified a chord incorrectly, please include the
+copied _Analysis Details_ from the app if possible, as this helps us reproduce
+the exact analysis context.


### PR DESCRIPTION
It's invalid to use a mailto: link directly inside of the url field of the Issue Forms configuration, so we'll make a dedicated doc we can link to instead.