### PR TITLE
Add pause control for the site animation

### DIFF
--- a/docs/site/css/style.css
+++ b/docs/site/css/style.css
@@ -368,7 +368,8 @@ section {
 }
 
 .motion-media .motion-video,
-.motion-media .motion-fallback {
+.motion-media .motion-fallback,
+.motion-toggle {
   grid-area: 1 / 1;
 }
 
@@ -386,8 +387,86 @@ section {
   pointer-events: none;
 }
 
+.motion-toggle {
+  align-self: end;
+  justify-self: start;
+  width: 44px;
+  height: 44px;
+  margin: 16px;
+  border: 1px solid rgba(234 234 242 / 0.16);
+  border-radius: 50%;
+  background: rgba(78 78 101 / 0.34);
+  color: rgba(255 255 255 / 0.82);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 2px 10px rgba(0 0 0 / 0.22);
+  backdrop-filter: blur(12px) saturate(1.2);
+  -webkit-backdrop-filter: blur(12px) saturate(1.2);
+  transition:
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    opacity 0.16s ease;
+}
+
+.motion-toggle[hidden] {
+  display: none;
+}
+
+.motion-toggle:hover {
+  background: rgba(78 78 101 / 0.58);
+  border-color: rgba(234 234 242 / 0.28);
+  color: rgba(255 255 255 / 0.94);
+}
+
+.motion-toggle:focus-visible {
+  outline: 3px solid var(--accent-light);
+  outline-offset: 3px;
+  background: rgba(78 78 101 / 0.68);
+  border-color: rgba(234 234 242 / 0.34);
+  color: #fff;
+}
+
+.motion-toggle svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+
+.motion-toggle-play {
+  display: none;
+  transform: translateX(1px);
+}
+
+.motion-media.is-video-active .motion-toggle {
+  opacity: 0.72;
+  pointer-events: auto;
+}
+
+.motion-media.is-video-active:hover .motion-toggle,
+.motion-media.is-video-active .motion-toggle:focus-visible {
+  opacity: 1;
+}
+
+.motion-media.is-video-paused .motion-toggle-pause {
+  display: none;
+}
+
+.motion-media.is-video-paused .motion-toggle-play {
+  display: block;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .motion-video {
+    display: none;
+  }
+
+  .motion-toggle {
     display: none;
   }
 }

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -119,6 +119,31 @@
                   src="images/real_time.webp"
                   alt="WhatChord identifying G7/B in real time, showing the chord name and piano keyboard"
                 />
+                <button
+                  class="motion-toggle"
+                  type="button"
+                  aria-label="Pause animation"
+                  data-motion-toggle
+                  hidden
+                >
+                  <svg
+                    class="motion-toggle-pause"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <path d="M8 5h3v14H8z" />
+                    <path d="M13 5h3v14h-3z" />
+                  </svg>
+                  <svg
+                    class="motion-toggle-play"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <path d="M8 5v14l11-7z" />
+                  </svg>
+                </button>
               </div>
             </div>
 
@@ -387,20 +412,61 @@
 
         document.querySelectorAll("[data-motion-media]").forEach(function (el) {
           var video = el.querySelector("[data-motion-video]");
+          var toggle = el.querySelector("[data-motion-toggle]");
           if (!video) return;
+
+          function setPaused(isPaused) {
+            el.classList.toggle("is-video-paused", isPaused);
+            if (toggle) {
+              toggle.setAttribute(
+                "aria-label",
+                isPaused ? "Play animation" : "Pause animation",
+              );
+            }
+          }
+
+          function activateVideoControl() {
+            el.classList.add("is-video-active");
+            setPaused(video.paused);
+            if (toggle) {
+              toggle.hidden = false;
+            }
+          }
 
           function activateVideo() {
             var play = video.play();
             if (play && typeof play.then === "function") {
               play
                 .then(function () {
-                  el.classList.add("is-video-active");
+                  activateVideoControl();
                 })
                 .catch(function () {});
               return;
             }
 
-            el.classList.add("is-video-active");
+            activateVideoControl();
+          }
+
+          if (toggle) {
+            toggle.addEventListener("click", function () {
+              if (video.paused) {
+                var play = video.play();
+                if (play && typeof play.then === "function") {
+                  play
+                    .then(function () {
+                      activateVideoControl();
+                    })
+                    .catch(function () {});
+                  return;
+                }
+
+                activateVideoControl();
+                return;
+              }
+
+              video.pause();
+              setPaused(true);
+            });
           }
 
           if (video.readyState >= 3) {


### PR DESCRIPTION
The real-time feature loop autoplays and runs longer than five seconds, so give visitors a direct way to pause and resume the motion. This complements prefers-reduced-motion for users who have not set an OS-level preference or only find this particular animation distracting.

Use an accessible icon button with play/pause labels, keep it hidden until the video is active, and place it in the lower-left corner so it avoids covering the active piano keys.