### PR TITLE
Make explore mode build chords from musical controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The format is based on [Keep a Changelog][1], and this project adheres to
   chords, plus flat-ninth colors for sixth chords, including symbols like Am#11
   and Cm6b9.
 
+### Changed
+
+- Changed Explore Chords to build chords from separate base quality, sixth or
+  seventh, and fifth controls instead of one long quality list.
+
 ### Fixed
 
 - Fixed chord ranking so complete triads are preferred over incomplete inverted

--- a/lib/features/explore/models/explore_chord_spec.dart
+++ b/lib/features/explore/models/explore_chord_spec.dart
@@ -1,0 +1,343 @@
+import 'package:meta/meta.dart';
+
+import 'package:whatchord/features/theory/theory.dart';
+
+enum ExploreBaseQuality { major, minor, diminished, augmented, sus2, sus4 }
+
+enum ExploreSeventhKind {
+  none,
+  sixth,
+  dominant7,
+  major7,
+  minor7,
+  minorMajor7,
+  halfDiminished7,
+  diminished7,
+}
+
+enum ExploreFifthAlteration { natural, flat, sharp }
+
+@immutable
+class ExploreChordSpec {
+  const ExploreChordSpec({
+    required this.baseQuality,
+    required this.seventhKind,
+    required this.fifthAlteration,
+  });
+
+  factory ExploreChordSpec.fromQuality(ChordQualityToken quality) {
+    return switch (quality) {
+      ChordQualityToken.major => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.major,
+        seventhKind: ExploreSeventhKind.none,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.minor => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.minor,
+        seventhKind: ExploreSeventhKind.none,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.diminished => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.diminished,
+        seventhKind: ExploreSeventhKind.none,
+        fifthAlteration: ExploreFifthAlteration.flat,
+      ),
+      ChordQualityToken.augmented => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.augmented,
+        seventhKind: ExploreSeventhKind.none,
+        fifthAlteration: ExploreFifthAlteration.sharp,
+      ),
+      ChordQualityToken.sus2 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.sus2,
+        seventhKind: ExploreSeventhKind.none,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.sus4 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.sus4,
+        seventhKind: ExploreSeventhKind.none,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.major6 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.major,
+        seventhKind: ExploreSeventhKind.sixth,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.minor6 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.minor,
+        seventhKind: ExploreSeventhKind.sixth,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.dominant7 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.major,
+        seventhKind: ExploreSeventhKind.dominant7,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.dominant7sus2 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.sus2,
+        seventhKind: ExploreSeventhKind.dominant7,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.dominant7sus4 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.sus4,
+        seventhKind: ExploreSeventhKind.dominant7,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.dominant7Flat5 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.major,
+        seventhKind: ExploreSeventhKind.dominant7,
+        fifthAlteration: ExploreFifthAlteration.flat,
+      ),
+      ChordQualityToken.dominant7Sharp5 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.augmented,
+        seventhKind: ExploreSeventhKind.dominant7,
+        fifthAlteration: ExploreFifthAlteration.sharp,
+      ),
+      ChordQualityToken.major7 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.major,
+        seventhKind: ExploreSeventhKind.major7,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.major7sus2 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.sus2,
+        seventhKind: ExploreSeventhKind.major7,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.major7sus4 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.sus4,
+        seventhKind: ExploreSeventhKind.major7,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.major7Flat5 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.major,
+        seventhKind: ExploreSeventhKind.major7,
+        fifthAlteration: ExploreFifthAlteration.flat,
+      ),
+      ChordQualityToken.major7Sharp5 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.augmented,
+        seventhKind: ExploreSeventhKind.major7,
+        fifthAlteration: ExploreFifthAlteration.sharp,
+      ),
+      ChordQualityToken.minor7 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.minor,
+        seventhKind: ExploreSeventhKind.minor7,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.minorMajor7 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.minor,
+        seventhKind: ExploreSeventhKind.minorMajor7,
+        fifthAlteration: ExploreFifthAlteration.natural,
+      ),
+      ChordQualityToken.halfDiminished7 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.diminished,
+        seventhKind: ExploreSeventhKind.halfDiminished7,
+        fifthAlteration: ExploreFifthAlteration.flat,
+      ),
+      ChordQualityToken.diminished7 => const ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.diminished,
+        seventhKind: ExploreSeventhKind.diminished7,
+        fifthAlteration: ExploreFifthAlteration.flat,
+      ),
+    };
+  }
+
+  final ExploreBaseQuality baseQuality;
+  final ExploreSeventhKind seventhKind;
+  final ExploreFifthAlteration fifthAlteration;
+
+  ExploreChordSpec normalized() {
+    final seventh = availableSeventhKindsFor(baseQuality).contains(seventhKind)
+        ? seventhKind
+        : ExploreSeventhKind.none;
+
+    final fifth =
+        availableFifthAlterationsFor(
+          baseQuality: baseQuality,
+          seventhKind: seventh,
+        ).contains(fifthAlteration)
+        ? fifthAlteration
+        : defaultFifthAlterationFor(baseQuality);
+
+    return ExploreChordSpec(
+      baseQuality: baseQuality,
+      seventhKind: seventh,
+      fifthAlteration: fifth,
+    );
+  }
+
+  ChordQualityToken get quality {
+    final spec = normalized();
+    return _qualityFromSpec(
+      baseQuality: spec.baseQuality,
+      seventhKind: spec.seventhKind,
+      fifthAlteration: spec.fifthAlteration,
+    );
+  }
+
+  ExploreChordSpec copyWith({
+    ExploreBaseQuality? baseQuality,
+    ExploreSeventhKind? seventhKind,
+    ExploreFifthAlteration? fifthAlteration,
+  }) {
+    return ExploreChordSpec(
+      baseQuality: baseQuality ?? this.baseQuality,
+      seventhKind: seventhKind ?? this.seventhKind,
+      fifthAlteration: fifthAlteration ?? this.fifthAlteration,
+    ).normalized();
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ExploreChordSpec &&
+          other.baseQuality == baseQuality &&
+          other.seventhKind == seventhKind &&
+          other.fifthAlteration == fifthAlteration;
+
+  @override
+  int get hashCode => Object.hash(baseQuality, seventhKind, fifthAlteration);
+}
+
+List<ExploreSeventhKind> availableSeventhKindsFor(
+  ExploreBaseQuality baseQuality,
+) {
+  return switch (baseQuality) {
+    ExploreBaseQuality.major => const [
+      ExploreSeventhKind.none,
+      ExploreSeventhKind.sixth,
+      ExploreSeventhKind.dominant7,
+      ExploreSeventhKind.major7,
+    ],
+    ExploreBaseQuality.minor => const [
+      ExploreSeventhKind.none,
+      ExploreSeventhKind.sixth,
+      ExploreSeventhKind.minor7,
+      ExploreSeventhKind.minorMajor7,
+    ],
+    ExploreBaseQuality.diminished => const [
+      ExploreSeventhKind.none,
+      ExploreSeventhKind.diminished7,
+      ExploreSeventhKind.halfDiminished7,
+    ],
+    ExploreBaseQuality.augmented => const [
+      ExploreSeventhKind.none,
+      ExploreSeventhKind.dominant7,
+      ExploreSeventhKind.major7,
+    ],
+    ExploreBaseQuality.sus2 || ExploreBaseQuality.sus4 => const [
+      ExploreSeventhKind.none,
+      ExploreSeventhKind.dominant7,
+      ExploreSeventhKind.major7,
+    ],
+  };
+}
+
+List<ExploreFifthAlteration> availableFifthAlterationsFor({
+  required ExploreBaseQuality baseQuality,
+  required ExploreSeventhKind seventhKind,
+}) {
+  return switch (baseQuality) {
+    ExploreBaseQuality.major
+        when seventhKind == ExploreSeventhKind.dominant7 ||
+            seventhKind == ExploreSeventhKind.major7 =>
+      const [
+        ExploreFifthAlteration.natural,
+        ExploreFifthAlteration.flat,
+        ExploreFifthAlteration.sharp,
+      ],
+    ExploreBaseQuality.major => const [ExploreFifthAlteration.natural],
+    ExploreBaseQuality.minor => const [ExploreFifthAlteration.natural],
+    ExploreBaseQuality.diminished => const [ExploreFifthAlteration.flat],
+    ExploreBaseQuality.augmented => const [ExploreFifthAlteration.sharp],
+    ExploreBaseQuality.sus2 ||
+    ExploreBaseQuality.sus4 => const [ExploreFifthAlteration.natural],
+  };
+}
+
+ExploreFifthAlteration defaultFifthAlterationFor(
+  ExploreBaseQuality baseQuality,
+) {
+  return switch (baseQuality) {
+    ExploreBaseQuality.diminished => ExploreFifthAlteration.flat,
+    ExploreBaseQuality.augmented => ExploreFifthAlteration.sharp,
+    _ => ExploreFifthAlteration.natural,
+  };
+}
+
+ChordQualityToken _qualityFromSpec({
+  required ExploreBaseQuality baseQuality,
+  required ExploreSeventhKind seventhKind,
+  required ExploreFifthAlteration fifthAlteration,
+}) {
+  if (seventhKind == ExploreSeventhKind.halfDiminished7) {
+    return ChordQualityToken.halfDiminished7;
+  }
+  if (seventhKind == ExploreSeventhKind.diminished7) {
+    return ChordQualityToken.diminished7;
+  }
+  if (seventhKind == ExploreSeventhKind.minor7) {
+    return ChordQualityToken.minor7;
+  }
+  if (seventhKind == ExploreSeventhKind.minorMajor7) {
+    return ChordQualityToken.minorMajor7;
+  }
+
+  return switch ((baseQuality, seventhKind, fifthAlteration)) {
+    (ExploreBaseQuality.major, ExploreSeventhKind.none, _) =>
+      ChordQualityToken.major,
+    (ExploreBaseQuality.major, ExploreSeventhKind.sixth, _) =>
+      ChordQualityToken.major6,
+    (
+      ExploreBaseQuality.major,
+      ExploreSeventhKind.dominant7,
+      ExploreFifthAlteration.flat,
+    ) =>
+      ChordQualityToken.dominant7Flat5,
+    (
+      ExploreBaseQuality.major,
+      ExploreSeventhKind.dominant7,
+      ExploreFifthAlteration.sharp,
+    ) =>
+      ChordQualityToken.dominant7Sharp5,
+    (ExploreBaseQuality.major, ExploreSeventhKind.dominant7, _) =>
+      ChordQualityToken.dominant7,
+    (
+      ExploreBaseQuality.major,
+      ExploreSeventhKind.major7,
+      ExploreFifthAlteration.flat,
+    ) =>
+      ChordQualityToken.major7Flat5,
+    (
+      ExploreBaseQuality.major,
+      ExploreSeventhKind.major7,
+      ExploreFifthAlteration.sharp,
+    ) =>
+      ChordQualityToken.major7Sharp5,
+    (ExploreBaseQuality.major, ExploreSeventhKind.major7, _) =>
+      ChordQualityToken.major7,
+    (ExploreBaseQuality.minor, ExploreSeventhKind.none, _) =>
+      ChordQualityToken.minor,
+    (ExploreBaseQuality.minor, ExploreSeventhKind.sixth, _) =>
+      ChordQualityToken.minor6,
+    (ExploreBaseQuality.diminished, ExploreSeventhKind.none, _) =>
+      ChordQualityToken.diminished,
+    (ExploreBaseQuality.augmented, ExploreSeventhKind.none, _) =>
+      ChordQualityToken.augmented,
+    (ExploreBaseQuality.augmented, ExploreSeventhKind.dominant7, _) =>
+      ChordQualityToken.dominant7Sharp5,
+    (ExploreBaseQuality.augmented, ExploreSeventhKind.major7, _) =>
+      ChordQualityToken.major7Sharp5,
+    (ExploreBaseQuality.sus2, ExploreSeventhKind.none, _) =>
+      ChordQualityToken.sus2,
+    (ExploreBaseQuality.sus2, ExploreSeventhKind.dominant7, _) =>
+      ChordQualityToken.dominant7sus2,
+    (ExploreBaseQuality.sus2, ExploreSeventhKind.major7, _) =>
+      ChordQualityToken.major7sus2,
+    (ExploreBaseQuality.sus4, ExploreSeventhKind.none, _) =>
+      ChordQualityToken.sus4,
+    (ExploreBaseQuality.sus4, ExploreSeventhKind.dominant7, _) =>
+      ChordQualityToken.dominant7sus4,
+    (ExploreBaseQuality.sus4, ExploreSeventhKind.major7, _) =>
+      ChordQualityToken.major7sus4,
+    _ => ChordQualityToken.major,
+  };
+}

--- a/lib/features/explore/models/explore_chord_state.dart
+++ b/lib/features/explore/models/explore_chord_state.dart
@@ -2,11 +2,27 @@ import 'package:meta/meta.dart';
 
 import 'package:whatchord/features/theory/theory.dart';
 
+import 'explore_chord_spec.dart';
+
 @immutable
 class ExploreChordState {
-  const ExploreChordState({
+  factory ExploreChordState({
+    required int rootPc,
+    required ChordQualityToken quality,
+    required Set<ChordExtension> extensions,
+    required int bassPc,
+  }) {
+    return ExploreChordState.fromSpec(
+      rootPc: rootPc,
+      spec: ExploreChordSpec.fromQuality(quality),
+      extensions: extensions,
+      bassPc: bassPc,
+    );
+  }
+
+  const ExploreChordState.fromSpec({
     required this.rootPc,
-    required this.quality,
+    required this.spec,
     required this.extensions,
     required this.bassPc,
   });
@@ -21,19 +37,27 @@ class ExploreChordState {
   }
 
   final int rootPc;
-  final ChordQualityToken quality;
+  final ExploreChordSpec spec;
   final Set<ChordExtension> extensions;
   final int bassPc;
 
+  ChordQualityToken get quality => spec.quality;
+
+  ExploreBaseQuality get baseQuality => spec.baseQuality;
+
+  ExploreSeventhKind get seventhKind => spec.seventhKind;
+
+  ExploreFifthAlteration get fifthAlteration => spec.fifthAlteration;
+
   ExploreChordState copyWith({
     int? rootPc,
-    ChordQualityToken? quality,
+    ExploreChordSpec? spec,
     Set<ChordExtension>? extensions,
     int? bassPc,
   }) {
-    return ExploreChordState(
+    return ExploreChordState.fromSpec(
       rootPc: rootPc ?? this.rootPc,
-      quality: quality ?? this.quality,
+      spec: spec ?? this.spec,
       extensions: Set<ChordExtension>.unmodifiable(
         extensions ?? this.extensions,
       ),
@@ -46,13 +70,13 @@ class ExploreChordState {
       identical(this, other) ||
       other is ExploreChordState &&
           other.rootPc == rootPc &&
-          other.quality == quality &&
+          other.spec == spec &&
           other.bassPc == bassPc &&
           _setEquals(other.extensions, extensions);
 
   @override
   int get hashCode =>
-      Object.hash(rootPc, quality, bassPc, Object.hashAllUnordered(extensions));
+      Object.hash(rootPc, spec, bassPc, Object.hashAllUnordered(extensions));
 
   static bool _setEquals<T>(Set<T> a, Set<T> b) {
     if (identical(a, b)) return true;

--- a/lib/features/explore/pages/explore_chord_page.dart
+++ b/lib/features/explore/pages/explore_chord_page.dart
@@ -213,9 +213,23 @@ class _ExploreChordPageState extends ConsumerState<ExploreChordPage> {
                                           onRootChanged: (value) => updateState(
                                             exploreStateWithRoot(_state, value),
                                           ),
-                                          onQualityChanged: (value) =>
+                                          onBaseQualityChanged: (value) =>
                                               updateState(
-                                                exploreStateWithQuality(
+                                                exploreStateWithBaseQuality(
+                                                  _state,
+                                                  value,
+                                                ),
+                                              ),
+                                          onSeventhKindChanged: (value) =>
+                                              updateState(
+                                                exploreStateWithSeventhKind(
+                                                  _state,
+                                                  value,
+                                                ),
+                                              ),
+                                          onFifthAlterationChanged: (value) =>
+                                              updateState(
+                                                exploreStateWithFifthAlteration(
                                                   _state,
                                                   value,
                                                 ),
@@ -282,9 +296,23 @@ class _ExploreChordPageState extends ConsumerState<ExploreChordPage> {
                                           onRootChanged: (value) => updateState(
                                             exploreStateWithRoot(_state, value),
                                           ),
-                                          onQualityChanged: (value) =>
+                                          onBaseQualityChanged: (value) =>
                                               updateState(
-                                                exploreStateWithQuality(
+                                                exploreStateWithBaseQuality(
+                                                  _state,
+                                                  value,
+                                                ),
+                                              ),
+                                          onSeventhKindChanged: (value) =>
+                                              updateState(
+                                                exploreStateWithSeventhKind(
+                                                  _state,
+                                                  value,
+                                                ),
+                                              ),
+                                          onFifthAlterationChanged: (value) =>
+                                              updateState(
+                                                exploreStateWithFifthAlteration(
                                                   _state,
                                                   value,
                                                 ),

--- a/lib/features/explore/services/explore_chord_options.dart
+++ b/lib/features/explore/services/explore_chord_options.dart
@@ -1,6 +1,6 @@
 import 'package:whatchord/features/theory/theory.dart';
 
-enum ExploreExtensionControlRole { highestExtension, addedTones, colors }
+enum ExploreExtensionControlRole { highestExtension, addedTones, alterations }
 
 class ExploreExtensionControlGroup {
   const ExploreExtensionControlGroup({
@@ -87,7 +87,7 @@ List<ExploreExtensionControlGroup> buildExploreExtensionControlGroups(
 
     return [
       ExploreExtensionControlGroup(
-        label: 'Highest extension',
+        label: 'Stacked extension',
         role: ExploreExtensionControlRole.highestExtension,
         allowsMultiple: false,
         choices: highestExtensionChoices,
@@ -101,8 +101,8 @@ List<ExploreExtensionControlGroup> buildExploreExtensionControlGroups(
         ),
       if (colorChoices.isNotEmpty)
         ExploreExtensionControlGroup(
-          label: 'Colors',
-          role: ExploreExtensionControlRole.colors,
+          label: 'Alterations',
+          role: ExploreExtensionControlRole.alterations,
           allowsMultiple: true,
           choices: colorChoices,
         ),
@@ -128,8 +128,8 @@ List<ExploreExtensionControlGroup> buildExploreExtensionControlGroups(
       ),
     if (availableColors.isNotEmpty)
       ExploreExtensionControlGroup(
-        label: 'Colors',
-        role: ExploreExtensionControlRole.colors,
+        label: 'Alterations',
+        role: ExploreExtensionControlRole.alterations,
         allowsMultiple: true,
         choices: [
           if (availableColors.contains(ChordExtension.flat9))

--- a/lib/features/explore/services/explore_chord_state_transitions.dart
+++ b/lib/features/explore/services/explore_chord_state_transitions.dart
@@ -1,14 +1,17 @@
 import 'package:whatchord/features/theory/theory.dart';
 
+import '../models/explore_chord_spec.dart';
 import '../models/explore_chord_state.dart';
 import 'explore_chord_example_builder.dart';
 import 'explore_chord_options.dart';
 
 ExploreChordState normalizeExploreChordState(ExploreChordState state) {
+  final spec = state.spec.normalized();
   return _withValidBass(
     state.copyWith(
+      spec: spec,
       extensions: normalizeExtensionsForQuality(
-        quality: state.quality,
+        quality: spec.quality,
         extensions: state.extensions,
       ),
     ),
@@ -19,15 +22,67 @@ ExploreChordState exploreStateWithRoot(ExploreChordState state, int rootPc) {
   return _withValidBass(state.copyWith(rootPc: rootPc));
 }
 
+ExploreChordState exploreStateWithBaseQuality(
+  ExploreChordState state,
+  ExploreBaseQuality baseQuality,
+) {
+  final nextSpec = state.spec.copyWith(
+    baseQuality: baseQuality,
+    fifthAlteration: defaultFifthAlterationFor(baseQuality),
+  );
+  return _withValidBass(
+    state.copyWith(
+      spec: nextSpec,
+      extensions: normalizeExtensionsForQuality(
+        quality: nextSpec.quality,
+        extensions: state.extensions,
+      ),
+    ),
+  );
+}
+
+ExploreChordState exploreStateWithSeventhKind(
+  ExploreChordState state,
+  ExploreSeventhKind seventhKind,
+) {
+  final nextSpec = state.spec.copyWith(seventhKind: seventhKind);
+  return _withValidBass(
+    state.copyWith(
+      spec: nextSpec,
+      extensions: normalizeExtensionsForQuality(
+        quality: nextSpec.quality,
+        extensions: state.extensions,
+      ),
+    ),
+  );
+}
+
+ExploreChordState exploreStateWithFifthAlteration(
+  ExploreChordState state,
+  ExploreFifthAlteration fifthAlteration,
+) {
+  final nextSpec = state.spec.copyWith(fifthAlteration: fifthAlteration);
+  return _withValidBass(
+    state.copyWith(
+      spec: nextSpec,
+      extensions: normalizeExtensionsForQuality(
+        quality: nextSpec.quality,
+        extensions: state.extensions,
+      ),
+    ),
+  );
+}
+
 ExploreChordState exploreStateWithQuality(
   ExploreChordState state,
   ChordQualityToken quality,
 ) {
+  final nextSpec = ExploreChordSpec.fromQuality(quality);
   return _withValidBass(
     state.copyWith(
-      quality: quality,
+      spec: nextSpec,
       extensions: normalizeExtensionsForQuality(
-        quality: quality,
+        quality: nextSpec.quality,
         extensions: state.extensions,
       ),
     ),

--- a/lib/features/explore/widgets/explore_controls.dart
+++ b/lib/features/explore/widgets/explore_controls.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'package:whatchord/features/theory/theory.dart';
 
+import '../models/explore_chord_spec.dart';
 import '../models/explore_chord_state.dart';
 import '../services/explore_chord_options.dart';
 
@@ -16,7 +17,9 @@ class ExploreControls extends StatelessWidget {
     required this.noteNameSystem,
     required this.isLandscape,
     required this.onRootChanged,
-    required this.onQualityChanged,
+    required this.onBaseQualityChanged,
+    required this.onSeventhKindChanged,
+    required this.onFifthAlterationChanged,
     required this.onExtensionsChanged,
     required this.onBassChanged,
   });
@@ -27,7 +30,9 @@ class ExploreControls extends StatelessWidget {
   final NoteNameSystem noteNameSystem;
   final bool isLandscape;
   final ValueChanged<int> onRootChanged;
-  final ValueChanged<ChordQualityToken> onQualityChanged;
+  final ValueChanged<ExploreBaseQuality> onBaseQualityChanged;
+  final ValueChanged<ExploreSeventhKind> onSeventhKindChanged;
+  final ValueChanged<ExploreFifthAlteration> onFifthAlterationChanged;
   final ValueChanged<Set<ChordExtension>> onExtensionsChanged;
   final ValueChanged<int> onBassChanged;
 
@@ -66,11 +71,36 @@ class ExploreControls extends StatelessWidget {
               ),
               SizedBox(
                 width: controlWidth,
-                child: _QualityWheel(
-                  value: state.quality,
-                  onChanged: onQualityChanged,
+                child: _BaseQualitySelector(
+                  value: state.baseQuality,
+                  onChanged: onBaseQualityChanged,
                 ),
               ),
+              SizedBox(
+                width: controlWidth,
+                child: _SeventhKindSelector(
+                  baseQuality: state.baseQuality,
+                  value: state.seventhKind,
+                  choices: availableSeventhKindsFor(state.baseQuality),
+                  onChanged: onSeventhKindChanged,
+                ),
+              ),
+              if (availableFifthAlterationsFor(
+                    baseQuality: state.baseQuality,
+                    seventhKind: state.seventhKind,
+                  ).length >
+                  1)
+                SizedBox(
+                  width: controlWidth,
+                  child: _FifthAlterationSelector(
+                    value: state.fifthAlteration,
+                    choices: availableFifthAlterationsFor(
+                      baseQuality: state.baseQuality,
+                      seventhKind: state.seventhKind,
+                    ),
+                    onChanged: onFifthAlterationChanged,
+                  ),
+                ),
               SizedBox(
                 width: controlWidth,
                 child: _ExtensionBuilder(
@@ -165,35 +195,144 @@ class ExploreControls extends StatelessWidget {
   }
 }
 
-double _wheelViewportFraction({
-  required double viewportWidth,
-  required double targetItemWidth,
-}) {
-  if (!viewportWidth.isFinite || viewportWidth <= 0) return 1;
-  return (targetItemWidth / viewportWidth).clamp(0.08, 0.92);
-}
+class _BaseQualitySelector extends StatelessWidget {
+  const _BaseQualitySelector({required this.value, required this.onChanged});
 
-bool _viewportFractionChanged(double? previous, double next) {
-  if (previous == null) return true;
-  return (previous - next).abs() > 0.001;
-}
+  static const _choices = ExploreBaseQuality.values;
 
-class _QualityWheel extends StatefulWidget {
-  const _QualityWheel({required this.value, required this.onChanged});
-
-  final ChordQualityToken value;
-  final ValueChanged<ChordQualityToken> onChanged;
+  final ExploreBaseQuality value;
+  final ValueChanged<ExploreBaseQuality> onChanged;
 
   @override
-  State<_QualityWheel> createState() => _QualityWheelState();
+  Widget build(BuildContext context) {
+    return _OptionWheel<ExploreBaseQuality>(
+      label: 'Quality',
+      value: value,
+      choices: _choices,
+      labelFor: _baseQualityLabel,
+      semanticLabelFor: _baseQualitySemanticLabel,
+      onChanged: onChanged,
+    );
+  }
 }
 
-class _QualityWheelState extends State<_QualityWheel> {
-  static const _qualities = exploreChordQualityOrder;
-  static final _qualityCount = _qualities.length;
+class _SeventhKindSelector extends StatelessWidget {
+  const _SeventhKindSelector({
+    required this.baseQuality,
+    required this.value,
+    required this.choices,
+    required this.onChanged,
+  });
+
+  final ExploreBaseQuality baseQuality;
+  final ExploreSeventhKind value;
+  final List<ExploreSeventhKind> choices;
+  final ValueChanged<ExploreSeventhKind> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedIndex = _selectedIndex();
+
+    return Semantics(
+      container: true,
+      label: 'Sixth / Seventh',
+      value: _seventhKindSemanticLabel(choices[selectedIndex]),
+      child: InputDecorator(
+        decoration: const InputDecoration(
+          labelText: 'Sixth / Seventh',
+          border: OutlineInputBorder(),
+        ),
+        child: _ExploreSegmentedChoiceGroup(
+          labels: [
+            for (final choice in choices)
+              theoryTokenDisplayLabel(_seventhKindLabel(choice, baseQuality)),
+          ],
+          semanticLabels: [
+            for (final choice in choices) _seventhKindSemanticLabel(choice),
+          ],
+          selectedIndex: selectedIndex,
+          onSelected: (index) => onChanged(choices[index]),
+        ),
+      ),
+    );
+  }
+
+  int _selectedIndex() {
+    final index = choices.indexOf(value);
+    return index < 0 ? 0 : index;
+  }
+}
+
+class _FifthAlterationSelector extends StatelessWidget {
+  const _FifthAlterationSelector({
+    required this.value,
+    required this.choices,
+    required this.onChanged,
+  });
+
+  final ExploreFifthAlteration value;
+  final List<ExploreFifthAlteration> choices;
+  final ValueChanged<ExploreFifthAlteration> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedIndex = _selectedIndex();
+
+    return Semantics(
+      container: true,
+      label: 'Fifth',
+      value: _fifthAlterationSemanticLabel(choices[selectedIndex]),
+      child: InputDecorator(
+        decoration: const InputDecoration(
+          labelText: 'Fifth',
+          border: OutlineInputBorder(),
+        ),
+        child: _ExploreSegmentedChoiceGroup(
+          labels: [
+            for (final choice in choices)
+              theoryTokenDisplayLabel(_fifthAlterationLabel(choice)),
+          ],
+          semanticLabels: [
+            for (final choice in choices) _fifthAlterationSemanticLabel(choice),
+          ],
+          selectedIndex: selectedIndex,
+          onSelected: (index) => onChanged(choices[index]),
+        ),
+      ),
+    );
+  }
+
+  int _selectedIndex() {
+    final index = choices.indexOf(value);
+    return index < 0 ? 0 : index;
+  }
+}
+
+class _OptionWheel<T> extends StatefulWidget {
+  const _OptionWheel({
+    required this.label,
+    required this.value,
+    required this.choices,
+    required this.labelFor,
+    required this.semanticLabelFor,
+    required this.onChanged,
+  });
+
+  final String label;
+  final T value;
+  final List<T> choices;
+  final String Function(T value) labelFor;
+  final String Function(T value) semanticLabelFor;
+  final ValueChanged<T> onChanged;
+
+  @override
+  State<_OptionWheel<T>> createState() => _OptionWheelState<T>();
+}
+
+class _OptionWheelState<T> extends State<_OptionWheel<T>> {
   static const _initialLoop = 500;
   static const _wheelHeight = 64.0;
-  static const _targetItemWidth = 116.0;
+  static const _targetItemWidth = 96.0;
   static const _wheelContentPadding = EdgeInsets.fromLTRB(8, 10, 8, 6);
 
   PageController? _controller;
@@ -203,26 +342,30 @@ class _QualityWheelState extends State<_QualityWheel> {
   @override
   void initState() {
     super.initState();
-    _currentPage = (_initialLoop * _qualityCount) + _indexOf(widget.value);
+    _currentPage =
+        (_initialLoop * widget.choices.length) + _indexOf(widget.value);
   }
 
   @override
-  void didUpdateWidget(covariant _QualityWheel oldWidget) {
+  void didUpdateWidget(covariant _OptionWheel<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.choices != widget.choices) {
+      _resetControllerToValue();
+      return;
+    }
+
     if (oldWidget.value == widget.value) return;
 
-    final controller = _controller;
-    final visiblePage = controller?.hasClients == true
-        ? (controller?.page?.round() ?? _currentPage)
-        : _currentPage;
-    if (_qualityForPage(visiblePage) == widget.value) return;
+    final visiblePage = _visiblePage;
+    if (_valueForPage(visiblePage) == widget.value) return;
 
-    final targetPage = _nearestPageForQuality(widget.value);
+    final targetPage = _nearestPageForValue(widget.value);
     _currentPage = targetPage;
-    if (controller?.hasClients != true) return;
+    if (_controller?.hasClients != true) return;
 
     unawaited(
-      controller!.animateToPage(
+      _controller!.animateToPage(
         targetPage,
         duration: const Duration(milliseconds: 180),
         curve: Curves.easeOutCubic,
@@ -238,21 +381,20 @@ class _QualityWheelState extends State<_QualityWheel> {
 
   @override
   Widget build(BuildContext context) {
-    final selectedLabel = _longLabel(widget.value);
-
+    final selectedLabel = widget.semanticLabelFor(widget.value);
     return Semantics(
       container: true,
-      label: 'Quality',
+      label: widget.label,
       value: selectedLabel,
-      increasedValue: _longLabel(_nextQuality(widget.value)),
-      decreasedValue: _longLabel(_previousQuality(widget.value)),
-      onIncrease: () => widget.onChanged(_nextQuality(widget.value)),
-      onDecrease: () => widget.onChanged(_previousQuality(widget.value)),
+      increasedValue: widget.semanticLabelFor(_nextValue(widget.value)),
+      decreasedValue: widget.semanticLabelFor(_previousValue(widget.value)),
+      onIncrease: () => widget.onChanged(_nextValue(widget.value)),
+      onDecrease: () => widget.onChanged(_previousValue(widget.value)),
       child: ExcludeSemantics(
         child: InputDecorator(
-          decoration: const InputDecoration(
-            labelText: 'Quality',
-            border: OutlineInputBorder(),
+          decoration: InputDecoration(
+            labelText: widget.label,
+            border: const OutlineInputBorder(),
             contentPadding: _wheelContentPadding,
           ),
           child: SizedBox(
@@ -272,13 +414,13 @@ class _QualityWheelState extends State<_QualityWheel> {
                       controller: controller,
                       onPageChanged: _handlePageChanged,
                       itemBuilder: (context, page) {
-                        final quality = _qualityForPage(page);
-                        return _QualityWheelItem(
+                        final value = _valueForPage(page);
+                        return _WheelItem(
                           label: theoryTokenDisplayLabel(
-                            quality.label(ChordQualityLabelForm.standalone),
+                            widget.labelFor(value),
                           ),
-                          selected: quality == widget.value,
-                          onTap: () => _selectQuality(quality),
+                          selected: value == widget.value,
+                          onTap: () => _selectValue(value),
                         );
                       },
                     ),
@@ -314,14 +456,14 @@ class _QualityWheelState extends State<_QualityWheel> {
 
   void _handlePageChanged(int page) {
     _currentPage = page;
-    final quality = _qualityForPage(page);
-    if (quality == widget.value) return;
-    widget.onChanged(quality);
+    final value = _valueForPage(page);
+    if (value == widget.value) return;
+    widget.onChanged(value);
   }
 
-  void _selectQuality(ChordQualityToken quality) {
+  void _selectValue(T value) {
     final controller = _controller;
-    final targetPage = _nearestPageForQuality(quality);
+    final targetPage = _nearestPageForValue(value);
     _currentPage = targetPage;
     if (controller?.hasClients == true) {
       unawaited(
@@ -332,94 +474,128 @@ class _QualityWheelState extends State<_QualityWheel> {
         ),
       );
     }
-    if (quality != widget.value) widget.onChanged(quality);
+    if (value != widget.value) widget.onChanged(value);
   }
 
-  int _nearestPageForQuality(ChordQualityToken quality) {
-    final controller = _controller;
-    final currentPage = controller?.hasClients == true
-        ? (controller?.page?.round() ?? _currentPage)
-        : _currentPage;
+  int _nearestPageForValue(T value) {
+    final currentPage = _visiblePage;
     final currentIndex = _indexForPage(currentPage);
-    var delta = (_indexOf(quality) - currentIndex) % _qualityCount;
-    if (delta > _qualityCount / 2) delta -= _qualityCount;
+    var delta = (_indexOf(value) - currentIndex) % widget.choices.length;
+    if (delta > widget.choices.length / 2) delta -= widget.choices.length;
     return currentPage + delta;
   }
 
-  ChordQualityToken _qualityForPage(int page) =>
-      _qualities[_indexForPage(page)];
+  int get _visiblePage => _controller?.hasClients == true
+      ? (_controller?.page?.round() ?? _currentPage)
+      : _currentPage;
 
-  ChordQualityToken _nextQuality(ChordQualityToken quality) {
-    return _qualities[(_indexOf(quality) + 1) % _qualityCount];
+  T _valueForPage(int page) => widget.choices[_indexForPage(page)];
+
+  T _nextValue(T value) {
+    return widget.choices[(_indexOf(value) + 1) % widget.choices.length];
   }
 
-  ChordQualityToken _previousQuality(ChordQualityToken quality) {
-    return _qualities[(_indexOf(quality) - 1) % _qualityCount];
+  T _previousValue(T value) {
+    return widget.choices[(_indexOf(value) - 1) % widget.choices.length];
   }
 
-  int _indexForPage(int page) => page % _qualityCount;
+  int _indexForPage(int page) => page % widget.choices.length;
 
-  int _indexOf(ChordQualityToken quality) {
-    final index = _qualities.indexOf(quality);
+  int _indexOf(T value) {
+    final index = widget.choices.indexOf(value);
     return index < 0 ? 0 : index;
   }
 
-  String _longLabel(ChordQualityToken quality) {
-    return quality.label(ChordQualityLabelForm.long);
+  void _resetControllerToValue() {
+    _controller?.dispose();
+    _controller = null;
+    _viewportFraction = null;
+    _currentPage =
+        (_initialLoop * widget.choices.length) + _indexOf(widget.value);
   }
 }
 
-class _QualityWheelItem extends StatelessWidget {
-  const _QualityWheelItem({
-    required this.label,
-    required this.selected,
-    required this.onTap,
-  });
+String _baseQualityLabel(ExploreBaseQuality quality) {
+  return switch (quality) {
+    ExploreBaseQuality.major => 'maj',
+    ExploreBaseQuality.minor => 'min',
+    ExploreBaseQuality.diminished => 'dim',
+    ExploreBaseQuality.augmented => 'aug',
+    ExploreBaseQuality.sus2 => 'sus2',
+    ExploreBaseQuality.sus4 => 'sus4',
+  };
+}
 
-  final String label;
-  final bool selected;
-  final VoidCallback onTap;
+String _baseQualitySemanticLabel(ExploreBaseQuality quality) {
+  return switch (quality) {
+    ExploreBaseQuality.major => 'Major',
+    ExploreBaseQuality.minor => 'Minor',
+    ExploreBaseQuality.diminished => 'Diminished',
+    ExploreBaseQuality.augmented => 'Augmented',
+    ExploreBaseQuality.sus2 => 'Suspended second',
+    ExploreBaseQuality.sus4 => 'Suspended fourth',
+  };
+}
 
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final cs = theme.colorScheme;
-    final labelStyle =
-        (selected ? theme.textTheme.titleLarge : theme.textTheme.titleMedium)
-            ?.copyWith(
-              color: selected ? cs.onPrimaryContainer : cs.onSurfaceVariant,
-              fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
-            );
+String _seventhKindLabel(
+  ExploreSeventhKind kind,
+  ExploreBaseQuality baseQuality,
+) {
+  return switch (kind) {
+    ExploreSeventhKind.none => 'None',
+    ExploreSeventhKind.sixth => switch (baseQuality) {
+      ExploreBaseQuality.minor => 'min6',
+      _ => 'maj6',
+    },
+    ExploreSeventhKind.dominant7 => '7',
+    ExploreSeventhKind.major7 => 'maj7',
+    ExploreSeventhKind.minor7 => 'min7',
+    ExploreSeventhKind.minorMajor7 => 'minmaj7',
+    ExploreSeventhKind.halfDiminished7 => 'hdim7',
+    ExploreSeventhKind.diminished7 => 'dim7',
+  };
+}
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 2),
-      child: Center(
-        child: Material(
-          color: selected ? cs.primaryContainer : cs.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(8),
-          child: InkWell(
-            borderRadius: BorderRadius.circular(8),
-            onTap: onTap,
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                minWidth: selected ? 76 : 64,
-                minHeight: 48,
-              ),
-              child: Center(
-                child: FittedBox(
-                  fit: BoxFit.scaleDown,
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: selected ? 8 : 6),
-                    child: Text(label, maxLines: 1, style: labelStyle),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+String _seventhKindSemanticLabel(ExploreSeventhKind kind) {
+  return switch (kind) {
+    ExploreSeventhKind.none => 'No sixth or seventh',
+    ExploreSeventhKind.sixth => 'Sixth',
+    ExploreSeventhKind.dominant7 => 'Dominant seventh',
+    ExploreSeventhKind.major7 => 'Major seventh',
+    ExploreSeventhKind.minor7 => 'Minor seventh',
+    ExploreSeventhKind.minorMajor7 => 'Minor-major seventh',
+    ExploreSeventhKind.halfDiminished7 => 'Half-diminished seventh',
+    ExploreSeventhKind.diminished7 => 'Diminished seventh',
+  };
+}
+
+String _fifthAlterationLabel(ExploreFifthAlteration alteration) {
+  return switch (alteration) {
+    ExploreFifthAlteration.natural => '5',
+    ExploreFifthAlteration.flat => 'b5',
+    ExploreFifthAlteration.sharp => '#5',
+  };
+}
+
+String _fifthAlterationSemanticLabel(ExploreFifthAlteration alteration) {
+  return switch (alteration) {
+    ExploreFifthAlteration.natural => 'Natural fifth',
+    ExploreFifthAlteration.flat => 'Flat fifth',
+    ExploreFifthAlteration.sharp => 'Sharp fifth',
+  };
+}
+
+double _wheelViewportFraction({
+  required double viewportWidth,
+  required double targetItemWidth,
+}) {
+  if (!viewportWidth.isFinite || viewportWidth <= 0) return 1;
+  return (targetItemWidth / viewportWidth).clamp(0.08, 0.92);
+}
+
+bool _viewportFractionChanged(double? previous, double next) {
+  if (previous == null) return true;
+  return (previous - next).abs() > 0.001;
 }
 
 class _RootWheel extends StatefulWidget {
@@ -649,6 +825,59 @@ class _RootWheelItem extends StatelessWidget {
                   fit: BoxFit.scaleDown,
                   child: Padding(
                     padding: EdgeInsets.symmetric(horizontal: selected ? 8 : 4),
+                    child: Text(label, maxLines: 1, style: textStyle),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WheelItem extends StatelessWidget {
+  const _WheelItem({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final textStyle =
+        (selected ? theme.textTheme.titleLarge : theme.textTheme.titleMedium)
+            ?.copyWith(
+              color: selected ? cs.onPrimaryContainer : cs.onSurfaceVariant,
+              fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+            );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 2),
+      child: Center(
+        child: Material(
+          color: selected ? cs.primaryContainer : cs.surfaceContainerLow,
+          borderRadius: BorderRadius.circular(8),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(8),
+            onTap: onTap,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                minWidth: selected ? 76 : 64,
+                minHeight: 48,
+              ),
+              child: Center(
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: selected ? 8 : 6),
                     child: Text(label, maxLines: 1, style: textStyle),
                   ),
                 ),

--- a/lib/features/theory/presentation/services/chord_quality_token_labels.dart
+++ b/lib/features/theory/presentation/services/chord_quality_token_labels.dart
@@ -2,31 +2,6 @@ import '../../domain/theory_domain.dart' show ChordQualityToken;
 
 enum ChordQualityLabelForm { symbol, suffix, standalone, long }
 
-const exploreChordQualityOrder = [
-  ChordQualityToken.major,
-  ChordQualityToken.minor,
-  ChordQualityToken.diminished,
-  ChordQualityToken.augmented,
-  ChordQualityToken.sus2,
-  ChordQualityToken.sus4,
-  ChordQualityToken.major6,
-  ChordQualityToken.minor6,
-  ChordQualityToken.dominant7,
-  ChordQualityToken.dominant7sus2,
-  ChordQualityToken.dominant7sus4,
-  ChordQualityToken.dominant7Flat5,
-  ChordQualityToken.dominant7Sharp5,
-  ChordQualityToken.major7,
-  ChordQualityToken.major7sus2,
-  ChordQualityToken.major7sus4,
-  ChordQualityToken.major7Flat5,
-  ChordQualityToken.major7Sharp5,
-  ChordQualityToken.minor7,
-  ChordQualityToken.minorMajor7,
-  ChordQualityToken.halfDiminished7,
-  ChordQualityToken.diminished7,
-];
-
 /// Formatting-only labels for chord quality tokens.
 extension ChordQualityTokenLabels on ChordQualityToken {
   String label(ChordQualityLabelForm form) {

--- a/test/explore_chord_options_test.dart
+++ b/test/explore_chord_options_test.dart
@@ -1,13 +1,70 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:whatchord/features/explore/models/explore_chord_example.dart';
+import 'package:whatchord/features/explore/models/explore_chord_spec.dart';
 import 'package:whatchord/features/explore/models/explore_chord_state.dart';
 import 'package:whatchord/features/explore/services/explore_chord_example_builder.dart';
 import 'package:whatchord/features/explore/services/explore_chord_derivation.dart';
 import 'package:whatchord/features/explore/services/explore_chord_options.dart';
+import 'package:whatchord/features/explore/services/explore_chord_state_transitions.dart';
 import 'package:whatchord/features/theory/theory.dart';
 
 void main() {
+  group('ExploreChordSpec', () {
+    test(
+      'round-trips analyzer quality seeds through compositional controls',
+      () {
+        for (final quality in ChordQualityToken.values) {
+          final spec = ExploreChordSpec.fromQuality(quality);
+
+          expect(spec.quality, quality, reason: quality.name);
+        }
+      },
+    );
+
+    test(
+      'normalizes unavailable seventh choices when base quality changes',
+      () {
+        final state = ExploreChordState.fromSpec(
+          rootPc: 0,
+          spec: const ExploreChordSpec(
+            baseQuality: ExploreBaseQuality.major,
+            seventhKind: ExploreSeventhKind.dominant7,
+            fifthAlteration: ExploreFifthAlteration.sharp,
+          ),
+          extensions: const {},
+          bassPc: 0,
+        );
+
+        final minor = exploreStateWithBaseQuality(
+          state,
+          ExploreBaseQuality.minor,
+        );
+
+        expect(minor.baseQuality, ExploreBaseQuality.minor);
+        expect(minor.seventhKind, ExploreSeventhKind.none);
+        expect(minor.fifthAlteration, ExploreFifthAlteration.natural);
+        expect(minor.quality, ChordQualityToken.minor);
+      },
+    );
+
+    test('builds altered seventh qualities from separate controls', () {
+      final dominantSharpFive = ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.major,
+        seventhKind: ExploreSeventhKind.dominant7,
+        fifthAlteration: ExploreFifthAlteration.sharp,
+      ).quality;
+      final majorFlatFive = ExploreChordSpec(
+        baseQuality: ExploreBaseQuality.major,
+        seventhKind: ExploreSeventhKind.major7,
+        fifthAlteration: ExploreFifthAlteration.flat,
+      ).quality;
+
+      expect(dominantSharpFive, ChordQualityToken.dominant7Sharp5);
+      expect(majorFlatFive, ChordQualityToken.major7Flat5);
+    });
+  });
+
   group('buildExploreExtensionControlGroups', () {
     test(
       'major qualities expose segmented extensions with sharp-eleventh color',
@@ -16,10 +73,13 @@ void main() {
           ChordQualityToken.major,
         );
 
-        expect(groups.map((group) => group.label), ['Added tones', 'Colors']);
+        expect(groups.map((group) => group.label), [
+          'Added tones',
+          'Alterations',
+        ]);
         expect(groups.map((group) => group.role), [
           ExploreExtensionControlRole.addedTones,
-          ExploreExtensionControlRole.colors,
+          ExploreExtensionControlRole.alterations,
         ]);
         expect(groups.map((group) => group.allowsMultiple), [true, true]);
         expect(groups[0].choices.map((choice) => choice.extension), [
@@ -46,10 +106,13 @@ void main() {
           ChordQualityToken.minor,
         );
 
-        expect(groups.map((group) => group.label), ['Added tones', 'Colors']);
+        expect(groups.map((group) => group.label), [
+          'Added tones',
+          'Alterations',
+        ]);
         expect(groups.map((group) => group.role), [
           ExploreExtensionControlRole.addedTones,
-          ExploreExtensionControlRole.colors,
+          ExploreExtensionControlRole.alterations,
         ]);
         expect(groups.map((group) => group.allowsMultiple), [true, true]);
         expect(groups[0].choices.map((choice) => choice.extension), [
@@ -68,7 +131,10 @@ void main() {
         ChordQualityToken.augmented,
       );
 
-      expect(groups.map((group) => group.label), ['Added tones', 'Colors']);
+      expect(groups.map((group) => group.label), [
+        'Added tones',
+        'Alterations',
+      ]);
       expect(groups[0].choices.map((choice) => choice.extension), [
         ChordExtension.add9,
         ChordExtension.add11,
@@ -84,7 +150,10 @@ void main() {
         ChordQualityToken.major6,
       );
 
-      expect(groups.map((group) => group.label), ['Added tones', 'Colors']);
+      expect(groups.map((group) => group.label), [
+        'Added tones',
+        'Alterations',
+      ]);
       expect(groups[0].choices.map((choice) => choice.extension), [
         ChordExtension.add9,
         ChordExtension.add11,
@@ -101,14 +170,14 @@ void main() {
       );
 
       expect(groups.map((group) => group.label), [
-        'Highest extension',
+        'Stacked extension',
         'Added tones',
-        'Colors',
+        'Alterations',
       ]);
       expect(groups.map((group) => group.role), [
         ExploreExtensionControlRole.highestExtension,
         ExploreExtensionControlRole.addedTones,
-        ExploreExtensionControlRole.colors,
+        ExploreExtensionControlRole.alterations,
       ]);
       expect(groups.map((group) => group.allowsMultiple), [false, true, true]);
       expect(groups[0].choices.map((choice) => choice.extension), [


### PR DESCRIPTION
Explore mode was using the analyzer-facing ChordQualityToken list as its primary quality picker. That made internal analysis distinctions like 7sus4, 7b5, and maj7#5 appear as peer choices alongside simpler qualities, even though those names combine separate musical decisions: base quality, sixth or seventh structure, fifth alteration, extensions, and colors.

Explore mode has a different job from analysis. The analyzer needs detailed templates for ranking observed voicings, but explore mode should help users intentionally build a chord from understandable musical parts and then compile that intent into the same canonical identity model.

Add an explore-specific chord spec for base quality, sixth/seventh kind, and fifth alteration. Keep analyzer seed values working by mapping existing ChordQualityToken identities into the new spec, then compile the spec back to ChordIdentity for presentation, examples, bass choices, and playback.