### PR TITLE
Show top 5 candidates in chord ranking modal and add icon affordance

### DIFF
--- a/lib/features/home/widgets/analysis_section.dart
+++ b/lib/features/home/widgets/analysis_section.dart
@@ -123,6 +123,7 @@ class AnalysisSection extends ConsumerWidget {
                                   textAlign: TextAlign.center,
                                   gap: 8,
                                   textScaleMultiplier: config.nearTieTextScale,
+                                  tappableWhenEmpty: identity is ChordDisplay,
                                   onTap: () => unawaited(
                                     showChordRankingDetailsSheet(
                                       context,

--- a/lib/features/home/widgets/chord_ranking_details_sheet.dart
+++ b/lib/features/home/widgets/chord_ranking_details_sheet.dart
@@ -323,30 +323,7 @@ class _FadedVerticalScrollViewState extends State<_FadedVerticalScrollView> {
 List<RankedCandidateDebug> _visibleCandidates(
   List<RankedCandidateDebug> candidates,
 ) {
-  if (candidates.length < 2) return candidates;
-
-  final bestScore = candidates.first.candidate.score;
-  final out = <RankedCandidateDebug>[candidates.first];
-  var includedLowerFit = false;
-
-  for (var i = 1; i < candidates.length; i++) {
-    final candidate = candidates[i];
-    final deltaFromBest = bestScore - candidate.candidate.score;
-    final isClose = deltaFromBest.abs() <= ChordCandidateRanking.nearTieWindow;
-
-    if (isClose) {
-      out.add(candidate);
-      continue;
-    }
-
-    if (!includedLowerFit) {
-      out.add(candidate);
-      includedLowerFit = true;
-    }
-    break;
-  }
-
-  return out;
+  return candidates.take(5).toList(growable: false);
 }
 
 class _SummaryPanel extends StatelessWidget {

--- a/lib/features/home/widgets/details_section.dart
+++ b/lib/features/home/widgets/details_section.dart
@@ -18,6 +18,8 @@ class DetailsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final identity = ref.watch(identityDisplayProvider);
+
     return Padding(
       padding: config.detailsSectionPadding,
       child: Column(
@@ -35,6 +37,7 @@ class DetailsSection extends ConsumerWidget {
                   padding: EdgeInsets.only(bottom: 12),
                   textScaleMultiplier: config.nearTieTextScale,
                   showScrollbarWhenOverflow: true,
+                  tappableWhenEmpty: identity is ChordDisplay,
                   onTap: () => unawaited(
                     showChordRankingDetailsSheet(
                       context,

--- a/lib/features/theory/presentation/widgets/near_tie_chord_candidates_list.dart
+++ b/lib/features/theory/presentation/widgets/near_tie_chord_candidates_list.dart
@@ -22,6 +22,7 @@ class NearTieChordCandidatesList extends ConsumerStatefulWidget {
     this.styleOverride,
     this.textScaleMultiplier = 1.0,
     this.showScrollbarWhenOverflow = false,
+    this.tappableWhenEmpty = false,
     this.onTap,
   });
 
@@ -35,6 +36,10 @@ class NearTieChordCandidatesList extends ConsumerStatefulWidget {
   final TextStyle? styleOverride;
   final double textScaleMultiplier;
   final bool showScrollbarWhenOverflow;
+
+  /// When true, the tap gesture and a minimum-height hit area remain active
+  /// even when there are no near-tie candidates to display.
+  final bool tappableWhenEmpty;
   final VoidCallback? onTap;
 
   @override
@@ -140,10 +145,24 @@ class _NearTieChordCandidatesListState
     }
 
     // Empty state must still occupy an animatable child.
-    // Using a SizedBox with a key ensures AnimatedSwitcher recognizes changes.
-    Widget empty() => const SizedBox(key: ValueKey('ambiguous_empty'));
+    // Using a key ensures AnimatedSwitcher recognizes state changes.
+    Widget empty() {
+      if (!widget.tappableWhenEmpty) {
+        return const SizedBox(key: ValueKey('ambiguous_empty'));
+      }
+      return Align(
+        key: const ValueKey('ambiguous_empty'),
+        alignment: widget.alignment,
+        child: Icon(
+          Icons.format_list_numbered,
+          color: cs.onSurface.withValues(alpha: 0.35),
+          size: 20,
+        ),
+      );
+    }
 
-    final canTap = hasContent && widget.onTap != null;
+    final canTap =
+        (hasContent || widget.tappableWhenEmpty) && widget.onTap != null;
 
     Widget interactive({required Widget child}) {
       if (!canTap) return child;
@@ -157,10 +176,10 @@ class _NearTieChordCandidatesListState
 
     return Semantics(
       container: true,
-      label: 'Alternative chord candidates',
+      label: hasContent ? 'Alternative chord candidates' : null,
       button: canTap,
       onTap: canTap ? widget.onTap : null,
-      onTapHint: canTap ? 'Explain chord alternatives' : null,
+      onTapHint: canTap ? 'Show chord ranking details' : null,
       child: AnimatedSwitcher(
         duration: const Duration(milliseconds: 120),
         reverseDuration: const Duration(milliseconds: 90),


### PR DESCRIPTION
Replace the near-tie-window-plus-one selection in the Why This Chord modal with a fixed top-5 list, and allow opening the modal even when no near-tie alternatives are shown.