### PR TITLE
Revert back to explicitly passing the used secrets through

### DIFF
--- a/.github/workflows/auto-draft-release.yml
+++ b/.github/workflows/auto-draft-release.yml
@@ -11,5 +11,15 @@ jobs:
     permissions:
       contents: write
     uses: EarthmanMuons/reusable-workflows/.github/workflows/draft-release-flutter.yml@main
+    secrets:
+      ANDROID_APP_SIGNING_KEYSTORE_B64: ${{ secrets.ANDROID_APP_SIGNING_KEYSTORE_B64 }}
+      ANDROID_APP_SIGNING_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_APP_SIGNING_KEYSTORE_PASSWORD }}
+      ANDROID_APP_SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_APP_SIGNING_KEY_PASSWORD }}
+      ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
+      ANDROID_UPLOAD_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
+      ANDROID_UPLOAD_KEY_PASSWORD: ${{ secrets.ANDROID_UPLOAD_KEY_PASSWORD }}
+      IOS_SIGNING_CERT_B64: ${{ secrets.IOS_SIGNING_CERT_B64 }}
+      IOS_SIGNING_CERT_PASSWORD: ${{ secrets.IOS_SIGNING_CERT_PASSWORD }}
+      IOS_PROVISIONING_PROFILE_B64: ${{ secrets.IOS_PROVISIONING_PROFILE_B64 }}
     with:
       slug: whatchord

--- a/.github/workflows/on-published-release.yml
+++ b/.github/workflows/on-published-release.yml
@@ -24,5 +24,7 @@ jobs:
     name: upload build
     if: github.event.release.prerelease == false
     uses: EarthmanMuons/reusable-workflows/.github/workflows/upload-build-ios.yml@main
+    secrets:
+      ASC_AUTH_KEY_B64: ${{ secrets.ASC_AUTH_KEY_B64 }}
     with:
       release_tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Even though these values aren't available to the caller, something about GitHub's setup of environmental secrets and reusable workflows means we have to declare them and pass the secret mapping from the caller (or use `inherit`).