### PR TITLE
Prefer complete major inversion over minor sharp-five

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 - Fixed a couple of "Why This Chord?" ranking explanations so close alternatives
   are described more clearly.
+- Fixed an enharmonic chord-ranking case so A-flat major over C is preferred
+  over C minor sharp-five for the notes C-Eb-Ab.
 - Fixed explore mode member chip transitions so changes are easier to follow
   while scrubbing through options.
 - Fixed explore mode Harte notation copy so sharp root spellings such as C#m are

--- a/docs/site/articles/under-the-hood.html
+++ b/docs/site/articles/under-the-hood.html
@@ -743,6 +743,13 @@ pcs: B♭ C E F♯  |  bass: F♯ (pc 6)  |  key: C major
               inverted 6th-chord spelling whose fifth is absent)
             </li>
             <li>
+              C-E♭-A♭ with C in the bass:
+              <span class="chord">A♭/C</span> vs.
+              <span class="chord">Cm♯5</span> (a complete first-inversion major
+              triad is the ordinary spelling unless additional color makes the
+              altered-minor reading clearer)
+            </li>
+            <li>
               B-D-F-A♭: <span class="chord">Bdim7</span> vs.
               <span class="chord">G♯dim7/B</span> vs.
               <span class="chord">Ddim7/C♭</span> vs.
@@ -801,6 +808,10 @@ pcs: B♭ C E F♯  |  bass: F♯ (pc 6)  |  key: C major
             <li>
               Prefer root-position extended dominant over altered-fifth dominant
               slash (the C9♯11 vs. D11♯5/C case)
+            </li>
+            <li>
+              Prefer a complete first-inversion major triad over a root-position
+              minor sharp-five reading (the A♭/C vs. Cm♯5 case)
             </li>
             <li>
               Prefer root-position diminished 7th (symmetrical chords default to

--- a/lib/features/theory/domain/analysis/chord_candidate_ranking.dart
+++ b/lib/features/theory/domain/analysis/chord_candidate_ranking.dart
@@ -139,6 +139,10 @@ abstract final class ChordCandidateRanking {
       'prefer root-position extended dominant over altered-fifth slash',
       _preferRootExtendedDom7OverAlteredFifthSlash,
     ),
+    _NamedRule(
+      'prefer complete major inversion over minor sharp-five',
+      _preferCompleteMajorInversionOverMinorSharpFive,
+    ),
     _NamedRule('prefer root-position diminished7', _preferDim7InRoot),
     _NamedRule('prefer dominant7 over dim7 slash', _preferDom7Shell),
     _NamedRule('prefer fewer altered/tension colors', _preferFewerAlterations),
@@ -326,6 +330,29 @@ abstract final class ChordCandidateRanking {
     if (!fOther.dom7HasShell) return null;
 
     return aIsPreferred ? -1 : 1;
+  }
+
+  /// Prefers the ordinary first-inversion major triad reading over the
+  /// enharmonically equivalent root-position minor-sharp-five reading.
+  ///
+  /// Example: {C, Eb, Ab} with C in the bass is normally heard and written as
+  /// Ab/C, not Cm#5. The latter is pitch-class valid, but it depends on spelling
+  /// Ab as G# and treats a complete consonant triad as an altered minor color.
+  static int? _preferCompleteMajorInversionOverMinorSharpFive(
+    ChordCandidate a,
+    ChordCandidate b,
+    _CandidateFeatures fa,
+    _CandidateFeatures fb,
+    Tonality _,
+  ) {
+    final aIsMajorInversion = fa.isCompleteMajorTriadFirstInversion;
+    final bIsMajorInversion = fb.isCompleteMajorTriadFirstInversion;
+    if (aIsMajorInversion == bIsMajorInversion) return null;
+
+    final fOther = aIsMajorInversion ? fb : fa;
+    if (!fOther.isRootPositionMinorSharpFive) return null;
+
+    return aIsMajorInversion ? -1 : 1;
   }
 
   static bool _isRootExtendedDom7(
@@ -748,6 +775,8 @@ class _CandidateFeatures {
   final bool isSus;
   final bool isCompleteMinorSharp11;
   final bool isCompleteMajorMinorTriad;
+  final bool isCompleteMajorTriadFirstInversion;
+  final bool isRootPositionMinorSharpFive;
   final bool isIncompleteInvertedSixth;
   final bool isSecondInversion;
   final bool isAlteredMajor7Sus4;
@@ -779,6 +808,8 @@ class _CandidateFeatures {
     required this.isSus,
     required this.isCompleteMinorSharp11,
     required this.isCompleteMajorMinorTriad,
+    required this.isCompleteMajorTriadFirstInversion,
+    required this.isRootPositionMinorSharpFive,
     required this.isIncompleteInvertedSixth,
     required this.isSecondInversion,
     required this.isAlteredMajor7Sus4,
@@ -834,6 +865,12 @@ class _CandidateFeatures {
       isSus: q.isSus,
       isCompleteMinorSharp11: _isCompleteMinorSharp11(id),
       isCompleteMajorMinorTriad: _isCompleteMajorMinorTriadCore(id),
+      isCompleteMajorTriadFirstInversion: _isCompleteMajorTriadFirstInversion(
+        id,
+        rootPos,
+      ),
+      isRootPositionMinorSharpFive:
+          rootPos && q == ChordQualityToken.minorSharp5,
       isIncompleteInvertedSixth: _isIncompleteInvertedSixth(id, rootPos),
       isSecondInversion: _bassRoleRank(id) == 2,
       isAlteredMajor7Sus4: _isAlteredMajor7Sus4(id, rootPos),
@@ -889,6 +926,21 @@ class _CandidateFeatures {
 
     return roles.contains(ChordToneRole.root) &&
         hasThird &&
+        roles.contains(ChordToneRole.perfect5);
+  }
+
+  static bool _isCompleteMajorTriadFirstInversion(
+    ChordIdentity id,
+    bool rootPos,
+  ) {
+    if (rootPos) return false;
+    if (id.quality != ChordQualityToken.major) return false;
+    if (id.extensions.isNotEmpty) return false;
+    if (_bassRoleRank(id) != 1) return false;
+
+    final roles = id.toneRolesByInterval.values;
+    return roles.contains(ChordToneRole.root) &&
+        roles.contains(ChordToneRole.major3) &&
         roles.contains(ChordToneRole.perfect5);
   }
 

--- a/lib/features/theory/domain/services/chord_member_speller.dart
+++ b/lib/features/theory/domain/services/chord_member_speller.dart
@@ -1,7 +1,7 @@
 import '../models/chord_identity.dart';
 import '../models/chord_tone_role.dart';
 import '../models/tonality.dart';
-import 'note_spelling.dart' show pcToName, spellPitchClass;
+import 'note_spelling.dart' show spellChordRoot, spellPitchClass;
 import 'pitch_class.dart';
 
 /// Role-aware spelling for the *currently sounding* chord members.
@@ -18,7 +18,7 @@ abstract final class ChordMemberSpeller {
   }) {
     if (pitchClasses.isEmpty) return const <String>[];
 
-    final rootName = pcToName(identity.rootPc, tonality: tonality);
+    final rootName = spellChordRoot(identity, tonality: tonality);
 
     // Build (interval -> spelled name) for all present tones we can classify.
     final entries = <_Member>[];

--- a/lib/features/theory/domain/services/note_spelling.dart
+++ b/lib/features/theory/domain/services/note_spelling.dart
@@ -1,3 +1,4 @@
+import '../models/chord_identity.dart';
 import '../models/chord_tone_role.dart';
 import '../models/key_signature.dart';
 import '../models/tonality.dart';
@@ -41,6 +42,45 @@ String spellPitchClass(
   }
 
   return targetLetter + _accidentalToAscii(delta);
+}
+
+/// Chooses a root spelling that keeps the whole chord readable.
+///
+/// Tonality still matters, but role-aware member spellings can override a
+/// chromatic tie. For example, pitch class 8 in C major is ambiguous as G# or
+/// Ab; a major triad rooted there spells cleanly as Ab-C-Eb, not G#-B#-D#.
+String spellChordRoot(ChordIdentity identity, {required Tonality tonality}) {
+  final tonalName = pcToName(identity.rootPc, tonality: tonality);
+  if (!identity.hasSlashBass) return tonalName;
+  if (_isDiatonicName(tonalName, tonality: tonality)) return tonalName;
+
+  final candidates = _candidateNamesForPc(identity.rootPc);
+
+  _RootSpellingCandidate? best;
+  for (final name in candidates) {
+    final score = _scoreChordRootName(
+      identity,
+      rootName: name,
+      tonality: tonality,
+      tonalName: tonalName,
+    );
+    final candidate = _RootSpellingCandidate(name: name, score: score);
+    if (best == null ||
+        candidate.score < best.score ||
+        (candidate.score == best.score && candidate.name == tonalName)) {
+      best = candidate;
+    }
+  }
+
+  return best?.name ?? tonalName;
+}
+
+bool _isDiatonicName(String name, {required Tonality tonality}) {
+  final diatonic = _buildDiatonicPcToName(
+    fifths: tonality.keySignature.fifths,
+    tonicLetter: _tonicLetter(tonality.tonic),
+  );
+  return diatonic.values.contains(normalizeNoteNameToAscii(name));
 }
 
 /// Tonality-aware pitch-class spelling (key-signature correct).
@@ -192,6 +232,63 @@ String _accidentalToAscii(int acc) {
   };
 }
 
+List<String> _candidateNamesForPc(int pc) {
+  final targetPc = pc % 12;
+  final out = <String>[];
+
+  for (final letter in _letters) {
+    final naturalPc = _naturalPcByLetter[letter]!;
+    var delta = (targetPc - naturalPc) % 12;
+    if (delta > 6) delta -= 12;
+    if (delta < -2 || delta > 2) continue;
+    out.add(letter + _accidentalToAscii(delta));
+  }
+
+  return out;
+}
+
+int _scoreChordRootName(
+  ChordIdentity identity, {
+  required String rootName,
+  required Tonality tonality,
+  required String tonalName,
+}) {
+  var score = 0;
+
+  if (rootName != tonalName) score += 3;
+  score += _noteNamePenalty(rootName);
+
+  for (final entry in identity.toneRolesByInterval.entries) {
+    final pc = (identity.rootPc + entry.key) % 12;
+    final member = spellPitchClass(
+      pc,
+      tonality: tonality,
+      chordRootName: rootName,
+      role: entry.value,
+    );
+    score += _noteNamePenalty(member);
+  }
+
+  return score;
+}
+
+int _noteNamePenalty(String name) {
+  final ascii = normalizeNoteNameToAscii(name);
+  if (ascii.isEmpty) return 1000;
+
+  final accidental = ascii.substring(1);
+  var score = 0;
+  for (final c in accidental.split('')) {
+    if (c == '#' || c == 'b') score += 10;
+    if (c == 'x') score += 20;
+  }
+  if (accidental.length == 2) score += 30;
+  if (ascii == 'B#' || ascii == 'Cb' || ascii == 'E#' || ascii == 'Fb') {
+    score += 16;
+  }
+  return score;
+}
+
 String _fallbackSharpName(int pc) {
   const sharps = [
     'C',
@@ -212,6 +309,12 @@ String _fallbackSharpName(int pc) {
 
 class _Candidate {
   _Candidate({required this.name, required this.score});
+  final String name;
+  final int score;
+}
+
+class _RootSpellingCandidate {
+  _RootSpellingCandidate({required this.name, required this.score});
   final String name;
   final int score;
 }

--- a/lib/features/theory/presentation/services/chord_symbol_builder.dart
+++ b/lib/features/theory/presentation/services/chord_symbol_builder.dart
@@ -8,7 +8,7 @@ class ChordSymbolBuilder {
     required Tonality tonality,
     required ChordNotationStyle notation,
   }) {
-    final root = pcToName(identity.rootPc, tonality: tonality);
+    final root = spellChordRoot(identity, tonality: tonality);
 
     String? bass;
     if (identity.hasSlashBass) {

--- a/test/chord_analyzer_golden_test.dart
+++ b/test/chord_analyzer_golden_test.dart
@@ -250,13 +250,26 @@ void main() {
       expectedToneRolesByInterval: {8: ChordToneRole.sharp5},
     ),
 
-    // Minor sharp 5 should treat the augmented fifth as a core tone.
+    // The pitch-class set also admits Cm#5, but a complete first-inversion
+    // major triad is the more conventional default for MIDI-style input.
     golden(
-      description: 'minor sharp fifth',
-      expectedSymbol: 'Cm#5',
+      description: 'first-inversion major triad beats minor sharp fifth',
+      expectedSymbol: 'Ab / C',
       pcs: ['C', 'Eb', 'G#'],
+      expectedRoot: 'Ab',
+      expectedBass: 'C',
+      expectedQuality: ChordQualityToken.major,
+    ),
+
+    // With added ninth color, the C-root altered minor reading is more coherent
+    // than treating the D as sharp-eleventh color on Ab/C.
+    golden(
+      description: 'minor sharp fifth with added ninth',
+      expectedSymbol: 'Cm#5add9',
+      pcs: ['C', 'Eb', 'G#', 'D'],
       expectedRoot: 'C',
       expectedQuality: ChordQualityToken.minorSharp5,
+      expectedExtensions: {ChordExtension.add9},
       expectedToneRolesByInterval: {8: ChordToneRole.sharp5},
     ),
 

--- a/test/chord_analyzer_ranking_golden_test.dart
+++ b/test/chord_analyzer_ranking_golden_test.dart
@@ -56,6 +56,17 @@ void main() {
     ),
 
     golden(
+      description: 'complete major inversion beats minor sharp fifth',
+      expectedSymbol: 'Ab / C',
+      expectedAlternateSymbols: ['Cm#5'],
+      pcs: ['C', 'Eb', 'Ab'],
+      bass: 'C',
+      expectedRoot: 'Ab',
+      expectedBass: 'C',
+      expectedQuality: ChordQualityToken.major,
+    ),
+
+    golden(
       description:
           'root-position dominant sus beats complete second-inversion sus',
       expectedSymbol: 'G7sus4',

--- a/test/chord_candidate_ranking_test.dart
+++ b/test/chord_candidate_ranking_test.dart
@@ -191,6 +191,30 @@ void main() {
       'prefer complete triad over incomplete inverted 6th',
     );
   });
+
+  test('complete major inversion beats minor sharp-five in a near-tie', () {
+    final majorInversion = _candidate(
+      quality: ChordQualityToken.major,
+      root: 'Ab',
+      bass: 'C',
+      presentIntervals: const {0, 4, 7},
+      score: 7.42,
+    );
+
+    final minorSharpFive = _candidate(
+      quality: ChordQualityToken.minorSharp5,
+      root: 'C',
+      bass: 'C',
+      presentIntervals: const {0, 3, 8},
+      score: 7.51,
+    );
+
+    _expectTieRule(
+      majorInversion,
+      minorSharpFive,
+      'prefer complete major inversion over minor sharp-five',
+    );
+  });
 }
 
 void _expectRule(

--- a/tool/chord_debug.dart
+++ b/tool/chord_debug.dart
@@ -300,12 +300,7 @@ String _formatChordMembersByRole(
   required AnalysisContext context,
 }) {
   // Determine the chord root name once, then reuse for all member spellings.
-  final rootName = _pcLabel(
-    id.rootPc,
-    context: context,
-    chordRootName: null,
-    role: ChordToneRole.root,
-  );
+  final rootName = spellChordRoot(id, tonality: context.tonality);
 
   final entries = <MapEntry<int, ChordToneRole>>[
     const MapEntry<int, ChordToneRole>(0, ChordToneRole.root),
@@ -385,12 +380,7 @@ Map<String, Object?> _candidateJson({
 }) {
   final c = result.candidate;
   final id = c.identity;
-  final rootName = _pcLabel(
-    id.rootPc,
-    context: context,
-    chordRootName: null,
-    role: ChordToneRole.root,
-  );
+  final rootName = spellChordRoot(id, tonality: context.tonality);
   final symbol = chordSymbolDisplayLabel(
     ChordSymbolBuilder.fromIdentity(
       identity: id,


### PR DESCRIPTION
This also adds a slash-chord enharmonic root spelling check, which can help guard against strict diatonic spellings when it would force awkward member names.