### PR TITLE
Refine explore mode structure and extension rules

### DIFF
--- a/lib/features/explore/pages/explore_chord_page.dart
+++ b/lib/features/explore/pages/explore_chord_page.dart
@@ -9,6 +9,7 @@ import 'package:whatchord/features/home/home.dart';
 import 'package:whatchord/features/piano/piano.dart';
 import 'package:whatchord/features/theory/theory.dart';
 
+import '../models/explore_chord_example.dart';
 import '../models/explore_chord_state.dart';
 import '../providers/explore_preferences_notifier.dart';
 import '../services/explore_chord_example_builder.dart';
@@ -78,13 +79,6 @@ class _ExploreChordPageState extends ConsumerState<ExploreChordPage> {
     );
     final presentation = example.presentation;
 
-    void updateState(ExploreChordState next) {
-      _previewAnimationController.cancel();
-      setState(() {
-        _state = next;
-      });
-    }
-
     final showScaleNotes = ref.watch(showScaleNotesProvider);
     final diatonicPitchClasses = ref.watch(diatonicPitchClassesProvider);
 
@@ -140,199 +134,16 @@ class _ExploreChordPageState extends ConsumerState<ExploreChordPage> {
                   child: Column(
                     children: [
                       Expanded(
-                        child: isLandscape
-                            ? Padding(
-                                padding: EdgeInsets.fromLTRB(
-                                  horizontalInset,
-                                  16,
-                                  horizontalInset,
-                                  12,
-                                ),
-                                child: Row(
-                                  crossAxisAlignment:
-                                      CrossAxisAlignment.stretch,
-                                  children: [
-                                    Expanded(
-                                      flex: 7,
-                                      child: ExploreFadedScrollView(
-                                        padding: const EdgeInsets.only(
-                                          top: 4,
-                                          right: 12,
-                                        ),
-                                        child: Column(
-                                          crossAxisAlignment:
-                                              CrossAxisAlignment.stretch,
-                                          children: [
-                                            ExploreSummary(
-                                              presentation: presentation,
-                                            ),
-                                            const SizedBox(height: 20),
-                                            ChordMembersSection(
-                                              members: example.members,
-                                              memberDegrees:
-                                                  example.memberDegrees,
-                                              noteNameSystem: noteNameSystem,
-                                              showDegrees:
-                                                  showChordMemberDegrees,
-                                              onShowDegreesChanged: (value) =>
-                                                  unawaited(
-                                                    ref
-                                                        .read(
-                                                          exploreChordMemberDegreesProvider
-                                                              .notifier,
-                                                        )
-                                                        .setShowDegrees(value),
-                                                  ),
-                                              previewNotes:
-                                                  example.normalizedVoicing,
-                                              activePitchClasses:
-                                                  previewPitchClasses,
-                                              memberPitchClasses: example
-                                                  .memberPitchClassesInOrder,
-                                              onPreviewStarted:
-                                                  _previewAnimationController
-                                                      .start,
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                    ),
-                                    Expanded(
-                                      flex: 6,
-                                      child: ExploreFadedScrollView(
-                                        padding: const EdgeInsets.only(
-                                          top: 4,
-                                          left: 12,
-                                        ),
-                                        child: ExploreControls(
-                                          state: _state,
-                                          identity: example.identity,
-                                          tonality: tonality,
-                                          noteNameSystem: noteNameSystem,
-                                          isLandscape: true,
-                                          onRootChanged: (value) => updateState(
-                                            exploreStateWithRoot(_state, value),
-                                          ),
-                                          onBaseQualityChanged: (value) =>
-                                              updateState(
-                                                exploreStateWithBaseQuality(
-                                                  _state,
-                                                  value,
-                                                ),
-                                              ),
-                                          onSeventhKindChanged: (value) =>
-                                              updateState(
-                                                exploreStateWithSeventhKind(
-                                                  _state,
-                                                  value,
-                                                ),
-                                              ),
-                                          onFifthAlterationChanged: (value) =>
-                                              updateState(
-                                                exploreStateWithFifthAlteration(
-                                                  _state,
-                                                  value,
-                                                ),
-                                              ),
-                                          onExtensionsChanged: (value) =>
-                                              updateState(
-                                                exploreStateWithExtensions(
-                                                  _state,
-                                                  value,
-                                                ),
-                                              ),
-                                          onBassChanged: (value) => updateState(
-                                            exploreStateWithBass(_state, value),
-                                          ),
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              )
-                            : Padding(
-                                padding: const EdgeInsets.fromLTRB(
-                                  16,
-                                  16,
-                                  16,
-                                  16,
-                                ),
-                                child: Column(
-                                  crossAxisAlignment:
-                                      CrossAxisAlignment.stretch,
-                                  children: [
-                                    ExploreSummary(presentation: presentation),
-                                    const SizedBox(height: 20),
-                                    ChordMembersSection(
-                                      members: example.members,
-                                      memberDegrees: example.memberDegrees,
-                                      noteNameSystem: noteNameSystem,
-                                      showDegrees: showChordMemberDegrees,
-                                      onShowDegreesChanged: (value) => unawaited(
-                                        ref
-                                            .read(
-                                              exploreChordMemberDegreesProvider
-                                                  .notifier,
-                                            )
-                                            .setShowDegrees(value),
-                                      ),
-                                      previewNotes: example.normalizedVoicing,
-                                      activePitchClasses: previewPitchClasses,
-                                      memberPitchClasses:
-                                          example.memberPitchClassesInOrder,
-                                      onPreviewStarted:
-                                          _previewAnimationController.start,
-                                    ),
-                                    const SizedBox(height: 20),
-                                    Expanded(
-                                      child: ExploreFadedScrollView(
-                                        padding: const EdgeInsets.only(top: 4),
-                                        child: ExploreControls(
-                                          state: _state,
-                                          identity: example.identity,
-                                          tonality: tonality,
-                                          noteNameSystem: noteNameSystem,
-                                          isLandscape: false,
-                                          onRootChanged: (value) => updateState(
-                                            exploreStateWithRoot(_state, value),
-                                          ),
-                                          onBaseQualityChanged: (value) =>
-                                              updateState(
-                                                exploreStateWithBaseQuality(
-                                                  _state,
-                                                  value,
-                                                ),
-                                              ),
-                                          onSeventhKindChanged: (value) =>
-                                              updateState(
-                                                exploreStateWithSeventhKind(
-                                                  _state,
-                                                  value,
-                                                ),
-                                              ),
-                                          onFifthAlterationChanged: (value) =>
-                                              updateState(
-                                                exploreStateWithFifthAlteration(
-                                                  _state,
-                                                  value,
-                                                ),
-                                              ),
-                                          onExtensionsChanged: (value) =>
-                                              updateState(
-                                                exploreStateWithExtensions(
-                                                  _state,
-                                                  value,
-                                                ),
-                                              ),
-                                          onBassChanged: (value) => updateState(
-                                            exploreStateWithBass(_state, value),
-                                          ),
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
+                        child: _buildMainContent(
+                          example: example,
+                          presentation: presentation,
+                          tonality: tonality,
+                          noteNameSystem: noteNameSystem,
+                          showChordMemberDegrees: showChordMemberDegrees,
+                          previewPitchClasses: previewPitchClasses,
+                          isLandscape: isLandscape,
+                          horizontalInset: horizontalInset,
+                        ),
                       ),
                       TonalityBarView(
                         height: kToolbarHeight,
@@ -376,5 +187,145 @@ class _ExploreChordPageState extends ConsumerState<ExploreChordPage> {
         );
       },
     );
+  }
+
+  Widget _buildMainContent({
+    required ExploreChordExample example,
+    required ChordPresentation presentation,
+    required Tonality tonality,
+    required NoteNameSystem noteNameSystem,
+    required bool showChordMemberDegrees,
+    required Set<int> previewPitchClasses,
+    required bool isLandscape,
+    required double horizontalInset,
+  }) {
+    if (isLandscape) {
+      return Padding(
+        padding: EdgeInsets.fromLTRB(horizontalInset, 16, horizontalInset, 12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              flex: 7,
+              child: ExploreFadedScrollView(
+                padding: const EdgeInsets.only(top: 4, right: 12),
+                child: _buildSummaryAndMembers(
+                  example: example,
+                  presentation: presentation,
+                  noteNameSystem: noteNameSystem,
+                  showChordMemberDegrees: showChordMemberDegrees,
+                  previewPitchClasses: previewPitchClasses,
+                ),
+              ),
+            ),
+            Expanded(
+              flex: 6,
+              child: ExploreFadedScrollView(
+                padding: const EdgeInsets.only(top: 4, left: 12),
+                child: _buildControls(
+                  example: example,
+                  tonality: tonality,
+                  noteNameSystem: noteNameSystem,
+                  isLandscape: true,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _buildSummaryAndMembers(
+            example: example,
+            presentation: presentation,
+            noteNameSystem: noteNameSystem,
+            showChordMemberDegrees: showChordMemberDegrees,
+            previewPitchClasses: previewPitchClasses,
+          ),
+          const SizedBox(height: 20),
+          Expanded(
+            child: ExploreFadedScrollView(
+              padding: const EdgeInsets.only(top: 4),
+              child: _buildControls(
+                example: example,
+                tonality: tonality,
+                noteNameSystem: noteNameSystem,
+                isLandscape: false,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummaryAndMembers({
+    required ExploreChordExample example,
+    required ChordPresentation presentation,
+    required NoteNameSystem noteNameSystem,
+    required bool showChordMemberDegrees,
+    required Set<int> previewPitchClasses,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ExploreSummary(presentation: presentation),
+        const SizedBox(height: 20),
+        ExploreChordMembersSection(
+          members: example.members,
+          memberDegrees: example.memberDegrees,
+          noteNameSystem: noteNameSystem,
+          showDegrees: showChordMemberDegrees,
+          onShowDegreesChanged: (value) => unawaited(
+            ref
+                .read(exploreChordMemberDegreesProvider.notifier)
+                .setShowDegrees(value),
+          ),
+          previewNotes: example.normalizedVoicing,
+          activePitchClasses: previewPitchClasses,
+          memberPitchClasses: example.memberPitchClassesInOrder,
+          onPreviewStarted: _previewAnimationController.start,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildControls({
+    required ExploreChordExample example,
+    required Tonality tonality,
+    required NoteNameSystem noteNameSystem,
+    required bool isLandscape,
+  }) {
+    return ExploreControls(
+      state: _state,
+      identity: example.identity,
+      tonality: tonality,
+      noteNameSystem: noteNameSystem,
+      isLandscape: isLandscape,
+      onRootChanged: (value) =>
+          _updateState(exploreStateWithRoot(_state, value)),
+      onBaseQualityChanged: (value) =>
+          _updateState(exploreStateWithBaseQuality(_state, value)),
+      onSeventhKindChanged: (value) =>
+          _updateState(exploreStateWithSeventhKind(_state, value)),
+      onFifthAlterationChanged: (value) =>
+          _updateState(exploreStateWithFifthAlteration(_state, value)),
+      onExtensionsChanged: (value) =>
+          _updateState(exploreStateWithExtensions(_state, value)),
+      onBassChanged: (value) =>
+          _updateState(exploreStateWithBass(_state, value)),
+    );
+  }
+
+  void _updateState(ExploreChordState next) {
+    _previewAnimationController.cancel();
+    setState(() {
+      _state = next;
+    });
   }
 }

--- a/lib/features/explore/services/explore_chord_example_builder.dart
+++ b/lib/features/explore/services/explore_chord_example_builder.dart
@@ -6,7 +6,7 @@ import 'explore_chord_derivation.dart';
 
 abstract final class ExploreChordExampleBuilder {
   static Set<int> canonicalBassPitchClasses(ExploreChordState state) {
-    final intervals = _canonicalExampleIntervals(state);
+    final intervals = _canonicalExampleParts(state).intervals;
     return Set<int>.unmodifiable(
       intervals.map((interval) => (state.rootPc + interval) % 12),
     );
@@ -18,74 +18,63 @@ abstract final class ExploreChordExampleBuilder {
     required ChordNotationStyle notation,
     NoteNameSystem noteNameSystem = NoteNameSystem.international,
   }) {
-    final selectedIdentity = buildExploreChordIdentity(state);
+    final displayIdentity = buildExploreChordIdentity(state);
     final presentation = ChordPresentationBuilder.fromIdentity(
-      identity: selectedIdentity,
+      identity: displayIdentity,
       tonality: tonality,
       notation: notation,
       noteNameSystem: noteNameSystem,
     );
 
-    final exampleIntervals = _canonicalExampleIntervals(state);
-    final exampleExtensions = _canonicalExampleExtensions(
-      state.quality,
-      state.extensions,
-    );
-    final exampleMask = _maskOfIntervals(exampleIntervals);
-    final toneRoles = ChordToneRoles.build(
-      quality: state.quality,
-      extensions: exampleExtensions,
-      relMask: exampleMask,
-    );
+    final parts = _canonicalExampleParts(state);
     final pitchClasses =
         ChordPresentationBuilder.chordMemberPitchClassesFromMask(
           rootPc: state.rootPc,
-          presentIntervalsMask: exampleMask,
+          presentIntervalsMask: parts.mask,
         );
     final bassPc = pitchClasses.contains(state.bassPc)
         ? state.bassPc
         : state.rootPc;
-    final exampleIdentity = ChordIdentity(
+    final canonicalExampleIdentity = ChordIdentity(
       rootPc: state.rootPc,
       bassPc: bassPc,
       quality: state.quality,
-      extensions: exampleExtensions,
-      toneRolesByInterval: toneRoles,
-      presentIntervalsMask: exampleMask,
+      extensions: parts.extensions,
+      toneRolesByInterval: parts.toneRoles,
+      presentIntervalsMask: parts.mask,
     );
-    final orderedPitchClasses = exampleIntervals
+    final orderedPitchClasses = parts.intervals
         .map((interval) => (state.rootPc + interval) % 12)
         .toList(growable: false);
 
     return ExploreChordExample(
       presentation: presentation,
-      identity: exampleIdentity,
+      identity: canonicalExampleIdentity,
       members: _spellMembersInIntervalOrder(
-        identity: exampleIdentity,
-        intervals: exampleIntervals,
+        identity: canonicalExampleIdentity,
+        intervals: parts.intervals,
         tonality: tonality,
       ),
       memberDegrees: _formatDegreesInIntervalOrder(
-        identity: exampleIdentity,
-        intervals: exampleIntervals,
+        identity: canonicalExampleIdentity,
+        intervals: parts.intervals,
       ),
       memberPitchClasses: pitchClasses,
       memberPitchClassesInOrder: orderedPitchClasses,
       normalizedVoicing: _canonicalVoicing(
         rootPc: state.rootPc,
         bassPc: bassPc,
-        intervals: exampleIntervals,
-        identity: exampleIdentity,
+        intervals: parts.intervals,
+        identity: canonicalExampleIdentity,
       ),
     );
   }
 
-  static List<int> _canonicalExampleIntervals(ExploreChordState state) {
+  static List<int> _canonicalExampleIntervals(
+    ExploreChordState state,
+    Set<ChordExtension> extensions,
+  ) {
     final intervals = <int>{...state.quality.canonicalIntervals};
-    final extensions = _canonicalExampleExtensions(
-      state.quality,
-      state.extensions,
-    );
 
     for (final extension in extensions) {
       intervals.add(extension.intervalAboveRoot);
@@ -106,6 +95,29 @@ abstract final class ExploreChordExampleBuilder {
         return a.compareTo(b);
       });
     return List<int>.unmodifiable(ordered);
+  }
+
+  static _CanonicalExampleParts _canonicalExampleParts(
+    ExploreChordState state,
+  ) {
+    final extensions = _canonicalExampleExtensions(
+      state.quality,
+      state.extensions,
+    );
+    final intervals = _canonicalExampleIntervals(state, extensions);
+    final mask = _maskOfIntervals(intervals);
+    final toneRoles = ChordToneRoles.build(
+      quality: state.quality,
+      extensions: extensions,
+      relMask: mask,
+    );
+
+    return _CanonicalExampleParts(
+      intervals: intervals,
+      extensions: extensions,
+      mask: mask,
+      toneRoles: toneRoles,
+    );
   }
 
   static Set<ChordExtension> _canonicalExampleExtensions(
@@ -302,4 +314,18 @@ abstract final class ExploreChordExampleBuilder {
     final normalized = value % 12;
     return normalized < 0 ? normalized + 12 : normalized;
   }
+}
+
+class _CanonicalExampleParts {
+  const _CanonicalExampleParts({
+    required this.intervals,
+    required this.extensions,
+    required this.mask,
+    required this.toneRoles,
+  });
+
+  final List<int> intervals;
+  final Set<ChordExtension> extensions;
+  final int mask;
+  final Map<int, ChordToneRole> toneRoles;
 }

--- a/lib/features/explore/services/explore_chord_options.dart
+++ b/lib/features/explore/services/explore_chord_options.dart
@@ -1,5 +1,7 @@
 import 'package:whatchord/features/theory/theory.dart';
 
+import 'explore_extension_rules.dart';
+
 enum ExploreExtensionControlRole { highestExtension, addedTones, alterations }
 
 class ExploreExtensionControlGroup {
@@ -32,52 +34,46 @@ List<ExploreExtensionControlGroup> buildExploreExtensionControlGroups(
   ChordQualityToken quality,
 ) {
   if (quality.isSeventhFamily) {
-    final availableHighestExtensions = _availableSeventhFamilyHighestExtensions(
-      quality,
-    );
-    final availableAddTones = _availableSeventhFamilyAddTones(quality);
-    final availableColors = _availableSeventhFamilyColorExtensions(quality);
-    final highestExtensionChoices = <ExploreExtensionChoice>[
+    final stack = seventhStackExtensions(quality);
+    final addTones = seventhAddTones(quality);
+    final alterations = seventhAlterations(quality);
+    final stackChoices = <ExploreExtensionChoice>[
       const ExploreExtensionChoice(
         label: 'None',
         semanticLabel: 'No highest extension',
       ),
-      if (availableHighestExtensions.contains(ChordExtension.nine))
-        _choice(ChordExtension.nine),
-      if (_allowsSeventhFamilyHighestEleven(quality) &&
-          availableHighestExtensions.contains(ChordExtension.eleven))
-        _choice(ChordExtension.eleven),
-      if (availableHighestExtensions.contains(ChordExtension.thirteen))
+      if (stack.contains(ChordExtension.nine)) _choice(ChordExtension.nine),
+      if (stack.contains(ChordExtension.eleven)) _choice(ChordExtension.eleven),
+      if (stack.contains(ChordExtension.thirteen))
         _choice(ChordExtension.thirteen),
     ];
     final addToneChoices = <ExploreExtensionChoice>[
-      if (availableAddTones.contains(ChordExtension.add9))
-        _choice(ChordExtension.add9),
-      if (availableAddTones.contains(ChordExtension.add11))
+      if (addTones.contains(ChordExtension.add9)) _choice(ChordExtension.add9),
+      if (addTones.contains(ChordExtension.add11))
         _choice(ChordExtension.add11),
-      if (availableAddTones.contains(ChordExtension.add13))
+      if (addTones.contains(ChordExtension.add13))
         _choice(ChordExtension.add13),
     ];
-    final colorChoices = <ExploreExtensionChoice>[
-      if (availableColors.contains(ChordExtension.flat9))
+    final alterationChoices = <ExploreExtensionChoice>[
+      if (alterations.contains(ChordExtension.flat9))
         ExploreExtensionChoice(
           label: theoryTokenDisplayLabel('b9'),
           semanticLabel: 'Flat ninth',
           extension: ChordExtension.flat9,
         ),
-      if (availableColors.contains(ChordExtension.sharp9))
+      if (alterations.contains(ChordExtension.sharp9))
         ExploreExtensionChoice(
           label: theoryTokenDisplayLabel('#9'),
           semanticLabel: 'Sharp ninth',
           extension: ChordExtension.sharp9,
         ),
-      if (availableColors.contains(ChordExtension.sharp11))
+      if (alterations.contains(ChordExtension.sharp11))
         ExploreExtensionChoice(
           label: theoryTokenDisplayLabel('#11'),
           semanticLabel: 'Sharp eleventh',
           extension: ChordExtension.sharp11,
         ),
-      if (availableColors.contains(ChordExtension.flat13))
+      if (alterations.contains(ChordExtension.flat13))
         ExploreExtensionChoice(
           label: theoryTokenDisplayLabel('b13'),
           semanticLabel: 'Flat thirteenth',
@@ -90,7 +86,7 @@ List<ExploreExtensionControlGroup> buildExploreExtensionControlGroups(
         label: 'Stacked extension',
         role: ExploreExtensionControlRole.highestExtension,
         allowsMultiple: false,
-        choices: highestExtensionChoices,
+        choices: stackChoices,
       ),
       if (addToneChoices.isNotEmpty)
         ExploreExtensionControlGroup(
@@ -99,42 +95,42 @@ List<ExploreExtensionControlGroup> buildExploreExtensionControlGroups(
           allowsMultiple: true,
           choices: addToneChoices,
         ),
-      if (colorChoices.isNotEmpty)
+      if (alterationChoices.isNotEmpty)
         ExploreExtensionControlGroup(
           label: 'Alterations',
           role: ExploreExtensionControlRole.alterations,
           allowsMultiple: true,
-          choices: colorChoices,
+          choices: alterationChoices,
         ),
     ];
   }
 
-  final availableAddTones = _availableTriadLikeAddTones(quality);
-  final availableColors = _availableTriadLikeColorExtensions(quality);
+  final addTones = triadLikeAddTones(quality);
+  final alterations = triadLikeAlterations(quality);
   return [
-    if (availableAddTones.isNotEmpty)
+    if (addTones.isNotEmpty)
       ExploreExtensionControlGroup(
         label: 'Added tones',
         role: ExploreExtensionControlRole.addedTones,
         allowsMultiple: true,
         choices: [
-          if (availableAddTones.contains(ChordExtension.add9))
+          if (addTones.contains(ChordExtension.add9))
             _choice(ChordExtension.add9),
-          if (availableAddTones.contains(ChordExtension.add11))
+          if (addTones.contains(ChordExtension.add11))
             _choice(ChordExtension.add11),
-          if (availableAddTones.contains(ChordExtension.add13))
+          if (addTones.contains(ChordExtension.add13))
             _choice(ChordExtension.add13),
         ],
       ),
-    if (availableColors.isNotEmpty)
+    if (alterations.isNotEmpty)
       ExploreExtensionControlGroup(
         label: 'Alterations',
         role: ExploreExtensionControlRole.alterations,
         allowsMultiple: true,
         choices: [
-          if (availableColors.contains(ChordExtension.flat9))
+          if (alterations.contains(ChordExtension.flat9))
             _choice(ChordExtension.flat9),
-          if (availableColors.contains(ChordExtension.sharp11))
+          if (alterations.contains(ChordExtension.sharp11))
             _choice(ChordExtension.sharp11),
         ],
       ),
@@ -160,8 +156,8 @@ Set<ChordExtension> selectExploreExtensionChoice({
     if (next.contains(extension)) {
       next.remove(extension);
     } else {
-      _removeMutuallyExclusiveTriadLikeExtensions(next, extension);
-      _removeConflictingSeventhFamilyExtensions(next, extension);
+      removeTriadLikeConflicts(next, extension);
+      removeSeventhConflicts(next, extension);
       next.add(extension);
       selected = true;
     }
@@ -169,7 +165,7 @@ Set<ChordExtension> selectExploreExtensionChoice({
     if (selected &&
         quality.isSeventhFamily &&
         group.role == ExploreExtensionControlRole.addedTones) {
-      _promoteSeventhFamilyAddedTone(next, extension);
+      promoteAddedToneToStack(next, extension);
     }
   } else {
     for (final option in group.choices) {
@@ -179,49 +175,12 @@ Set<ChordExtension> selectExploreExtensionChoice({
 
     final extension = choice.extension;
     if (extension != null) {
-      _removeConflictingSeventhFamilyExtensions(next, extension);
+      removeSeventhConflicts(next, extension);
       next.add(extension);
     }
   }
 
   return normalizeExtensionsForQuality(quality: quality, extensions: next);
-}
-
-void _promoteSeventhFamilyAddedTone(
-  Set<ChordExtension> extensions,
-  ChordExtension selected,
-) {
-  switch (selected) {
-    case ChordExtension.add9:
-      extensions.remove(ChordExtension.add9);
-      extensions.add(ChordExtension.nine);
-      break;
-    case ChordExtension.add11:
-      if (!_hasAnyNinth(extensions)) break;
-      extensions.remove(ChordExtension.nine);
-      extensions.remove(ChordExtension.add9);
-      extensions.remove(ChordExtension.add11);
-      extensions.add(ChordExtension.eleven);
-      break;
-    case ChordExtension.add13:
-      if (!extensions.contains(ChordExtension.eleven)) break;
-      extensions.remove(ChordExtension.nine);
-      extensions.remove(ChordExtension.eleven);
-      extensions.remove(ChordExtension.add9);
-      extensions.remove(ChordExtension.add11);
-      extensions.remove(ChordExtension.add13);
-      extensions.add(ChordExtension.thirteen);
-      break;
-    default:
-      break;
-  }
-}
-
-bool _hasAnyNinth(Set<ChordExtension> extensions) {
-  return extensions.contains(ChordExtension.nine) ||
-      extensions.contains(ChordExtension.add9) ||
-      extensions.contains(ChordExtension.flat9) ||
-      extensions.contains(ChordExtension.sharp9);
 }
 
 ExploreExtensionChoice _choice(ChordExtension extension) {
@@ -230,325 +189,4 @@ ExploreExtensionChoice _choice(ChordExtension extension) {
     semanticLabel: extension.longLabel,
     extension: extension,
   );
-}
-
-Set<ChordExtension> normalizeExtensionsForQuality({
-  required ChordQualityToken quality,
-  required Set<ChordExtension> extensions,
-}) {
-  final normalized = <ChordExtension>{};
-  final availableSeventhHighestExtensions = quality.isSeventhFamily
-      ? _availableSeventhFamilyHighestExtensions(quality)
-      : const <ChordExtension>{};
-  final availableSeventhAddTones = quality.isSeventhFamily
-      ? _availableSeventhFamilyAddTones(quality)
-      : const <ChordExtension>{};
-  final availableSeventhColors = quality.isSeventhFamily
-      ? _availableSeventhFamilyColorExtensions(quality)
-      : const <ChordExtension>{};
-  final availableTriadLikeExtensions = !quality.isSeventhFamily
-      ? _availableTriadLikeExtensions(quality)
-      : const <ChordExtension>{};
-
-  void addSeventhHighestExtension(ChordExtension extension) {
-    if (availableSeventhHighestExtensions.contains(extension)) {
-      normalized.add(extension);
-    }
-  }
-
-  void addSeventhAddTone(ChordExtension extension) {
-    if (availableSeventhAddTones.contains(extension)) {
-      normalized.add(extension);
-    }
-  }
-
-  void addSeventhColor(ChordExtension extension) {
-    if (availableSeventhColors.contains(extension)) {
-      normalized.add(extension);
-    }
-  }
-
-  void addTriadLikeExtension(ChordExtension extension) {
-    if (availableTriadLikeExtensions.contains(extension)) {
-      normalized.add(extension);
-    }
-  }
-
-  for (final extension in extensions) {
-    switch (extension) {
-      case ChordExtension.add9:
-        if (quality.isSeventhFamily) {
-          addSeventhHighestExtension(ChordExtension.nine);
-        } else {
-          addTriadLikeExtension(ChordExtension.add9);
-        }
-        break;
-      case ChordExtension.add11:
-        if (quality.isSeventhFamily) {
-          addSeventhAddTone(ChordExtension.add11);
-        } else {
-          addTriadLikeExtension(ChordExtension.add11);
-        }
-        break;
-      case ChordExtension.add13:
-        if (quality.isSeventhFamily) {
-          addSeventhAddTone(ChordExtension.add13);
-        } else {
-          addTriadLikeExtension(ChordExtension.add13);
-        }
-        break;
-      case ChordExtension.nine:
-        if (quality.isSeventhFamily) {
-          addSeventhHighestExtension(ChordExtension.nine);
-        } else {
-          addTriadLikeExtension(ChordExtension.add9);
-        }
-        break;
-      case ChordExtension.eleven:
-        if (quality.isSeventhFamily) {
-          if (_allowsSeventhFamilyHighestEleven(quality)) {
-            addSeventhHighestExtension(ChordExtension.eleven);
-          }
-        } else {
-          addTriadLikeExtension(ChordExtension.add11);
-        }
-        break;
-      case ChordExtension.thirteen:
-        if (quality.isSeventhFamily) {
-          addSeventhHighestExtension(ChordExtension.thirteen);
-        } else {
-          addTriadLikeExtension(ChordExtension.add13);
-        }
-        break;
-      case ChordExtension.sharp9:
-      case ChordExtension.flat13:
-        addSeventhColor(extension);
-        break;
-      case ChordExtension.flat9:
-        if (quality.isSeventhFamily) {
-          addSeventhColor(extension);
-        } else {
-          addTriadLikeExtension(ChordExtension.flat9);
-        }
-        break;
-      case ChordExtension.sharp11:
-        if (quality.isSeventhFamily) {
-          addSeventhColor(extension);
-        } else {
-          addTriadLikeExtension(ChordExtension.sharp11);
-        }
-        break;
-    }
-  }
-
-  if (quality.isSeventhFamily) {
-    _promoteSeventhFamilyCompletedStacks(normalized);
-  }
-
-  return Set<ChordExtension>.unmodifiable(normalized);
-}
-
-void _promoteSeventhFamilyCompletedStacks(Set<ChordExtension> extensions) {
-  if (extensions.contains(ChordExtension.add11) && _hasAnyNinth(extensions)) {
-    extensions.remove(ChordExtension.nine);
-    extensions.remove(ChordExtension.add9);
-    extensions.remove(ChordExtension.add11);
-    extensions.add(ChordExtension.eleven);
-  }
-
-  if (extensions.contains(ChordExtension.add13) &&
-      extensions.contains(ChordExtension.eleven)) {
-    extensions.remove(ChordExtension.nine);
-    extensions.remove(ChordExtension.eleven);
-    extensions.remove(ChordExtension.add9);
-    extensions.remove(ChordExtension.add11);
-    extensions.remove(ChordExtension.add13);
-    extensions.add(ChordExtension.thirteen);
-  }
-}
-
-bool _allowsTriadLikeSharp11(ChordQualityToken quality) {
-  return switch (quality) {
-    ChordQualityToken.major ||
-    ChordQualityToken.minor ||
-    ChordQualityToken.major6 ||
-    ChordQualityToken.minor6 ||
-    ChordQualityToken.augmented => true,
-    _ => false,
-  };
-}
-
-bool _allowsTriadLikeFlat9(ChordQualityToken quality) {
-  return switch (quality) {
-    ChordQualityToken.major6 || ChordQualityToken.minor6 => true,
-    _ => false,
-  };
-}
-
-Set<ChordExtension> _availableTriadLikeExtensions(ChordQualityToken quality) {
-  final canonicalIntervals = quality.canonicalIntervals;
-  return {
-    for (final extension in const {
-      ChordExtension.flat9,
-      ChordExtension.add9,
-      ChordExtension.add11,
-      ChordExtension.add13,
-      ChordExtension.sharp11,
-    })
-      if (!canonicalIntervals.contains(extension.intervalAboveRoot) &&
-          (!_isTriadLikeSharp11(extension) ||
-              _allowsTriadLikeSharp11(quality)) &&
-          (!_isTriadLikeFlat9(extension) || _allowsTriadLikeFlat9(quality)))
-        extension,
-  };
-}
-
-Set<ChordExtension> _availableTriadLikeAddTones(ChordQualityToken quality) {
-  final available = _availableTriadLikeExtensions(quality);
-  return {
-    for (final extension in const {
-      ChordExtension.add9,
-      ChordExtension.add11,
-      ChordExtension.add13,
-    })
-      if (available.contains(extension)) extension,
-  };
-}
-
-Set<ChordExtension> _availableTriadLikeColorExtensions(
-  ChordQualityToken quality,
-) {
-  final available = _availableTriadLikeExtensions(quality);
-  return {
-    if (available.contains(ChordExtension.flat9)) ChordExtension.flat9,
-    if (available.contains(ChordExtension.sharp11)) ChordExtension.sharp11,
-  };
-}
-
-bool _isTriadLikeFlat9(ChordExtension extension) {
-  return extension == ChordExtension.flat9;
-}
-
-bool _isTriadLikeSharp11(ChordExtension extension) {
-  return extension == ChordExtension.sharp11;
-}
-
-bool _allowsSeventhFamilyHighestEleven(ChordQualityToken quality) {
-  return quality.isSeventhFamily;
-}
-
-void _removeMutuallyExclusiveTriadLikeExtensions(
-  Set<ChordExtension> extensions,
-  ChordExtension selected,
-) {
-  switch (selected) {
-    case ChordExtension.add9:
-      extensions.remove(ChordExtension.flat9);
-      break;
-    case ChordExtension.flat9:
-      extensions.remove(ChordExtension.add9);
-      break;
-    case ChordExtension.add11:
-      extensions.remove(ChordExtension.sharp11);
-      break;
-    case ChordExtension.sharp11:
-      extensions.remove(ChordExtension.add11);
-      break;
-    default:
-      break;
-  }
-}
-
-void _removeConflictingSeventhFamilyExtensions(
-  Set<ChordExtension> extensions,
-  ChordExtension selected,
-) {
-  switch (selected) {
-    case ChordExtension.nine:
-      extensions.remove(ChordExtension.add9);
-      extensions.remove(ChordExtension.flat9);
-      extensions.remove(ChordExtension.sharp9);
-      break;
-    case ChordExtension.eleven:
-      extensions.remove(ChordExtension.add9);
-      extensions.remove(ChordExtension.add11);
-      extensions.remove(ChordExtension.sharp11);
-      break;
-    case ChordExtension.thirteen:
-      extensions.remove(ChordExtension.add9);
-      extensions.remove(ChordExtension.add11);
-      extensions.remove(ChordExtension.add13);
-      extensions.remove(ChordExtension.flat13);
-      break;
-    case ChordExtension.add9:
-      extensions.remove(ChordExtension.nine);
-      extensions.remove(ChordExtension.eleven);
-      extensions.remove(ChordExtension.thirteen);
-      extensions.remove(ChordExtension.flat9);
-      extensions.remove(ChordExtension.sharp9);
-      break;
-    case ChordExtension.add11:
-      extensions.remove(ChordExtension.eleven);
-      extensions.remove(ChordExtension.thirteen);
-      extensions.remove(ChordExtension.sharp11);
-      break;
-    case ChordExtension.add13:
-      extensions.remove(ChordExtension.thirteen);
-      extensions.remove(ChordExtension.flat13);
-      break;
-    case ChordExtension.flat9:
-      extensions.remove(ChordExtension.nine);
-      extensions.remove(ChordExtension.add9);
-      break;
-    case ChordExtension.sharp9:
-      extensions.remove(ChordExtension.nine);
-      extensions.remove(ChordExtension.add9);
-      break;
-    case ChordExtension.sharp11:
-      extensions.remove(ChordExtension.eleven);
-      extensions.remove(ChordExtension.add11);
-      break;
-    case ChordExtension.flat13:
-      extensions.remove(ChordExtension.thirteen);
-      extensions.remove(ChordExtension.add13);
-      break;
-  }
-}
-
-Set<ChordExtension> _availableSeventhFamilyHighestExtensions(
-  ChordQualityToken quality,
-) {
-  final canonicalIntervals = quality.canonicalIntervals;
-  return {
-    for (final extension in const {
-      ChordExtension.flat9,
-      ChordExtension.nine,
-      ChordExtension.eleven,
-      ChordExtension.thirteen,
-    })
-      if (!canonicalIntervals.contains(extension.intervalAboveRoot)) extension,
-  };
-}
-
-Set<ChordExtension> _availableSeventhFamilyAddTones(ChordQualityToken quality) {
-  final canonicalIntervals = quality.canonicalIntervals;
-  return {
-    for (final extension in const {ChordExtension.add11, ChordExtension.add13})
-      if (!canonicalIntervals.contains(extension.intervalAboveRoot)) extension,
-  };
-}
-
-Set<ChordExtension> _availableSeventhFamilyColorExtensions(
-  ChordQualityToken quality,
-) {
-  final canonicalIntervals = quality.canonicalIntervals;
-  return {
-    for (final extension in const {
-      ChordExtension.flat9,
-      ChordExtension.sharp9,
-      ChordExtension.sharp11,
-      ChordExtension.flat13,
-    })
-      if (!canonicalIntervals.contains(extension.intervalAboveRoot)) extension,
-  };
 }

--- a/lib/features/explore/services/explore_chord_state_transitions.dart
+++ b/lib/features/explore/services/explore_chord_state_transitions.dart
@@ -3,19 +3,11 @@ import 'package:whatchord/features/theory/theory.dart';
 import '../models/explore_chord_spec.dart';
 import '../models/explore_chord_state.dart';
 import 'explore_chord_example_builder.dart';
-import 'explore_chord_options.dart';
+import 'explore_extension_rules.dart';
 
 ExploreChordState normalizeExploreChordState(ExploreChordState state) {
   final spec = state.spec.normalized();
-  return _withValidBass(
-    state.copyWith(
-      spec: spec,
-      extensions: normalizeExtensionsForQuality(
-        quality: spec.quality,
-        extensions: state.extensions,
-      ),
-    ),
-  );
+  return _withSpec(state, spec);
 }
 
 ExploreChordState exploreStateWithRoot(ExploreChordState state, int rootPc) {
@@ -30,15 +22,7 @@ ExploreChordState exploreStateWithBaseQuality(
     baseQuality: baseQuality,
     fifthAlteration: defaultFifthAlterationFor(baseQuality),
   );
-  return _withValidBass(
-    state.copyWith(
-      spec: nextSpec,
-      extensions: normalizeExtensionsForQuality(
-        quality: nextSpec.quality,
-        extensions: state.extensions,
-      ),
-    ),
-  );
+  return _withSpec(state, nextSpec);
 }
 
 ExploreChordState exploreStateWithSeventhKind(
@@ -46,15 +30,7 @@ ExploreChordState exploreStateWithSeventhKind(
   ExploreSeventhKind seventhKind,
 ) {
   final nextSpec = state.spec.copyWith(seventhKind: seventhKind);
-  return _withValidBass(
-    state.copyWith(
-      spec: nextSpec,
-      extensions: normalizeExtensionsForQuality(
-        quality: nextSpec.quality,
-        extensions: state.extensions,
-      ),
-    ),
-  );
+  return _withSpec(state, nextSpec);
 }
 
 ExploreChordState exploreStateWithFifthAlteration(
@@ -62,15 +38,7 @@ ExploreChordState exploreStateWithFifthAlteration(
   ExploreFifthAlteration fifthAlteration,
 ) {
   final nextSpec = state.spec.copyWith(fifthAlteration: fifthAlteration);
-  return _withValidBass(
-    state.copyWith(
-      spec: nextSpec,
-      extensions: normalizeExtensionsForQuality(
-        quality: nextSpec.quality,
-        extensions: state.extensions,
-      ),
-    ),
-  );
+  return _withSpec(state, nextSpec);
 }
 
 ExploreChordState exploreStateWithQuality(
@@ -78,11 +46,15 @@ ExploreChordState exploreStateWithQuality(
   ChordQualityToken quality,
 ) {
   final nextSpec = ExploreChordSpec.fromQuality(quality);
+  return _withSpec(state, nextSpec);
+}
+
+ExploreChordState _withSpec(ExploreChordState state, ExploreChordSpec spec) {
   return _withValidBass(
     state.copyWith(
-      spec: nextSpec,
+      spec: spec,
       extensions: normalizeExtensionsForQuality(
-        quality: nextSpec.quality,
+        quality: spec.quality,
         extensions: state.extensions,
       ),
     ),

--- a/lib/features/explore/services/explore_extension_rules.dart
+++ b/lib/features/explore/services/explore_extension_rules.dart
@@ -1,0 +1,359 @@
+import 'package:whatchord/features/theory/theory.dart';
+
+/// Keeps Explore selections musically meaningful when the base quality changes.
+///
+/// The same pitch can be notated differently depending on context: triad-like
+/// chords use add tones, while seventh-family chords can use stacked 9/11/13
+/// extensions once the lower stack is present.
+Set<ChordExtension> normalizeExtensionsForQuality({
+  required ChordQualityToken quality,
+  required Set<ChordExtension> extensions,
+}) {
+  final normalized = <ChordExtension>{};
+  final stack = quality.isSeventhFamily
+      ? seventhStackExtensions(quality)
+      : const <ChordExtension>{};
+  final addTones = quality.isSeventhFamily
+      ? seventhAddTones(quality)
+      : const <ChordExtension>{};
+  final alterations = quality.isSeventhFamily
+      ? seventhAlterations(quality)
+      : const <ChordExtension>{};
+  final triadLike = !quality.isSeventhFamily
+      ? triadLikeExtensions(quality)
+      : const <ChordExtension>{};
+
+  void addStackExtension(ChordExtension extension) {
+    if (stack.contains(extension)) {
+      normalized.add(extension);
+    }
+  }
+
+  void addSeventhAddTone(ChordExtension extension) {
+    if (addTones.contains(extension)) {
+      normalized.add(extension);
+    }
+  }
+
+  void addSeventhAlteration(ChordExtension extension) {
+    if (alterations.contains(extension)) {
+      normalized.add(extension);
+    }
+  }
+
+  void addTriadLikeExtension(ChordExtension extension) {
+    if (triadLike.contains(extension)) {
+      normalized.add(extension);
+    }
+  }
+
+  for (final extension in extensions) {
+    switch (extension) {
+      case ChordExtension.add9:
+        if (quality.isSeventhFamily) {
+          addStackExtension(ChordExtension.nine);
+        } else {
+          addTriadLikeExtension(ChordExtension.add9);
+        }
+        break;
+      case ChordExtension.add11:
+        if (quality.isSeventhFamily) {
+          addSeventhAddTone(ChordExtension.add11);
+        } else {
+          addTriadLikeExtension(ChordExtension.add11);
+        }
+        break;
+      case ChordExtension.add13:
+        if (quality.isSeventhFamily) {
+          addSeventhAddTone(ChordExtension.add13);
+        } else {
+          addTriadLikeExtension(ChordExtension.add13);
+        }
+        break;
+      case ChordExtension.nine:
+        if (quality.isSeventhFamily) {
+          addStackExtension(ChordExtension.nine);
+        } else {
+          addTriadLikeExtension(ChordExtension.add9);
+        }
+        break;
+      case ChordExtension.eleven:
+        if (quality.isSeventhFamily) {
+          addStackExtension(ChordExtension.eleven);
+        } else {
+          addTriadLikeExtension(ChordExtension.add11);
+        }
+        break;
+      case ChordExtension.thirteen:
+        if (quality.isSeventhFamily) {
+          addStackExtension(ChordExtension.thirteen);
+        } else {
+          addTriadLikeExtension(ChordExtension.add13);
+        }
+        break;
+      case ChordExtension.sharp9:
+      case ChordExtension.flat13:
+        addSeventhAlteration(extension);
+        break;
+      case ChordExtension.flat9:
+        if (quality.isSeventhFamily) {
+          addSeventhAlteration(extension);
+        } else {
+          addTriadLikeExtension(ChordExtension.flat9);
+        }
+        break;
+      case ChordExtension.sharp11:
+        if (quality.isSeventhFamily) {
+          addSeventhAlteration(extension);
+        } else {
+          addTriadLikeExtension(ChordExtension.sharp11);
+        }
+        break;
+    }
+  }
+
+  if (quality.isSeventhFamily) {
+    promoteCompletedStacks(normalized);
+  }
+
+  return Set<ChordExtension>.unmodifiable(normalized);
+}
+
+/// Turns add-tone picks into stacked extensions when the implied stack exists.
+///
+/// Example: selecting add11 above an existing ninth should become an eleventh,
+/// because 11 implies the lower 9 in standard seventh-family chord spelling.
+void promoteAddedToneToStack(
+  Set<ChordExtension> extensions,
+  ChordExtension selected,
+) {
+  switch (selected) {
+    case ChordExtension.add9:
+      extensions.remove(ChordExtension.add9);
+      extensions.add(ChordExtension.nine);
+      break;
+    case ChordExtension.add11:
+      if (!hasAnyNinth(extensions)) break;
+      _replaceWithStackedEleventh(extensions);
+      break;
+    case ChordExtension.add13:
+      if (!extensions.contains(ChordExtension.eleven)) break;
+      _replaceWithStackedThirteenth(extensions);
+      break;
+    default:
+      break;
+  }
+}
+
+/// Collapses skipped add tones after bulk normalization or quality changes.
+void promoteCompletedStacks(Set<ChordExtension> extensions) {
+  if (extensions.contains(ChordExtension.add11) && hasAnyNinth(extensions)) {
+    _replaceWithStackedEleventh(extensions);
+  }
+
+  if (extensions.contains(ChordExtension.add13) &&
+      extensions.contains(ChordExtension.eleven)) {
+    _replaceWithStackedThirteenth(extensions);
+  }
+}
+
+bool hasAnyNinth(Set<ChordExtension> extensions) {
+  return extensions.contains(ChordExtension.nine) ||
+      extensions.contains(ChordExtension.add9) ||
+      extensions.contains(ChordExtension.flat9) ||
+      extensions.contains(ChordExtension.sharp9);
+}
+
+void removeTriadLikeConflicts(
+  Set<ChordExtension> extensions,
+  ChordExtension selected,
+) {
+  // Triad-like chords expose enharmonic alternatives as separate controls, but
+  // the resulting chord should not contain both versions of the same degree.
+  switch (selected) {
+    case ChordExtension.add9:
+      extensions.remove(ChordExtension.flat9);
+      break;
+    case ChordExtension.flat9:
+      extensions.remove(ChordExtension.add9);
+      break;
+    case ChordExtension.add11:
+      extensions.remove(ChordExtension.sharp11);
+      break;
+    case ChordExtension.sharp11:
+      extensions.remove(ChordExtension.add11);
+      break;
+    default:
+      break;
+  }
+}
+
+void removeSeventhConflicts(
+  Set<ChordExtension> extensions,
+  ChordExtension selected,
+) {
+  // Stacked extensions, explicit add tones, and alterations are mutually
+  // exclusive when they spell the same chord degree or imply incompatible stack
+  // intent.
+  switch (selected) {
+    case ChordExtension.nine:
+      extensions.remove(ChordExtension.add9);
+      extensions.remove(ChordExtension.flat9);
+      extensions.remove(ChordExtension.sharp9);
+      break;
+    case ChordExtension.eleven:
+      extensions.remove(ChordExtension.add9);
+      extensions.remove(ChordExtension.add11);
+      extensions.remove(ChordExtension.sharp11);
+      break;
+    case ChordExtension.thirteen:
+      extensions.remove(ChordExtension.add9);
+      extensions.remove(ChordExtension.add11);
+      extensions.remove(ChordExtension.add13);
+      extensions.remove(ChordExtension.flat13);
+      break;
+    case ChordExtension.add9:
+      extensions.remove(ChordExtension.nine);
+      extensions.remove(ChordExtension.eleven);
+      extensions.remove(ChordExtension.thirteen);
+      extensions.remove(ChordExtension.flat9);
+      extensions.remove(ChordExtension.sharp9);
+      break;
+    case ChordExtension.add11:
+      extensions.remove(ChordExtension.eleven);
+      extensions.remove(ChordExtension.thirteen);
+      extensions.remove(ChordExtension.sharp11);
+      break;
+    case ChordExtension.add13:
+      extensions.remove(ChordExtension.thirteen);
+      extensions.remove(ChordExtension.flat13);
+      break;
+    case ChordExtension.flat9:
+      extensions.remove(ChordExtension.nine);
+      extensions.remove(ChordExtension.add9);
+      break;
+    case ChordExtension.sharp9:
+      extensions.remove(ChordExtension.nine);
+      extensions.remove(ChordExtension.add9);
+      break;
+    case ChordExtension.sharp11:
+      extensions.remove(ChordExtension.eleven);
+      extensions.remove(ChordExtension.add11);
+      break;
+    case ChordExtension.flat13:
+      extensions.remove(ChordExtension.thirteen);
+      extensions.remove(ChordExtension.add13);
+      break;
+  }
+}
+
+/// Extensions available before splitting them into add-tone and alteration UI.
+Set<ChordExtension> triadLikeExtensions(ChordQualityToken quality) {
+  final canonicalIntervals = quality.canonicalIntervals;
+  return {
+    for (final extension in const {
+      ChordExtension.flat9,
+      ChordExtension.add9,
+      ChordExtension.add11,
+      ChordExtension.add13,
+      ChordExtension.sharp11,
+    })
+      if (!canonicalIntervals.contains(extension.intervalAboveRoot) &&
+          (extension != ChordExtension.sharp11 ||
+              _allowsTriadLikeSharp11(quality)) &&
+          (extension != ChordExtension.flat9 || _allowsTriadLikeFlat9(quality)))
+        extension,
+  };
+}
+
+Set<ChordExtension> triadLikeAddTones(ChordQualityToken quality) {
+  final available = triadLikeExtensions(quality);
+  return {
+    for (final extension in const {
+      ChordExtension.add9,
+      ChordExtension.add11,
+      ChordExtension.add13,
+    })
+      if (available.contains(extension)) extension,
+  };
+}
+
+Set<ChordExtension> triadLikeAlterations(ChordQualityToken quality) {
+  final available = triadLikeExtensions(quality);
+  return {
+    if (available.contains(ChordExtension.flat9)) ChordExtension.flat9,
+    if (available.contains(ChordExtension.sharp11)) ChordExtension.sharp11,
+  };
+}
+
+Set<ChordExtension> seventhStackExtensions(ChordQualityToken quality) {
+  final canonicalIntervals = quality.canonicalIntervals;
+  return {
+    for (final extension in const {
+      ChordExtension.flat9,
+      ChordExtension.nine,
+      ChordExtension.eleven,
+      ChordExtension.thirteen,
+    })
+      if (!canonicalIntervals.contains(extension.intervalAboveRoot)) extension,
+  };
+}
+
+/// Add-tone choices for seventh-family chords intentionally start above add9.
+///
+/// In this UI, choosing an added ninth on a seventh chord promotes directly to
+/// the stacked ninth.
+Set<ChordExtension> seventhAddTones(ChordQualityToken quality) {
+  final canonicalIntervals = quality.canonicalIntervals;
+  return {
+    for (final extension in const {ChordExtension.add11, ChordExtension.add13})
+      if (!canonicalIntervals.contains(extension.intervalAboveRoot)) extension,
+  };
+}
+
+Set<ChordExtension> seventhAlterations(ChordQualityToken quality) {
+  final canonicalIntervals = quality.canonicalIntervals;
+  return {
+    for (final extension in const {
+      ChordExtension.flat9,
+      ChordExtension.sharp9,
+      ChordExtension.sharp11,
+      ChordExtension.flat13,
+    })
+      if (!canonicalIntervals.contains(extension.intervalAboveRoot)) extension,
+  };
+}
+
+void _replaceWithStackedEleventh(Set<ChordExtension> extensions) {
+  extensions.remove(ChordExtension.nine);
+  extensions.remove(ChordExtension.add9);
+  extensions.remove(ChordExtension.add11);
+  extensions.add(ChordExtension.eleven);
+}
+
+void _replaceWithStackedThirteenth(Set<ChordExtension> extensions) {
+  extensions.remove(ChordExtension.nine);
+  extensions.remove(ChordExtension.eleven);
+  extensions.remove(ChordExtension.add9);
+  extensions.remove(ChordExtension.add11);
+  extensions.remove(ChordExtension.add13);
+  extensions.add(ChordExtension.thirteen);
+}
+
+bool _allowsTriadLikeSharp11(ChordQualityToken quality) {
+  return switch (quality) {
+    ChordQualityToken.major ||
+    ChordQualityToken.minor ||
+    ChordQualityToken.major6 ||
+    ChordQualityToken.minor6 ||
+    ChordQualityToken.augmented => true,
+    _ => false,
+  };
+}
+
+bool _allowsTriadLikeFlat9(ChordQualityToken quality) {
+  return switch (quality) {
+    ChordQualityToken.major6 || ChordQualityToken.minor6 => true,
+    _ => false,
+  };
+}

--- a/lib/features/explore/widgets/explore_chord_members_section.dart
+++ b/lib/features/explore/widgets/explore_chord_members_section.dart
@@ -9,8 +9,8 @@ import 'package:whatchord/features/audio/audio.dart';
 import 'package:whatchord/features/input/input.dart';
 import 'package:whatchord/features/theory/theory.dart';
 
-class ChordMembersSection extends StatefulWidget {
-  const ChordMembersSection({
+class ExploreChordMembersSection extends StatefulWidget {
+  const ExploreChordMembersSection({
     super.key,
     required this.members,
     required this.memberDegrees,
@@ -34,10 +34,11 @@ class ChordMembersSection extends StatefulWidget {
   final ValueChanged<List<int>> onPreviewStarted;
 
   @override
-  State<ChordMembersSection> createState() => _ChordMembersSectionState();
+  State<ExploreChordMembersSection> createState() =>
+      _ExploreChordMembersSectionState();
 }
 
-class _ChordMembersSectionState extends State<ChordMembersSection>
+class _ExploreChordMembersSectionState extends State<ExploreChordMembersSection>
     with TickerProviderStateMixin {
   static const Duration _insertDuration = Duration(milliseconds: 140);
   static const Duration _removeDuration = Duration(milliseconds: 120);
@@ -51,7 +52,7 @@ class _ChordMembersSectionState extends State<ChordMembersSection>
   }
 
   @override
-  void didUpdateWidget(covariant ChordMembersSection oldWidget) {
+  void didUpdateWidget(covariant ExploreChordMembersSection oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.showDegrees != widget.showDegrees ||
         oldWidget.members != widget.members ||

--- a/lib/features/explore/widgets/explore_controls.dart
+++ b/lib/features/explore/widgets/explore_controls.dart
@@ -39,6 +39,11 @@ class ExploreControls extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final extensionGroups = buildExploreExtensionControlGroups(state.quality);
+    final seventhKindChoices = availableSeventhKindsFor(state.baseQuality);
+    final fifthAlterationChoices = availableFifthAlterationsFor(
+      baseQuality: state.baseQuality,
+      seventhKind: state.seventhKind,
+    );
     final memberPitchClasses =
         ChordPresentationBuilder.chordMemberPitchClassesFromMask(
           rootPc: identity.rootPc,
@@ -76,28 +81,22 @@ class ExploreControls extends StatelessWidget {
                   onChanged: onBaseQualityChanged,
                 ),
               ),
-              SizedBox(
-                width: controlWidth,
-                child: _SeventhKindSelector(
-                  baseQuality: state.baseQuality,
-                  value: state.seventhKind,
-                  choices: availableSeventhKindsFor(state.baseQuality),
-                  onChanged: onSeventhKindChanged,
-                ),
-              ),
-              if (availableFifthAlterationsFor(
+              if (seventhKindChoices.length > 1)
+                SizedBox(
+                  width: controlWidth,
+                  child: _SeventhKindSelector(
                     baseQuality: state.baseQuality,
-                    seventhKind: state.seventhKind,
-                  ).length >
-                  1)
+                    value: state.seventhKind,
+                    choices: seventhKindChoices,
+                    onChanged: onSeventhKindChanged,
+                  ),
+                ),
+              if (fifthAlterationChoices.length > 1)
                 SizedBox(
                   width: controlWidth,
                   child: _FifthAlterationSelector(
                     value: state.fifthAlteration,
-                    choices: availableFifthAlterationsFor(
-                      baseQuality: state.baseQuality,
-                      seventhKind: state.seventhKind,
-                    ),
+                    choices: fifthAlterationChoices,
                     onChanged: onFifthAlterationChanged,
                   ),
                 ),
@@ -127,20 +126,15 @@ class ExploreControls extends StatelessWidget {
                       memberPitchClasses,
                       identity.rootPc,
                     ))
-                      _BassChoice(
+                      _buildBassChoice(
                         pc: pc,
-                        label: pc == identity.rootPc
-                            ? 'Root'
-                            : '/${noteDisplayLabel(
-                                _spellBass(pc: pc, identity: identity, tonality: tonality),
-                                noteNameSystem: noteNameSystem,
-                              )}',
-                        semanticLabel: pc == identity.rootPc
-                            ? 'Root position'
-                            : 'Bass ${noteSemanticLabel(
-                                _spellBass(pc: pc, identity: identity, tonality: tonality),
-                                noteNameSystem: noteNameSystem,
-                              )}',
+                        rootPc: identity.rootPc,
+                        bassName: _spellBass(
+                          pc: pc,
+                          identity: identity,
+                          tonality: tonality,
+                        ),
+                        noteNameSystem: noteNameSystem,
                       ),
                   ],
                   onChanged: onBassChanged,
@@ -171,8 +165,8 @@ class ExploreControls extends StatelessWidget {
   List<int> _sortedPitchClasses(Set<int> pitchClasses, int rootPc) {
     final values = pitchClasses.toList();
     values.sort((a, b) {
-      final intervalA = (a - rootPc) % 12;
-      final intervalB = (b - rootPc) % 12;
+      final intervalA = _normalizedPitchClass(a - rootPc);
+      final intervalB = _normalizedPitchClass(b - rootPc);
       return intervalA.compareTo(intervalB);
     });
     return values;
@@ -184,13 +178,36 @@ class ExploreControls extends StatelessWidget {
     required Tonality tonality,
   }) {
     final root = pcToName(identity.rootPc, tonality: tonality);
-    final interval = (pc - identity.rootPc) % 12;
+    final interval = _normalizedPitchClass(pc - identity.rootPc);
     final role = identity.toneRolesByInterval[interval];
     return spellPitchClass(
       pc,
       tonality: tonality,
       chordRootName: root,
       role: role,
+    );
+  }
+
+  int _normalizedPitchClass(int value) {
+    final normalized = value % 12;
+    return normalized < 0 ? normalized + 12 : normalized;
+  }
+
+  _BassChoice _buildBassChoice({
+    required int pc,
+    required int rootPc,
+    required String bassName,
+    required NoteNameSystem noteNameSystem,
+  }) {
+    if (pc == rootPc) {
+      return _BassChoice(pc: pc, label: 'Root', semanticLabel: 'Root position');
+    }
+
+    return _BassChoice(
+      pc: pc,
+      label: '/${noteDisplayLabel(bassName, noteNameSystem: noteNameSystem)}',
+      semanticLabel:
+          'Bass ${noteSemanticLabel(bassName, noteNameSystem: noteNameSystem)}',
     );
   }
 }
@@ -308,7 +325,7 @@ class _FifthAlterationSelector extends StatelessWidget {
   }
 }
 
-class _OptionWheel<T> extends StatefulWidget {
+class _OptionWheel<T> extends StatelessWidget {
   const _OptionWheel({
     required this.label,
     required this.value,
@@ -326,13 +343,57 @@ class _OptionWheel<T> extends StatefulWidget {
   final ValueChanged<T> onChanged;
 
   @override
-  State<_OptionWheel<T>> createState() => _OptionWheelState<T>();
+  Widget build(BuildContext context) {
+    return _CyclicWheel<T>(
+      label: label,
+      value: value,
+      choices: choices,
+      displayLabelFor: (value) => theoryTokenDisplayLabel(labelFor(value)),
+      semanticLabelFor: semanticLabelFor,
+      targetItemWidth: 96,
+      selectedMinWidth: 76,
+      unselectedMinWidth: 64,
+      selectedHorizontalPadding: 8,
+      unselectedHorizontalPadding: 6,
+      onChanged: onChanged,
+    );
+  }
 }
 
-class _OptionWheelState<T> extends State<_OptionWheel<T>> {
+class _CyclicWheel<T> extends StatefulWidget {
+  const _CyclicWheel({
+    required this.label,
+    required this.value,
+    required this.choices,
+    required this.displayLabelFor,
+    required this.semanticLabelFor,
+    required this.targetItemWidth,
+    required this.selectedMinWidth,
+    required this.unselectedMinWidth,
+    required this.selectedHorizontalPadding,
+    required this.unselectedHorizontalPadding,
+    required this.onChanged,
+  });
+
+  final String label;
+  final T value;
+  final List<T> choices;
+  final String Function(T value) displayLabelFor;
+  final String Function(T value) semanticLabelFor;
+  final double targetItemWidth;
+  final double selectedMinWidth;
+  final double unselectedMinWidth;
+  final double selectedHorizontalPadding;
+  final double unselectedHorizontalPadding;
+  final ValueChanged<T> onChanged;
+
+  @override
+  State<_CyclicWheel<T>> createState() => _CyclicWheelState<T>();
+}
+
+class _CyclicWheelState<T> extends State<_CyclicWheel<T>> {
   static const _initialLoop = 500;
   static const _wheelHeight = 64.0;
-  static const _targetItemWidth = 96.0;
   static const _wheelContentPadding = EdgeInsets.fromLTRB(8, 10, 8, 6);
 
   PageController? _controller;
@@ -347,7 +408,7 @@ class _OptionWheelState<T> extends State<_OptionWheel<T>> {
   }
 
   @override
-  void didUpdateWidget(covariant _OptionWheel<T> oldWidget) {
+  void didUpdateWidget(covariant _CyclicWheel<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
 
     if (oldWidget.choices != widget.choices) {
@@ -404,7 +465,7 @@ class _OptionWheelState<T> extends State<_OptionWheel<T>> {
                 final controller = _controllerForViewport(
                   _wheelViewportFraction(
                     viewportWidth: constraints.maxWidth,
-                    targetItemWidth: _targetItemWidth,
+                    targetItemWidth: widget.targetItemWidth,
                   ),
                 );
 
@@ -416,15 +477,19 @@ class _OptionWheelState<T> extends State<_OptionWheel<T>> {
                       itemBuilder: (context, page) {
                         final value = _valueForPage(page);
                         return _WheelItem(
-                          label: theoryTokenDisplayLabel(
-                            widget.labelFor(value),
-                          ),
+                          label: widget.displayLabelFor(value),
                           selected: value == widget.value,
+                          selectedMinWidth: widget.selectedMinWidth,
+                          unselectedMinWidth: widget.unselectedMinWidth,
+                          selectedHorizontalPadding:
+                              widget.selectedHorizontalPadding,
+                          unselectedHorizontalPadding:
+                              widget.unselectedHorizontalPadding,
                           onTap: () => _selectValue(value),
                         );
                       },
                     ),
-                    const Positioned.fill(child: _RootWheelEdgeFades()),
+                    const Positioned.fill(child: _WheelEdgeFades()),
                   ],
                 );
               },
@@ -480,7 +545,7 @@ class _OptionWheelState<T> extends State<_OptionWheel<T>> {
   int _nearestPageForValue(T value) {
     final currentPage = _visiblePage;
     final currentIndex = _indexForPage(currentPage);
-    var delta = (_indexOf(value) - currentIndex) % widget.choices.length;
+    var delta = _wrapIndex(_indexOf(value) - currentIndex);
     if (delta > widget.choices.length / 2) delta -= widget.choices.length;
     return currentPage + delta;
   }
@@ -496,10 +561,15 @@ class _OptionWheelState<T> extends State<_OptionWheel<T>> {
   }
 
   T _previousValue(T value) {
-    return widget.choices[(_indexOf(value) - 1) % widget.choices.length];
+    return widget.choices[_wrapIndex(_indexOf(value) - 1)];
   }
 
-  int _indexForPage(int page) => page % widget.choices.length;
+  int _indexForPage(int page) => _wrapIndex(page);
+
+  int _wrapIndex(int value) {
+    final index = value % widget.choices.length;
+    return index < 0 ? index + widget.choices.length : index;
+  }
 
   int _indexOf(T value) {
     final index = widget.choices.indexOf(value);
@@ -598,7 +668,7 @@ bool _viewportFractionChanged(double? previous, double next) {
   return (previous - next).abs() > 0.001;
 }
 
-class _RootWheel extends StatefulWidget {
+class _RootWheel extends StatelessWidget {
   const _RootWheel({
     required this.value,
     required this.tonality,
@@ -612,227 +682,26 @@ class _RootWheel extends StatefulWidget {
   final ValueChanged<int> onChanged;
 
   @override
-  State<_RootWheel> createState() => _RootWheelState();
-}
-
-class _RootWheelState extends State<_RootWheel> {
-  static const _pitchClassCount = 12;
-  static const _initialLoop = 500;
-  static const _wheelHeight = 64.0;
-  static const _targetItemWidth = 72.0;
-  static const _wheelContentPadding = EdgeInsets.fromLTRB(8, 10, 8, 6);
-
-  PageController? _controller;
-  double? _viewportFraction;
-  late int _currentPage;
-
-  @override
-  void initState() {
-    super.initState();
-    _currentPage = (_initialLoop * _pitchClassCount) + widget.value;
-  }
-
-  @override
-  void didUpdateWidget(covariant _RootWheel oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.value == widget.value) return;
-
-    final controller = _controller;
-    final visiblePage = controller?.hasClients == true
-        ? (controller?.page?.round() ?? _currentPage)
-        : _currentPage;
-    if (_pcForPage(visiblePage) == widget.value) return;
-
-    final targetPage = _nearestPageForPc(widget.value);
-    _currentPage = targetPage;
-    if (controller?.hasClients != true) return;
-
-    unawaited(
-      controller!.animateToPage(
-        targetPage,
-        duration: const Duration(milliseconds: 180),
-        curve: Curves.easeOutCubic,
-      ),
-    );
-  }
-
-  @override
-  void dispose() {
-    _controller?.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final selectedLabel = _labelForPc(widget.value);
-
-    return Semantics(
-      container: true,
+    return _CyclicWheel<int>(
       label: 'Root',
-      value: selectedLabel,
-      increasedValue: _labelForPc(_nextPc(widget.value)),
-      decreasedValue: _labelForPc(_previousPc(widget.value)),
-      onIncrease: () => widget.onChanged(_nextPc(widget.value)),
-      onDecrease: () => widget.onChanged(_previousPc(widget.value)),
-      child: ExcludeSemantics(
-        child: InputDecorator(
-          decoration: const InputDecoration(
-            labelText: 'Root',
-            border: OutlineInputBorder(),
-            contentPadding: _wheelContentPadding,
-          ),
-          child: SizedBox(
-            height: _wheelHeight,
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                final controller = _controllerForViewport(
-                  _wheelViewportFraction(
-                    viewportWidth: constraints.maxWidth,
-                    targetItemWidth: _targetItemWidth,
-                  ),
-                );
-
-                return Stack(
-                  children: [
-                    PageView.builder(
-                      controller: controller,
-                      onPageChanged: _handlePageChanged,
-                      itemBuilder: (context, page) {
-                        final pc = _pcForPage(page);
-                        return _RootWheelItem(
-                          label: _labelForPc(pc),
-                          selected: pc == widget.value,
-                          onTap: () => _selectPc(pc),
-                        );
-                      },
-                    ),
-                    const Positioned.fill(child: _RootWheelEdgeFades()),
-                  ],
-                );
-              },
-            ),
-          ),
-        ),
-      ),
+      value: value,
+      choices: const [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      displayLabelFor: _labelForPc,
+      semanticLabelFor: _labelForPc,
+      targetItemWidth: 72,
+      selectedMinWidth: 46,
+      unselectedMinWidth: 40,
+      selectedHorizontalPadding: 8,
+      unselectedHorizontalPadding: 4,
+      onChanged: onChanged,
     );
   }
-
-  PageController _controllerForViewport(double viewportFraction) {
-    final existing = _controller;
-    if (existing != null &&
-        !_viewportFractionChanged(_viewportFraction, viewportFraction)) {
-      return existing;
-    }
-
-    final page = existing?.hasClients == true
-        ? (existing?.page?.round() ?? _currentPage)
-        : _currentPage;
-    existing?.dispose();
-    _currentPage = page;
-    _viewportFraction = viewportFraction;
-    return _controller = PageController(
-      initialPage: _currentPage,
-      viewportFraction: viewportFraction,
-    );
-  }
-
-  void _handlePageChanged(int page) {
-    _currentPage = page;
-    final pc = _pcForPage(page);
-    if (pc == widget.value) return;
-    widget.onChanged(pc);
-  }
-
-  void _selectPc(int pc) {
-    final controller = _controller;
-    final targetPage = _nearestPageForPc(pc);
-    _currentPage = targetPage;
-    if (controller?.hasClients == true) {
-      unawaited(
-        controller!.animateToPage(
-          targetPage,
-          duration: const Duration(milliseconds: 180),
-          curve: Curves.easeOutCubic,
-        ),
-      );
-    }
-    if (pc != widget.value) widget.onChanged(pc);
-  }
-
-  int _nearestPageForPc(int pc) {
-    final controller = _controller;
-    final currentPage = controller?.hasClients == true
-        ? (controller?.page?.round() ?? _currentPage)
-        : _currentPage;
-    final currentPc = _pcForPage(currentPage);
-    var delta = (pc - currentPc) % _pitchClassCount;
-    if (delta > _pitchClassCount / 2) delta -= _pitchClassCount;
-    return currentPage + delta;
-  }
-
-  int _pcForPage(int page) => page % _pitchClassCount;
-
-  int _nextPc(int pc) => (pc + 1) % _pitchClassCount;
-
-  int _previousPc(int pc) => (pc - 1) % _pitchClassCount;
 
   String _labelForPc(int pc) {
     return noteDisplayLabel(
-      pcToName(pc, tonality: widget.tonality),
-      noteNameSystem: widget.noteNameSystem,
-    );
-  }
-}
-
-class _RootWheelItem extends StatelessWidget {
-  const _RootWheelItem({
-    required this.label,
-    required this.selected,
-    required this.onTap,
-  });
-
-  final String label;
-  final bool selected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final cs = theme.colorScheme;
-    final textStyle =
-        (selected ? theme.textTheme.titleLarge : theme.textTheme.titleMedium)
-            ?.copyWith(
-              color: selected ? cs.onPrimaryContainer : cs.onSurfaceVariant,
-              fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
-            );
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 2),
-      child: Center(
-        child: Material(
-          color: selected ? cs.primaryContainer : cs.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(8),
-          child: InkWell(
-            borderRadius: BorderRadius.circular(8),
-            onTap: onTap,
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                minWidth: selected ? 46 : 40,
-                minHeight: 48,
-              ),
-              child: Center(
-                child: FittedBox(
-                  fit: BoxFit.scaleDown,
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: selected ? 8 : 4),
-                    child: Text(label, maxLines: 1, style: textStyle),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
+      pcToName(pc, tonality: tonality),
+      noteNameSystem: noteNameSystem,
     );
   }
 }
@@ -841,11 +710,19 @@ class _WheelItem extends StatelessWidget {
   const _WheelItem({
     required this.label,
     required this.selected,
+    required this.selectedMinWidth,
+    required this.unselectedMinWidth,
+    required this.selectedHorizontalPadding,
+    required this.unselectedHorizontalPadding,
     required this.onTap,
   });
 
   final String label;
   final bool selected;
+  final double selectedMinWidth;
+  final double unselectedMinWidth;
+  final double selectedHorizontalPadding;
+  final double unselectedHorizontalPadding;
   final VoidCallback onTap;
 
   @override
@@ -870,14 +747,18 @@ class _WheelItem extends StatelessWidget {
             onTap: onTap,
             child: ConstrainedBox(
               constraints: BoxConstraints(
-                minWidth: selected ? 76 : 64,
+                minWidth: selected ? selectedMinWidth : unselectedMinWidth,
                 minHeight: 48,
               ),
               child: Center(
                 child: FittedBox(
                   fit: BoxFit.scaleDown,
                   child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: selected ? 8 : 6),
+                    padding: EdgeInsets.symmetric(
+                      horizontal: selected
+                          ? selectedHorizontalPadding
+                          : unselectedHorizontalPadding,
+                    ),
                     child: Text(label, maxLines: 1, style: textStyle),
                   ),
                 ),
@@ -890,8 +771,8 @@ class _WheelItem extends StatelessWidget {
   }
 }
 
-class _RootWheelEdgeFades extends StatelessWidget {
-  const _RootWheelEdgeFades();
+class _WheelEdgeFades extends StatelessWidget {
+  const _WheelEdgeFades();
 
   static const _fadeWidth = 56.0;
 
@@ -907,7 +788,7 @@ class _RootWheelEdgeFades extends StatelessWidget {
             top: 0,
             bottom: 0,
             width: _fadeWidth,
-            child: _RootWheelFade(
+            child: _WheelFade(
               begin: Alignment.centerLeft,
               end: Alignment.centerRight,
               surface: surface,
@@ -918,7 +799,7 @@ class _RootWheelEdgeFades extends StatelessWidget {
             top: 0,
             bottom: 0,
             width: _fadeWidth,
-            child: _RootWheelFade(
+            child: _WheelFade(
               begin: Alignment.centerRight,
               end: Alignment.centerLeft,
               surface: surface,
@@ -930,8 +811,8 @@ class _RootWheelEdgeFades extends StatelessWidget {
   }
 }
 
-class _RootWheelFade extends StatelessWidget {
-  const _RootWheelFade({
+class _WheelFade extends StatelessWidget {
+  const _WheelFade({
     required this.begin,
     required this.end,
     required this.surface,

--- a/lib/features/explore/widgets/explore_summary.dart
+++ b/lib/features/explore/widgets/explore_summary.dart
@@ -1,5 +1,3 @@
-import 'dart:io' show Platform;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -38,7 +36,7 @@ class ExploreSummary extends ConsumerWidget {
         '${presentation.longLabel}';
 
     Future<void> copyToClipboard() async {
-      final messenger = Platform.isIOS
+      final messenger = Theme.of(context).platform == TargetPlatform.iOS
           ? ScaffoldMessenger.maybeOf(context)
           : null;
 

--- a/lib/features/settings/pages/settings_page.dart
+++ b/lib/features/settings/pages/settings_page.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -456,7 +455,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                     final version = ref.read(appVersionProvider).asData?.value;
                     if (version == null) return;
 
-                    final messenger = Platform.isIOS
+                    final messenger =
+                        Theme.of(context).platform == TargetPlatform.iOS
                         ? ScaffoldMessenger.maybeOf(context)
                         : null;
 

--- a/test/explore_chord_options_test.dart
+++ b/test/explore_chord_options_test.dart
@@ -7,6 +7,7 @@ import 'package:whatchord/features/explore/services/explore_chord_example_builde
 import 'package:whatchord/features/explore/services/explore_chord_derivation.dart';
 import 'package:whatchord/features/explore/services/explore_chord_options.dart';
 import 'package:whatchord/features/explore/services/explore_chord_state_transitions.dart';
+import 'package:whatchord/features/explore/services/explore_extension_rules.dart';
 import 'package:whatchord/features/theory/theory.dart';
 
 void main() {


### PR DESCRIPTION
Big refactoring here after the explore mode code has been growing and changing organically:

- Extracted duplicated portrait/landscape page content into helpers in lib/features/explore/pages/explore_chord_page.dart.
- Renamed ChordMembersSection to ExploreChordMembersSection.
- Split extension rule/normalization logic into lib/features/explore/services/explore_extension_rules.dart, leaving control-group construction in explore_chord_options.dart.
- Collapsed repeated state transition normalization into _withSpec.
- Unified root and option wheels under one reusable _CyclicWheel.
- Clarified displayIdentity vs canonicalExampleIdentity in the example builder and cached canonical example parts.
- Removed the dart:io dependency from ExploreSummary.