### PR TITLE
Give the ranking alternatives a bit more affordance

### DIFF
--- a/lib/features/home/widgets/chord_ranking_details_sheet.dart
+++ b/lib/features/home/widgets/chord_ranking_details_sheet.dart
@@ -150,7 +150,7 @@ class _RankingDetailsBody extends StatelessWidget {
           _SummaryPanel(symbol: chosenSymbol, reason: chosenReason),
           const SizedBox(height: 14),
           const SectionHeader(
-            title: 'Ranking',
+            title: 'Ranking Alternatives',
             icon: Icons.format_list_numbered,
           ),
           for (var i = 0; i < visible.length; i++) ...[


### PR DESCRIPTION
Adding the word "alternatives" to the ranking subsection title a little more explanation for people when they first encounter the modal.