### PR TITLE
Fix stuck Cancel button when reconnecting to a dead Network Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ The format is based on [Keep a Changelog][1], and this project adheres to
   reconnect attempts immediately and stays disconnected until you connect again.
 - Fixed a race where disconnecting or cancelling while a connection was still
   being established could leave the device connected anyway.
+- Fixed the Cancel button getting stuck on "Connecting..." when reconnecting to
+  a Network Session that is no longer reachable. Cancel now always stops the
+  attempt and returns to a disconnected state.
 
 ## [2026.5.28] - 2026-05-28
 

--- a/lib/features/midi/providers/midi_connection_notifier.dart
+++ b/lib/features/midi/providers/midi_connection_notifier.dart
@@ -65,17 +65,19 @@ class MidiConnectionNotifier extends Notifier<MidiConnectionState> {
     // The active reconnect run clears the flag in tryAutoReconnect's `finally`
     // after all in-flight async work has unwound.
 
-    // If already connected, do not reset connection state.
     final connected = ref.read(midiDeviceManagerProvider).connectedDevice;
-    if (connected?.isConnected == true) {
-      // Still stop scanning if it is running (likely already stopped by MidiManager.connect).
+
+    // Backgrounding must not drop a live connection; just pause scanning. A
+    // network session's local endpoint always reads connected even when its
+    // peer is gone, so only trust the snapshot for the background case.
+    if (reason == 'background' && connected?.isConnected == true) {
       try {
         await _midi.stopScanning();
       } catch (_) {}
       return;
     }
 
-    // Not connected: abort any in-flight connect and stop scanning.
+    // User cancel: abort any in-flight connect and stop scanning.
     // `disconnect()` bumps the manager's connect generation, so a connect that
     // is parked mid-flight self-aborts instead of landing after we cancel.
     try {


### PR DESCRIPTION
cancel() decided whether to act based on the device manager's connectedDevice.isConnected snapshot. For a Network Session that snapshot is unreliable: the local CoreMIDI endpoint reports connected even after the remote peer becomes unreachable. So when the app foregrounded after moving out of range and entered a reconnect attempt, tapping Cancel hit the "already connected, just stop scanning" shortcut and returned without normalizing the UI. That left the status frozen on "Connecting..." with a Cancel button that did nothing, and it also flipped _cancelRequested, halting the in-flight reconnect loop before it could publish a terminal state.

Gate that shortcut on reason == 'background' instead of the snapshot. Backgrounding still preserves a live connection, but any user cancel now falls through to the real teardown: disconnect() (which bumps the connect generation so a parked connect self-aborts), stop scanning, then settle on a terminal idle or bluetoothUnavailable state. The Cancel button only ever shows while attempting, so this makes it always take effect.