### PR TITLE
Fit three chord alternatives in Android landscape

### DIFF
--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -94,7 +95,14 @@ class _HomePageState extends ConsumerState<HomePage> {
         final config = resolveHomeLayoutConfig(constraints);
         final isLandscape = config.isLandscape;
 
-        final toolbarHeight = kToolbarHeight;
+        // Android keeps the landscape status bar; a shorter app bar buys back a
+        // little of that vertical room.
+        final tightenForStatusBar =
+            isLandscape && defaultTargetPlatform == TargetPlatform.android;
+        // Keep the bar a touch taller than the 48px icons and bias the content
+        // up, so the icons sit near the status bar with a little room below.
+        final toolbarHeight = tightenForStatusBar ? 52.0 : kToolbarHeight;
+        final toolbarBottomInset = tightenForStatusBar ? 4.0 : 0.0;
 
         const barBaseInset = 16.0;
         final maxHorizontalCutout = isLandscape
@@ -120,6 +128,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                           right: !isLandscape,
                           child: _HomeTopBar(
                             toolbarHeight: toolbarHeight,
+                            contentBottomInset: toolbarBottomInset,
                             horizontalInset: horizontalInset,
                             midiStatusIconKey: _midiStatusIconKey,
                             onOpenMidiSettings: _openMidiSettings,
@@ -163,12 +172,14 @@ class _HomePageState extends ConsumerState<HomePage> {
 class _HomeTopBar extends ConsumerWidget {
   const _HomeTopBar({
     required this.toolbarHeight,
+    required this.contentBottomInset,
     required this.horizontalInset,
     required this.midiStatusIconKey,
     required this.onOpenMidiSettings,
   });
 
   final double toolbarHeight;
+  final double contentBottomInset;
   final double horizontalInset;
   final GlobalKey midiStatusIconKey;
   final VoidCallback onOpenMidiSettings;
@@ -193,6 +204,7 @@ class _HomeTopBar extends ConsumerWidget {
           padding: EdgeInsets.only(
             left: horizontalInset,
             right: horizontalInset,
+            bottom: contentBottomInset,
           ),
           child: Row(
             children: [

--- a/lib/features/home/widgets/details_section.dart
+++ b/lib/features/home/widgets/details_section.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -20,8 +21,20 @@ class DetailsSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final identity = ref.watch(identityDisplayProvider);
 
+    // Reclaim the vertical room Android's persistent landscape status bar
+    // steals, so the third alternative isn't clipped.
+    final tightenForStatusBar =
+        config.isLandscape && defaultTargetPlatform == TargetPlatform.android;
+    final sectionPadding = tightenForStatusBar
+        ? config.detailsSectionPadding.copyWith(
+            top: config.analysisPadding.top,
+            bottom: config.analysisPadding.bottom,
+          )
+        : config.detailsSectionPadding;
+    final listBottomPad = tightenForStatusBar ? 8.0 : 12.0;
+
     return Padding(
-      padding: config.detailsSectionPadding,
+      padding: sectionPadding,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -34,7 +47,7 @@ class DetailsSection extends ConsumerWidget {
                   alignment: Alignment.topLeft,
                   textAlign: TextAlign.left,
                   gap: 6,
-                  padding: EdgeInsets.only(bottom: 12),
+                  padding: EdgeInsets.only(bottom: listBottomPad),
                   textScaleMultiplier: config.nearTieTextScale,
                   showScrollbarWhenOverflow: true,
                   tappableWhenEmpty: identity is ChordDisplay,

--- a/lib/features/home/widgets/keyboard_section.dart
+++ b/lib/features/home/widgets/keyboard_section.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -38,6 +39,12 @@ class KeyboardSection extends ConsumerWidget {
         );
 
         var height = whiteKeyWidth * config.whiteKeyAspectRatio;
+
+        // Reclaim a few pixels for the chrome on Android's tighter landscape.
+        if (config.isLandscape &&
+            defaultTargetPlatform == TargetPlatform.android) {
+          height -= 4;
+        }
 
         // Guardrails to prevent extremes.
         height = height.clamp(90.0, 200.0);


### PR DESCRIPTION
Android keeps the system status bar visible in landscape, leaving less vertical room than iOS, which clipped the third alternative chord behind a scrollbar. Reclaim the needed pixels from the surrounding chrome: tighten the details section's padding to match the identity card, shrink the app bar while biasing its content up, and trim a few pixels off the keyboard.