### PR TITLE
Add WhatChord Symbols regeneration tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 .svn/
 .swiftpm/
 migrate_working_dir/
+tool/whatchord_symbols/LelandText.otf
+tool/whatchord_symbols/specimen.svg
 
 # IntelliJ related
 *.iml

--- a/mise.toml
+++ b/mise.toml
@@ -22,3 +22,17 @@ run = "python tool/chord_oracle_compare.py"
 description = "Run a small chord oracle comparison sample"
 depends = ["oracle:install"]
 run = "python tool/chord_oracle_compare.py --max-cases 20"
+
+[tasks."symbols:install"]
+description = "Install Python dependencies for regenerating WhatChord Symbols fonts"
+run = "uv pip install -r tool/whatchord_symbols/requirements.txt"
+
+[tasks."symbols:build"]
+description = "Regenerate the WhatChord Symbols font assets"
+depends = ["symbols:install"]
+run = "python tool/whatchord_symbols/build_font.py"
+
+[tasks."symbols:specimen"]
+description = "Regenerate the WhatChord Symbols font assets and specimen sheet"
+depends = ["symbols:build"]
+run = "python tool/whatchord_symbols/generate_specimen.py"

--- a/tool/whatchord_symbols/README.md
+++ b/tool/whatchord_symbols/README.md
@@ -1,0 +1,29 @@
+# WhatChord Symbols tooling
+
+This folder contains the scripts used to regenerate the bundled WhatChord
+Symbols fonts from a local copy of `LelandText.otf`.
+
+The upstream source font is not committed. Download `LelandText.otf` from the
+Leland project and place it in this folder:
+
+- <https://github.com/MuseScoreFonts/Leland>
+
+Regenerate the app font assets:
+
+```sh
+mise run symbols:build
+```
+
+Generate a local SVG specimen sheet for inspecting sidebearings and bold weight:
+
+```sh
+mise run symbols:specimen
+```
+
+Generated outputs:
+
+- `../../assets/fonts/WhatChordSymbols-Regular.otf`
+- `../../assets/fonts/WhatChordSymbols-Bold.otf`
+- `specimen.svg`
+
+`LelandText.otf` and `specimen.svg` are intentionally ignored by git.

--- a/tool/whatchord_symbols/build_font.py
+++ b/tool/whatchord_symbols/build_font.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Build the "WhatChord Symbols" font family.
+
+Extracts a handful of source glyphs from LelandText.otf (a SMuFL/CFF font) and
+emits small dedicated fonts that contain only those glyphs, remapped to the
+target codepoints declared in glyph_map.txt.
+
+Upstream Leland ships a single weight, so the Bold instance is *synthesized*:
+each outline is stroked and unioned back onto itself, thickening every stem
+uniformly. The two instances share a family name so the OS bold toggle links
+them.
+
+Run with:  mise run symbols:build
+       or:  python tool/whatchord_symbols/build_font.py
+"""
+
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import pathops
+from fontTools.ttLib import TTFont, newTable
+from fontTools.ttLib.tables._c_m_a_p import cmap_format_4, cmap_format_12
+from fontTools.subset import Subsetter, Options
+from fontTools.pens.boundsPen import BoundsPen
+from fontTools.pens.t2CharStringPen import T2CharStringPen
+from fontTools.pens.transformPen import TransformPen
+
+TOOL_DIR = Path(__file__).resolve().parent
+REPO_ROOT = TOOL_DIR.parents[1]
+SOURCE_FONT = TOOL_DIR / "LelandText.otf"
+MAPPING_FILE = TOOL_DIR / "glyph_map.txt"
+OUTPUT_DIR = REPO_ROOT / "assets/fonts"
+
+FAMILY_NAME = "WhatChord Symbols"
+VERSION = "1.000"
+VENDOR_ID = "    "  # blank (4 spaces); avoids inheriting FontForge's 'PfEd'
+
+# Extra horizontal breathing room added to EACH side of every glyph, in font
+# units (this font is 1000 units/em, so 80 == 8% of the em per side). The source
+# SMuFL glyphs ship with ~0 sidebearing because a music engraver spaces them
+# externally; as standalone text symbols they look cramped. Set to 0 to disable.
+SIDE_PAD = 80
+
+# Bold emboldening: how far (font units) each outline edge is pushed outward.
+# Stems thicken by 2*BOLD_STRENGTH; ~20 gives a solid bold at 1000 units/em.
+# Larger = heavier (counters in the sharp/flat stay open up to ~40 or so).
+BOLD_STRENGTH = 20
+
+# Identity/licensing metadata is intentionally NOT carried inside the font:
+# attribution and the SIL OFL text for the upstream Leland font live in the
+# consuming repo's NOTICE.md, which travels with the .otf and satisfies OFL 1.1
+# (the "stand-alone text files" route in clause 2). Keeping it out of the binary
+# also keeps the font small.
+
+
+@dataclass(frozen=True)
+class Instance:
+    """One weight in the family."""
+    subfamily: str        # name ID 2, e.g. "Regular" / "Bold"
+    ps_name: str          # PostScript name (no spaces, ASCII)
+    weight_class: int     # OS/2 usWeightClass
+    bold: bool            # set the bold selection bits + embolden outlines
+
+    @property
+    def full_name(self) -> str:
+        # Regular is conventionally omitted from the full name.
+        if self.subfamily == "Regular":
+            return FAMILY_NAME
+        return f"{FAMILY_NAME} {self.subfamily}"
+
+    @property
+    def output(self) -> str:
+        # Filename mirrors the PostScript name (Family-Style.otf convention).
+        return f"{self.ps_name}.otf"
+
+    @property
+    def output_path(self) -> Path:
+        return OUTPUT_DIR / self.output
+
+
+INSTANCES = [
+    Instance("Regular", "WhatChordSymbols-Regular", 400, False),
+    Instance("Bold", "WhatChordSymbols-Bold", 700, True),
+]
+
+_ROW_RE = re.compile(
+    r"""^\s*U\+(?P<src>[0-9A-Fa-f]+)\s*->\s*U\+(?P<dst>[0-9A-Fa-f]+)""",
+    re.VERBOSE,
+)
+
+
+def parse_mapping(path: Path) -> list[tuple[int, int]]:
+    """Return a list of (source_codepoint, target_codepoint) tuples."""
+    rows: list[tuple[int, int]] = []
+    for lineno, raw in enumerate(path.read_text().splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _ROW_RE.match(line)
+        if not m:
+            sys.exit(f"{path}:{lineno}: could not parse mapping row: {raw!r}")
+        rows.append((int(m["src"], 16), int(m["dst"], 16)))
+    if not rows:
+        sys.exit(f"{path}: no mapping rows found")
+    return rows
+
+
+def resolve_glyphs(font: TTFont, rows) -> dict[int, str]:
+    """Map each target codepoint to the Leland glyph name at its source."""
+    src_cmap = font.getBestCmap()
+    target_to_glyph: dict[int, str] = {}
+    for src_cp, dst_cp in rows:
+        gname = src_cmap.get(src_cp)
+        if gname is None:
+            sys.exit(
+                f"Source U+{src_cp:04X} not found in {SOURCE_FONT.name}'s cmap. "
+                f"Fix the SOURCE_CP in {MAPPING_FILE}."
+            )
+        if dst_cp in target_to_glyph:
+            sys.exit(f"Target U+{dst_cp:04X} is mapped more than once.")
+        target_to_glyph[dst_cp] = gname
+        print(f"  U+{src_cp:04X} ({gname})  ->  U+{dst_cp:04X}")
+    return target_to_glyph
+
+
+def build_cmap(mapping: dict[int, str]) -> "newTable":
+    """Build a cmap table with a BMP (format 4) and full (format 12) subtable."""
+    cmap = newTable("cmap")
+    cmap.tableVersion = 0
+
+    sub4 = cmap_format_4(4)
+    sub4.platformID, sub4.platEncID, sub4.language = 3, 1, 0
+    sub4.cmap = {cp: gn for cp, gn in mapping.items() if cp <= 0xFFFF}
+
+    subtables = [sub4]
+
+    # Only add a format-12 subtable if we actually have astral codepoints,
+    # but include the full mapping when we do (format 12 supersedes 4).
+    if any(cp > 0xFFFF for cp in mapping):
+        sub12 = cmap_format_12(12)
+        sub12.platformID, sub12.platEncID = 3, 10
+        sub12.reserved, sub12.length, sub12.language, sub12.nGroups = 0, 0, 0, 0
+        sub12.cmap = dict(mapping)
+        subtables.append(sub12)
+
+    cmap.tables = subtables
+    return cmap
+
+
+def set_names(font: TTFont, inst: Instance) -> None:
+    """Replace the name table with WhatChord Symbols metadata."""
+    name = font["name"]
+    name.names = []  # wipe inherited Leland names
+    values = {
+        1: FAMILY_NAME,                          # Family
+        2: inst.subfamily,                       # Subfamily
+        3: f"{inst.ps_name};{VERSION}",          # Unique ID
+        4: inst.full_name,                       # Full name
+        5: f"Version {VERSION}",                 # Version string
+        6: inst.ps_name,                         # PostScript name
+    }
+    for nid, val in values.items():
+        # Windows (3,1,0x409) and Mac (1,0,0) records for broad compatibility.
+        name.setName(val, nid, 3, 1, 0x409)
+        name.setName(val, nid, 1, 0, 0)
+
+
+def rename_cff(font: TTFont, inst: Instance) -> None:
+    """Rewrite the CFF-internal identity, which the name table does NOT cover.
+
+    Also drops the inherited Notice (Leland trademark) and Copyright (OFL text);
+    that attribution is carried in the consuming repo's NOTICE.md instead.
+    """
+    cff = font["CFF "].cff
+    top = cff[cff.fontNames[0]]
+    cff.fontNames = [inst.ps_name]
+    top.FullName = inst.full_name
+    top.FamilyName = FAMILY_NAME
+    top.Weight = inst.subfamily
+    top.version = VERSION
+    for key in ("Notice", "Copyright"):
+        top.rawDict.pop(key, None)
+        if hasattr(top, key):
+            delattr(top, key)
+
+
+def _set_charstring(font: TTFont, gname: str, path, advance: int) -> None:
+    """Replace one glyph's CFF charstring from a pen-drawable `path`."""
+    cff = font["CFF "].cff
+    top = cff[cff.fontNames[0]]
+    pen = T2CharStringPen(advance, font.getGlyphSet())
+    path.draw(pen)
+    new_cs = pen.getCharString(top.Private, top.GlobalSubrs)
+    cs = top.CharStrings[gname]
+    cs.program = new_cs.program
+    cs.bytecode = None  # force recompile from the new program
+
+
+def embolden_glyphs(font: TTFont, strength: int) -> None:
+    """Synthesize bold by stroking each outline and unioning it onto the fill.
+
+    Pushes every edge outward by `strength` units (stems gain 2*strength), using
+    a miter join so the geometric corners of the accidentals stay crisp.
+    """
+    if strength == 0:
+        return
+    glyph_set = font.getGlyphSet()
+    hmtx = font["hmtx"]
+    for gname in font.getGlyphOrder():
+        fill = pathops.Path()
+        glyph_set[gname].draw(fill.getPen(glyphSet=glyph_set))
+        stroked = pathops.Path()
+        glyph_set[gname].draw(stroked.getPen(glyphSet=glyph_set))
+        stroked.stroke(
+            2 * strength,
+            pathops.LineCap.BUTT_CAP,
+            pathops.LineJoin.MITER_JOIN,
+            4.0,
+        )
+        builder = pathops.OpBuilder(fix_winding=True, keep_starting_points=False)
+        builder.add(fill, pathops.PathOp.UNION)
+        builder.add(stroked, pathops.PathOp.UNION)
+        result = builder.resolve()
+        # Advance is normalized afterwards by set_sidebearings; keep current.
+        _set_charstring(font, gname, result, hmtx[gname][0])
+
+
+def set_sidebearings(font: TTFont, pad: int) -> None:
+    """Give every glyph exactly `pad` units of space on each side.
+
+    Absolute (not additive): the outline is shifted so its left edge sits at
+    `pad`, and the advance is set to ink-width + 2*pad. Works the same whether or
+    not the glyph was just emboldened.
+    """
+    glyph_set = font.getGlyphSet()
+    hmtx = font["hmtx"]
+    for gname in font.getGlyphOrder():
+        bp = BoundsPen(glyph_set)
+        glyph_set[gname].draw(bp)
+        if bp.bounds is None:  # empty glyph (no contours): just set advance
+            hmtx[gname] = (2 * pad, pad)
+            continue
+        x0, _, x1, _ = bp.bounds
+        shift = pad - x0
+        new_adv = round((x1 + shift) + pad)
+        path = pathops.Path()
+        glyph_set[gname].draw(TransformPen(path.getPen(glyphSet=glyph_set),
+                                           (1, 0, 0, 1, shift, 0)))
+        _set_charstring(font, gname, path, new_adv)
+        hmtx[gname] = (new_adv, round(pad))
+
+
+def recompute_bounds(font: TTFont) -> None:
+    """Refresh head and CFF FontBBox to enclose all (possibly shifted) glyphs."""
+    glyph_set = font.getGlyphSet()
+    box = None
+    for gname in font.getGlyphOrder():
+        bp = BoundsPen(glyph_set)
+        glyph_set[gname].draw(bp)
+        if bp.bounds is None:
+            continue
+        x0, y0, x1, y1 = bp.bounds
+        if box is None:
+            box = [x0, y0, x1, y1]
+        else:
+            box = [min(box[0], x0), min(box[1], y0),
+                   max(box[2], x1), max(box[3], y1)]
+    if box is None:
+        return
+    ibox = [round(v) for v in box]
+    head = font["head"]
+    head.xMin, head.yMin, head.xMax, head.yMax = ibox
+    font["CFF "].cff[font["CFF "].cff.fontNames[0]].FontBBox = ibox
+
+
+def fix_metadata(font: TTFont, inst: Instance) -> None:
+    """Correct head/OS-2 fields inherited from Leland and set weight bits."""
+    head = font["head"]
+    head.fontRevision = float(VERSION)  # match name-table "Version 1.000"
+    head.modified = int(time.time()) - 2082844800  # now, in Mac font epoch
+    head.macStyle = (head.macStyle & ~0x01) | (0x01 if inst.bold else 0)
+
+    os2 = font["OS/2"]
+    os2.achVendID = VENDOR_ID
+    os2.usWeightClass = inst.weight_class
+    # fsSelection: clear ITALIC/BOLD/REGULAR, then set the right one.
+    fs = os2.fsSelection & ~(0x01 | 0x20 | 0x40)
+    os2.fsSelection = fs | (0x20 if inst.bold else 0x40)
+    # Recompute Unicode coverage bits (Leland's claimed the PUA, now untrue).
+    os2.recalcUnicodeRanges(font, pruneOnly=False)
+
+    # GSUB/GPOS survived subsetting as empty shells (0 features, 0 lookups).
+    for tag in ("GSUB", "GPOS"):
+        if tag in font:
+            del font[tag]
+
+
+def build_instance(rows, inst: Instance) -> None:
+    """Build and save one weight."""
+    font = TTFont(SOURCE_FONT)
+    target_to_glyph = resolve_glyphs(font, rows)
+
+    # Subset down to just the glyphs we want (handles CFF, hmtx, layout tables).
+    options = Options()
+    options.name_IDs = ["*"]
+    options.name_legacy = True
+    options.name_languages = ["*"]
+    options.notdef_outline = True
+    options.recalc_bounds = True
+    options.drop_tables = ["DSIG"]
+    subsetter = Subsetter(options=options)
+    subsetter.populate(unicodes=[src for src, _ in rows])
+    subsetter.subset(font)
+
+    # Rebuild the cmap at the target codepoints.
+    font["cmap"] = build_cmap(target_to_glyph)
+
+    # Identity, scrub Leland from the CFF interior, and weight metadata.
+    set_names(font, inst)
+    rename_cff(font, inst)
+    fix_metadata(font, inst)
+
+    # Geometry: embolden (bold only), normalize sidebearings, refresh bounds.
+    if inst.bold:
+        embolden_glyphs(font, BOLD_STRENGTH)
+    set_sidebearings(font, SIDE_PAD)
+    recompute_bounds(font)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    font.save(inst.output_path)
+    print(f"Wrote {inst.output_path} ({inst.subfamily}, "
+          f"{len(target_to_glyph)} glyph(s)).\n")
+
+
+def main() -> None:
+    rows = parse_mapping(Path(MAPPING_FILE))
+    for inst in INSTANCES:
+        build_instance(rows, inst)
+
+
+if __name__ == "__main__":
+    main()

--- a/tool/whatchord_symbols/generate_specimen.py
+++ b/tool/whatchord_symbols/generate_specimen.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Render an SVG specimen sheet for the WhatChord Symbols family.
+
+For every glyph it draws Regular and Bold side by side, each sitting in its
+advance-width box with the baseline, the advance edges, and the ink edges
+(sidebearings) marked. Dependency-free: uses fontTools' SVGPathPen.
+
+Run with:  mise run symbols:specimen
+"""
+
+from html import escape
+from pathlib import Path
+
+from fontTools.ttLib import TTFont
+from fontTools.pens.svgPathPen import SVGPathPen
+from fontTools.pens.boundsPen import BoundsPen
+
+TOOL_DIR = Path(__file__).resolve().parent
+REPO_ROOT = TOOL_DIR.parents[1]
+
+FONTS = [
+    ("Regular", REPO_ROOT / "assets/fonts/WhatChordSymbols-Regular.otf"),
+    ("Bold", REPO_ROOT / "assets/fonts/WhatChordSymbols-Bold.otf"),
+]
+OUTPUT = TOOL_DIR / "specimen.svg"
+
+SCALE = 0.15            # px per font unit (1000-unit em -> 150px)
+ASC, DESC = 900, -300   # framing extents (font units), not real metrics
+CELL_W = 200            # px width of one weight's cell
+LABEL_W = 230           # px width of the left label column
+ROW_GAP = 26            # px between rows
+PAD = 30                # px outer margin
+
+CELL_H = round((ASC - DESC) * SCALE)
+ROW_H = CELL_H + ROW_GAP
+
+
+def load():
+    """Return [(weight, TTFont, cmap)] and the shared codepoint->glyph map."""
+    loaded = []
+    for weight, path in FONTS:
+        f = TTFont(path)
+        loaded.append((weight, f, f.getBestCmap()))
+    return loaded
+
+
+def cell_svg(font: TTFont, gname: str, ox: float, oy: float) -> str:
+    """SVG for one glyph in one weight, top-left of the cell at (ox, oy)."""
+    adv = font["hmtx"][gname][0]
+    gs = font.getGlyphSet()
+    bp = BoundsPen(gs)
+    gs[gname].draw(bp)
+    xmin, xmax = (bp.bounds[0], bp.bounds[2]) if bp.bounds else (0, 0)
+
+    # Center the advance box within the cell horizontally.
+    box_px = adv * SCALE
+    gx = ox + (CELL_W - box_px) / 2
+    baseline = oy + ASC * SCALE  # font y=0 lands here
+    g = f'translate({gx:.2f},{baseline:.2f}) scale({SCALE},{-SCALE})'
+
+    pen = SVGPathPen(gs)
+    gs[gname].draw(pen)
+    d = pen.getCommands()
+
+    def vline(x, cls):
+        return (f'<line x1="{x}" y1="{DESC}" x2="{x}" y2="{ASC}" '
+                f'class="{cls}"/>')
+
+    parts = [f'<g transform="{g}">']
+    # advance box edges + baseline
+    parts.append(vline(0, "adv"))
+    parts.append(vline(adv, "adv"))
+    parts.append(f'<line x1="0" y1="0" x2="{adv}" y2="0" class="base"/>')
+    # ink edges (sidebearings)
+    parts.append(vline(xmin, "ink"))
+    parts.append(vline(xmax, "ink"))
+    parts.append(f'<path d="{d}" class="glyph"/>')
+    parts.append("</g>")
+
+    # sidebearing readout under the cell
+    lsb, rsb = round(xmin), round(adv - xmax)
+    parts.append(
+        f'<text x="{ox + CELL_W/2:.1f}" y="{oy + CELL_H + 16:.1f}" '
+        f'class="sb">adv {adv}  ·  sb {lsb}/{rsb}</text>'
+    )
+    return "".join(parts)
+
+
+def main() -> None:
+    fonts = load()
+    # Glyph order/cmap from the first font; assume both share it.
+    base_font, base_cmap = fonts[0][1], fonts[0][2]
+    glyph_to_cp = {g: cp for cp, g in base_cmap.items()}
+    glyphs = [g for g in base_font.getGlyphOrder() if g in glyph_to_cp]
+
+    width = LABEL_W + len(fonts) * CELL_W + 2 * PAD
+    height = PAD + 40 + len(glyphs) * ROW_H + PAD
+
+    out = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" '
+        f'height="{height}" viewBox="0 0 {width} {height}" '
+        f'font-family="ui-sans-serif,system-ui,sans-serif">',
+        "<style>"
+        ".glyph{fill:#111}"
+        ".adv{stroke:#c8c8c8;stroke-width:1;vector-effect:non-scaling-stroke}"
+        ".base{stroke:#9bb;stroke-width:1;vector-effect:non-scaling-stroke}"
+        ".ink{stroke:#e08;stroke-width:1;stroke-dasharray:3 3;"
+        "vector-effect:non-scaling-stroke}"
+        ".sb{fill:#888;font-size:11px;text-anchor:middle}"
+        ".lbl{fill:#222;font-size:13px}"
+        ".sub{fill:#888;font-size:11px}"
+        ".hdr{fill:#111;font-size:14px;font-weight:600;text-anchor:middle}"
+        "</style>",
+        f'<rect width="{width}" height="{height}" fill="#fff"/>',
+    ]
+
+    # Column headers
+    for i, (weight, _) in enumerate(FONTS):
+        cx = PAD + LABEL_W + i * CELL_W + CELL_W / 2
+        out.append(f'<text x="{cx:.1f}" y="{PAD + 22}" class="hdr">{weight}</text>')
+
+    for r, gname in enumerate(glyphs):
+        oy = PAD + 40 + r * ROW_H
+        cp = glyph_to_cp[gname]
+        # label
+        out.append(
+            f'<text x="{PAD}" y="{oy + CELL_H/2 - 4:.1f}" class="lbl">'
+            f'U+{cp:04X}</text>'
+        )
+        out.append(
+            f'<text x="{PAD}" y="{oy + CELL_H/2 + 14:.1f}" class="sub">'
+            f'{escape(gname)}</text>'
+        )
+        for i, (_, font, _) in enumerate(fonts):
+            ox = PAD + LABEL_W + i * CELL_W
+            out.append(cell_svg(font, gname, ox, oy))
+
+    out.append("</svg>")
+    OUTPUT.write_text("\n".join(out))
+    print(f"Wrote {OUTPUT} ({len(glyphs)} glyphs x {len(fonts)} weights).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tool/whatchord_symbols/glyph_map.txt
+++ b/tool/whatchord_symbols/glyph_map.txt
@@ -1,0 +1,22 @@
+# Glyph mapping for the "WhatChord Symbols" font.
+#
+# Each row:  SOURCE_CP  ->  TARGET_CP   # notes
+#   SOURCE_CP  = codepoint of the glyph as it lives in LelandText.otf
+#   TARGET_CP  = codepoint you want it to live at in the output font
+#
+# The trailing "(name)" is the glyph's name inside Leland, shown only to help
+# you confirm you picked the right source. Edit the SOURCE_CP column to swap
+# which Leland glyph gets used; edit TARGET_CP to change where it lands.
+#
+# Blank lines and lines starting with '#' are ignored.
+
+U+ED64  ->  U+1D12B   # double flat        (csymAccidentalDoubleFlat)
+U+ED60  ->  U+266D    # flat               (csymAccidentalFlat)
+U+ED61  ->  U+266E    # natural            (csymAccidentalNatural)
+U+ED62  ->  U+266F    # sharp              (csymAccidentalSharp)
+U+ED63  ->  U+1D12A   # double sharp       (csymAccidentalDoubleSharp)
+U+E870  ->  U+00B0    # diminished         (csymDiminished)
+U+E871  ->  U+00F8    # half-diminished    (csymHalfDiminished)
+U+E873  ->  U+0394    # major seventh      (csymMajorSeventh)
+U+E874  ->  U+2212    # minor              (csymMinor)
+U+E872  ->  U+002B    # augmented          (csymAugmented)

--- a/tool/whatchord_symbols/requirements.txt
+++ b/tool/whatchord_symbols/requirements.txt
@@ -1,0 +1,2 @@
+fonttools>=4.50
+skia-pathops>=0.8   # outline boolean ops + stroking, for the synthesized Bold


### PR DESCRIPTION
Add scripts and metadata for rebuilding the bundled WhatChord Symbols fonts from a local LelandText.otf source, including glyph mapping, specimen generation, and Python dependency notes.

Wire the workflow into mise with symbols:install, symbols:build, and symbols:specimen tasks, and ignore the local upstream font plus generated specimen output.