### PR TITLE
Clamp home app bar title to toolbar height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 - Replaced the MIDI status pill in the home app bar with a compact status icon
   button to improve legibility and avoid layout overflow at large text sizes.
+- Clamped the home app bar title text scaling to the toolbar height to keep the
+  title visible when system text size is increased.
 - Improved input display scaling at larger system text sizes, including the
   pedal indicator and note chip sizing to prevent clipping and keep spacing
   balanced.

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -154,7 +154,7 @@ class _HomeTopBar extends ConsumerWidget {
               Expanded(
                 child: DefaultTextStyle(
                   style: titleStyle!,
-                  child: const AppBarTitle(),
+                  child: AppBarTitle(maxHeight: toolbarHeight),
                 ),
               ),
               const SizedBox(width: 4),

--- a/lib/features/home/widgets/app_bar_title.dart
+++ b/lib/features/home/widgets/app_bar_title.dart
@@ -7,14 +7,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:whatchord/features/demo/demo.dart';
 
 class AppBarTitle extends ConsumerWidget {
-  const AppBarTitle({
-    super.key,
-    this.maxLines = 1,
-    this.overflow = TextOverflow.ellipsis,
-  });
+  const AppBarTitle({super.key, this.maxHeight});
 
-  final int maxLines;
-  final TextOverflow overflow;
+  final double? maxHeight;
 
   // Set to true for ad-hoc demo builds (e.g. iOS device untethered from Xcode).
   static const bool kForceDemoSupport = false;
@@ -31,8 +26,8 @@ class AppBarTitle extends ConsumerWidget {
           ),
         ],
       ),
-      maxLines: maxLines,
-      overflow: overflow,
+      maxLines: 1,
+      overflow: TextOverflow.clip,
       softWrap: false,
     );
 
@@ -76,7 +71,7 @@ class AppBarTitle extends ConsumerWidget {
 
     final baseStyle = DefaultTextStyle.of(context).style;
 
-    return Text.rich(
+    final debugTitle = Text.rich(
       TextSpan(
         children: [
           WidgetSpan(
@@ -101,9 +96,27 @@ class AppBarTitle extends ConsumerWidget {
           ),
         ],
       ),
-      maxLines: maxLines,
-      overflow: overflow,
+      maxLines: 1,
+      overflow: TextOverflow.clip,
       softWrap: false,
+    );
+    return _clampToHeight(context, debugTitle);
+  }
+
+  Widget _clampToHeight(BuildContext context, Widget title) {
+    final maxHeight = this.maxHeight;
+    if (maxHeight == null) return title;
+
+    return SizedBox(
+      height: maxHeight,
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          alignment: Alignment.centerLeft,
+          child: title,
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
This keeps the title visible at large text sizes.