### PR TITLE
Spell split thirds as minor thirds

### DIFF
--- a/lib/features/explore/services/explore_chord_example_builder.dart
+++ b/lib/features/explore/services/explore_chord_example_builder.dart
@@ -241,7 +241,9 @@ abstract final class ExploreChordExampleBuilder {
       return switch (role) {
         ChordToneRole.root => 10,
         ChordToneRole.sus2 => 20,
-        ChordToneRole.minor3 || ChordToneRole.major3 => 30,
+        ChordToneRole.minor3 ||
+        ChordToneRole.splitMinor3 ||
+        ChordToneRole.major3 => 30,
         ChordToneRole.sus4 => 40,
         ChordToneRole.flat5 ||
         ChordToneRole.perfect5 ||

--- a/lib/features/home/widgets/chord_ranking_details_sheet.dart
+++ b/lib/features/home/widgets/chord_ranking_details_sheet.dart
@@ -590,6 +590,7 @@ String _roleLabel(ChordToneRole role) {
     ChordToneRole.add9 => 'the added ninth',
     ChordToneRole.addSharp9 => 'the added sharp ninth',
     ChordToneRole.minor3 => 'the minor third',
+    ChordToneRole.splitMinor3 => 'the split minor third',
     ChordToneRole.major3 => 'the major third',
     ChordToneRole.sus4 => 'the suspended fourth',
     ChordToneRole.eleven => 'the eleventh',

--- a/lib/features/theory/domain/analysis/chord_candidate_ranking.dart
+++ b/lib/features/theory/domain/analysis/chord_candidate_ranking.dart
@@ -966,6 +966,7 @@ class _CandidateFeatures {
       ChordToneRole.thirteenth => ChordExtension.thirteen,
       ChordToneRole.add9 => ChordExtension.add9,
       ChordToneRole.addSharp9 => ChordExtension.addSharp9,
+      ChordToneRole.splitMinor3 => ChordExtension.addSharp9,
       ChordToneRole.add11 => ChordExtension.add11,
       ChordToneRole.add13 => ChordExtension.add13,
       _ => null,

--- a/lib/features/theory/domain/models/chord_tone_role.dart
+++ b/lib/features/theory/domain/models/chord_tone_role.dart
@@ -14,6 +14,7 @@ enum ChordToneRole {
 
   // 3rd-degree family
   minor3,
+  splitMinor3,
   major3,
 
   // 4th-degree family
@@ -55,6 +56,7 @@ extension ChordToneRoleDegree on ChordToneRole {
         return 2;
 
       case ChordToneRole.minor3:
+      case ChordToneRole.splitMinor3:
       case ChordToneRole.major3:
         return 3;
 

--- a/lib/features/theory/domain/services/chord_member_degree_formatter.dart
+++ b/lib/features/theory/domain/services/chord_member_degree_formatter.dart
@@ -114,6 +114,8 @@ extension on ChordToneRole {
 
       case ChordToneRole.minor3:
         return 'b3';
+      case ChordToneRole.splitMinor3:
+        return 'b3';
       case ChordToneRole.major3:
         return '3';
 

--- a/lib/features/theory/domain/services/chord_tone_roles.dart
+++ b/lib/features/theory/domain/services/chord_tone_roles.dart
@@ -185,7 +185,7 @@ abstract final class ChordToneRoles {
           addExt(3, ChordToneRole.sharp9);
           break;
         case ChordExtension.addSharp9:
-          addExt(3, ChordToneRole.addSharp9);
+          addExt(3, ChordToneRole.splitMinor3);
           break;
         case ChordExtension.eleven:
           addExt(5, ChordToneRole.eleven);

--- a/lib/features/theory/presentation/services/chord_tone_role_token_labels.dart
+++ b/lib/features/theory/presentation/services/chord_tone_role_token_labels.dart
@@ -22,6 +22,8 @@ extension ChordToneRoleTokenLabels on ChordToneRole {
 
       case ChordToneRole.minor3:
         return 'b3';
+      case ChordToneRole.splitMinor3:
+        return 'b3';
       case ChordToneRole.major3:
         return '3';
 

--- a/lib/features/theory/presentation/services/harte_chord_formatter.dart
+++ b/lib/features/theory/presentation/services/harte_chord_formatter.dart
@@ -62,7 +62,7 @@ abstract final class HarteChordFormatter {
         ChordToneRole.nine || ChordToneRole.add9 => '9',
         ChordToneRole.flat9 => 'b9',
         ChordToneRole.sharp9 || ChordToneRole.addSharp9 => '#9',
-        ChordToneRole.minor3 => 'b3',
+        ChordToneRole.minor3 || ChordToneRole.splitMinor3 => 'b3',
         ChordToneRole.major3 => '3',
         ChordToneRole.sus4 => '4',
         ChordToneRole.eleven || ChordToneRole.add11 => '11',

--- a/test/chord_analyzer_golden_test.dart
+++ b/test/chord_analyzer_golden_test.dart
@@ -31,7 +31,7 @@ void main() {
       expectedRoot: 'C',
       expectedQuality: ChordQualityToken.major,
       expectedExtensions: {ChordExtension.addSharp9},
-      expectedToneRolesByInterval: {3: ChordToneRole.addSharp9},
+      expectedToneRolesByInterval: {3: ChordToneRole.splitMinor3},
     ),
 
     golden(
@@ -41,7 +41,7 @@ void main() {
       expectedRoot: 'C',
       expectedQuality: ChordQualityToken.major,
       expectedExtensions: {ChordExtension.addSharp9},
-      expectedToneRolesByInterval: {3: ChordToneRole.addSharp9},
+      expectedToneRolesByInterval: {3: ChordToneRole.splitMinor3},
     ),
 
     golden(
@@ -51,7 +51,7 @@ void main() {
       expectedRoot: 'C',
       expectedQuality: ChordQualityToken.major6,
       expectedExtensions: {ChordExtension.addSharp9},
-      expectedToneRolesByInterval: {3: ChordToneRole.addSharp9},
+      expectedToneRolesByInterval: {3: ChordToneRole.splitMinor3},
     ),
 
     golden(

--- a/test/explore_chord_options_test.dart
+++ b/test/explore_chord_options_test.dart
@@ -934,9 +934,9 @@ void main() {
       );
 
       expect(example.presentation.symbol.toString(), 'C(add#9)');
-      expect(example.members, ['C', 'E', 'G', 'D#']);
-      expect(example.memberDegrees, ['1', '3', '5', '#9']);
-      expect(example.normalizedVoicing, [60, 64, 67, 75]);
+      expect(example.members, ['C', 'Eb', 'E', 'G']);
+      expect(example.memberDegrees, ['1', 'b3', '3', '5']);
+      expect(example.normalizedVoicing, [60, 63, 64, 67]);
     });
 
     test('builds minor sharp-eleventh examples', () {


### PR DESCRIPTION
Keep split-third chord symbols using add#9, but give the added tone a dedicated split-minor-third role for member spelling and degree display.

This keeps the harmonic label concise, e.g. C(add#9), while showing the actual structure as C-Eb-E-G and 1-b3-3-5. A plain add#9 role would spell the tone as D#, which is correct for altered-ninth function but misleading for mixed-third sonorities.

This is intentionally narrow so dominant #9 chords continue to spell and behave as altered ninths, while triad-family split thirds can teach the edge-case structure without changing the broader #9 model.