### PR TITLE
Show copy affordance when long pressing the version info

### DIFF
--- a/lib/features/home/widgets/analysis_details_sheet.dart
+++ b/lib/features/home/widgets/analysis_details_sheet.dart
@@ -1,4 +1,3 @@
-import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -82,20 +81,12 @@ Future<void> showAnalysisDetailsSheet(
                       child: FilledButton.icon(
                         onPressed: canCopy
                             ? () async {
-                                final messenger = Platform.isIOS
-                                    ? ScaffoldMessenger.maybeOf(context)
-                                    : null;
-
                                 await Clipboard.setData(
                                   ClipboardData(text: copyText),
                                 );
 
-                                messenger?.hideCurrentSnackBar();
-                                messenger?.showSnackBar(
-                                  const SnackBar(
-                                    content: Text('Copied to clipboard'),
-                                  ),
-                                );
+                                // Subtle confirmation without UI chrome.
+                                HapticFeedback.selectionClick();
                               }
                             : null,
                         icon: const Icon(Icons.copy),

--- a/lib/features/settings/pages/settings_page.dart
+++ b/lib/features/settings/pages/settings_page.dart
@@ -1,3 +1,4 @@
+import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -171,13 +172,22 @@ class SettingsPage extends ConsumerWidget {
                   ),
               onLongPress: () async {
                 final version = ref.read(appVersionProvider).asData?.value;
-
                 if (version == null) return;
+
+                final messenger = Platform.isIOS
+                    ? ScaffoldMessenger.maybeOf(context)
+                    : null;
 
                 await Clipboard.setData(
                   ClipboardData(text: 'WhatChord v$version'),
                 );
+
                 HapticFeedback.selectionClick();
+
+                messenger?.hideCurrentSnackBar();
+                messenger?.showSnackBar(
+                  const SnackBar(content: Text('Copied to clipboard')),
+                );
               },
             ),
 


### PR DESCRIPTION
This is only needed on iOS, as we automatically get a system pop-up on Android. For the explicit copy action under Analysis Details, we'll just mirror the haptic feedback for consistency.