### PR TITLE
Fix explore mode note chips to respect the selected root spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed explore mode note chips so they spell members relative to the explicitly
+  selected root, matching the chord symbol (e.g., C# major now shows C# E# G#
+  instead of Db F Ab).
+
 ## [2026.5.28] - 2026-05-28
 
 ### Added

--- a/lib/features/explore/services/explore_chord_example_builder.dart
+++ b/lib/features/explore/services/explore_chord_example_builder.dart
@@ -48,6 +48,8 @@ abstract final class ExploreChordExampleBuilder {
         .map((interval) => (state.rootPc + interval) % 12)
         .toList(growable: false);
 
+    final explicitRootName = pcToName(state.rootPc, tonality: tonality);
+
     return ExploreChordExample(
       presentation: presentation,
       identity: canonicalExampleIdentity,
@@ -55,6 +57,7 @@ abstract final class ExploreChordExampleBuilder {
         identity: canonicalExampleIdentity,
         intervals: parts.intervals,
         tonality: tonality,
+        rootName: explicitRootName,
       ),
       memberDegrees: _formatDegreesInIntervalOrder(
         identity: canonicalExampleIdentity,
@@ -260,6 +263,7 @@ abstract final class ExploreChordExampleBuilder {
     required ChordIdentity identity,
     required List<int> intervals,
     required Tonality tonality,
+    String? rootName,
   }) {
     return [
       for (final interval in intervals)
@@ -267,6 +271,7 @@ abstract final class ExploreChordExampleBuilder {
           identity: identity,
           pitchClasses: {(identity.rootPc + interval) % 12},
           tonality: tonality,
+          rootName: rootName,
         ).single,
     ];
   }

--- a/lib/features/theory/domain/services/chord_member_speller.dart
+++ b/lib/features/theory/domain/services/chord_member_speller.dart
@@ -15,10 +15,12 @@ abstract final class ChordMemberSpeller {
     required ChordIdentity identity,
     required Set<int> pitchClasses, // unique 0..11
     required Tonality tonality,
+    String? rootName,
   }) {
     if (pitchClasses.isEmpty) return const <String>[];
 
-    final rootName = spellChordRoot(identity, tonality: tonality);
+    final effectiveRootName =
+        rootName ?? spellChordRoot(identity, tonality: tonality);
 
     // Build (interval -> spelled name) for all present tones we can classify.
     final entries = <_Member>[];
@@ -30,7 +32,7 @@ abstract final class ChordMemberSpeller {
       final name = spellPitchClass(
         pc,
         tonality: tonality,
-        chordRootName: rootName,
+        chordRootName: effectiveRootName,
         role: role,
       );
 


### PR DESCRIPTION
When the user picks a root like C# in explore mode, the chord symbol already uses that explicit name. The note chips were using a separate scoring algorithm that could choose the enharmonic equivalent (Db F Ab instead of C# E# G#). Thread the same pcToName-derived root through the member speller so chips and symbol always agree.

This was a regression caused by altering chord name ranking based on note name simplicity.