### PR TITLE
Cut a fresh automated release of v2026.2.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: whatchord
 description: Real-time chord identification via Bluetooth MIDI.
 
 publish_to: none
-version: 2026.2.4+5
+version: 2026.2.4+6
 
 environment:
   sdk: ^3.10.8


### PR DESCRIPTION
These normally happen all in CI, but we were missing our ExportOptions.plist file to build cleaning on our GitHub Actions runner, and we don't need a full version bump, so manually bumping the build number should get things going again.