### PR TITLE
Remove environment-scoped vars and secrets from the caller workflow

### DIFF
--- a/.github/workflows/auto-draft-release.yml
+++ b/.github/workflows/auto-draft-release.yml
@@ -11,15 +11,5 @@ jobs:
     permissions:
       contents: write
     uses: EarthmanMuons/reusable-workflows/.github/workflows/draft-release-flutter.yml@main
-    secrets:
-      ANDROID_APP_SIGNING_KEYSTORE_B64: ${{ secrets.ANDROID_APP_SIGNING_KEYSTORE_B64 }}
-      ANDROID_APP_SIGNING_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_APP_SIGNING_KEYSTORE_PASSWORD }}
-      ANDROID_APP_SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_APP_SIGNING_KEY_PASSWORD }}
-      ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
-      ANDROID_UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
-      ANDROID_UPLOAD_KEY_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEY_PASSWORD }}
-      IOS_SIGNING_CERT_B64: ${{ secrets.IOS_SIGNING_CERT_B64 }}
-      IOS_SIGNING_CERT_PASSWORD: ${{ secrets.IOS_SIGNING_CERT_PASSWORD }}
-      IOS_PROVISIONING_PROFILE_B64: ${{ secrets.IOS_PROVISIONING_PROFILE_B64 }}
     with:
       slug: whatchord

--- a/.github/workflows/on-published-release.yml
+++ b/.github/workflows/on-published-release.yml
@@ -17,9 +17,6 @@ jobs:
     uses: EarthmanMuons/reusable-workflows/.github/workflows/upload-build-android.yml@main
     with:
       release_tag: ${{ github.event.release.tag_name }}
-      gcp_wif_provider: ${{ vars.GCP_WIF_PROVIDER }}
-      gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-      package_name: ${{ vars.GOOGLE_PLAY_PACKAGE_NAME }}
       track: alpha
       release_status: draft
 
@@ -27,9 +24,5 @@ jobs:
     name: upload build
     if: github.event.release.prerelease == false
     uses: EarthmanMuons/reusable-workflows/.github/workflows/upload-build-ios.yml@main
-    secrets:
-      ASC_AUTH_KEY_B64: ${{ secrets.ASC_AUTH_KEY_B64 }}
     with:
       release_tag: ${{ github.event.release.tag_name }}
-      asc_issuer_id: ${{ vars.ASC_ISSUER_ID }}
-      asc_key_id: ${{ vars.ASC_KEY_ID }}


### PR DESCRIPTION
The signing was only working previously by coincidence, since we moved these values into a repository environment, they aren't actually available here in the call site, only inside of the jobs defined in the reusable workflows, so we rely on convention, documentation, and validation on the other side to ensure we've done this correctly for both the signing and release environmental jobs.

See:
- https://github.com/EarthmanMuons/reusable-workflows/pull/189