### PR TITLE
Use standard scale-degree diminished notation with scoped font

### DIFF
--- a/lib/features/theory/domain/services/scale_degree_classifier.dart
+++ b/lib/features/theory/domain/services/scale_degree_classifier.dart
@@ -444,10 +444,16 @@ abstract final class ScaleDegreeClassifier {
       ChordQualityToken.minor7 => '${base}7',
       ChordQualityToken.minor7Sharp5 => '${base}7#5',
       ChordQualityToken.minorMajor7 => '$base(maj7)',
-      ChordQualityToken.halfDiminished7 => '${base}7',
+      ChordQualityToken.halfDiminished7 => '${_baseWithoutQuality(base)}ø7',
       ChordQualityToken.diminished7 => '${base}7',
       _ => base,
     };
+  }
+
+  static String _baseWithoutQuality(String romanNumeral) {
+    return romanNumeral.endsWith('°')
+        ? romanNumeral.substring(0, romanNumeral.length - 1)
+        : romanNumeral;
   }
 
   static String _spokenScaleDegreeFor(

--- a/lib/features/theory/presentation/widgets/scale_degrees.dart
+++ b/lib/features/theory/presentation/widgets/scale_degrees.dart
@@ -27,6 +27,7 @@ class ScaleDegrees extends StatefulWidget {
 
 class _ScaleDegreesState extends State<ScaleDegrees> {
   static const double _fadeWidth = 24.0;
+  static const double _indicatorGap = 10.0;
   static const double _defaultIndicatorHeight = 56.0;
   static const Duration _tooltipShowDuration = Duration(seconds: 3);
 
@@ -81,6 +82,7 @@ class _ScaleDegreesState extends State<ScaleDegrees> {
         widget.fadeColor ?? Theme.of(context).colorScheme.surfaceContainerLow;
     final maxHeight = widget.maxHeight ?? _defaultIndicatorHeight;
     final tooltipMessage = _tooltipMessageForCurrent(widget.current);
+    final tooltipRichMessage = _tooltipRichMessageForCurrent(widget.current);
 
     return Semantics(
       container: true,
@@ -88,7 +90,8 @@ class _ScaleDegreesState extends State<ScaleDegrees> {
       value: _semanticsValueForCurrent(widget.current),
       child: ExcludeSemantics(
         child: Tooltip(
-          message: tooltipMessage,
+          message: tooltipRichMessage == null ? tooltipMessage : null,
+          richMessage: tooltipRichMessage,
           showDuration: _tooltipShowDuration,
           child: LayoutBuilder(
             builder: (context, constraints) {
@@ -109,7 +112,7 @@ class _ScaleDegreesState extends State<ScaleDegrees> {
                         textScaleMultiplier: widget.textScaleMultiplier,
                       ),
                       if (i < widget.values.length - 1)
-                        const SizedBox(width: 10),
+                        const SizedBox(width: _indicatorGap),
                     ],
                   ],
                 ),
@@ -194,6 +197,22 @@ class _ScaleDegreesState extends State<ScaleDegrees> {
     return 'Scale degree\n${analysis.romanNumeral} ($function$source)';
   }
 
+  InlineSpan? _tooltipRichMessageForCurrent(ScaleDegreeAnalysis? analysis) {
+    if (analysis == null) return null;
+
+    final function = _titleCase(analysis.functionName);
+    final source = analysis.source == ScaleDegreeSource.major
+        ? ''
+        : ' · ${analysis.source.displayLabel}';
+    return TextSpan(
+      children: [
+        const TextSpan(text: 'Scale degree\n'),
+        ..._scaleDegreeGlyphSpans(analysis.romanNumeral),
+        TextSpan(text: ' ($function$source)'),
+      ],
+    );
+  }
+
   String _labelForDegree(ScaleDegree degree) {
     final current = widget.current;
     if (current?.degree == degree) return current!.romanNumeral;
@@ -247,7 +266,7 @@ class _ScaleDegreeIndicator extends StatelessWidget {
     final maxScale = (availableHeight / baseLineHeight).clamp(1.0, 3.0);
     final clampedScale = scale.clamp(1.0, maxScale);
 
-    final textStyle = baseStyle?.copyWith(
+    final textStyle = (baseStyle ?? const TextStyle()).copyWith(
       fontSize: baseFontSize,
       color: isCurrent
           ? cs.primary
@@ -260,10 +279,10 @@ class _ScaleDegreeIndicator extends StatelessWidget {
       child: Stack(
         alignment: Alignment.center,
         children: [
-          Text(
-            label,
+          _ScaleDegreeLabel(
+            text: label,
             style: textStyle,
-            textScaler: TextScaler.linear(clampedScale),
+            textScale: clampedScale,
           ),
           Align(
             alignment: Alignment.bottomCenter,
@@ -284,4 +303,44 @@ class _ScaleDegreeIndicator extends StatelessWidget {
       ),
     );
   }
+}
+
+class _ScaleDegreeLabel extends StatelessWidget {
+  final String text;
+  final TextStyle style;
+  final double textScale;
+
+  const _ScaleDegreeLabel({
+    required this.text,
+    required this.style,
+    required this.textScale,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text.rich(
+      TextSpan(children: [..._scaleDegreeGlyphSpans(text)]),
+      style: style,
+      textScaler: TextScaler.linear(textScale),
+    );
+  }
+}
+
+List<TextSpan> _scaleDegreeGlyphSpans(String text) {
+  return [
+    for (final char in text.characters)
+      TextSpan(
+        text: char,
+        style: _usesTextFont(char) ? _scaleDegreeTextFontStyle : null,
+      ),
+  ];
+}
+
+const _scaleDegreeTextFontStyle = TextStyle(
+  fontFamily: 'Inter',
+  fontFamilyFallback: [],
+);
+
+bool _usesTextFont(String char) {
+  return char == '°' || char == 'ø';
 }

--- a/test/scale_degree_golden_test.dart
+++ b/test/scale_degree_golden_test.dart
@@ -97,6 +97,7 @@ void main() {
       description: 'leading-tone half-diminished seventh',
       pcs: ['B', 'D', 'F', 'A'],
       expected: ScaleDegree.seven,
+      expectedRomanNumeral: 'viiø7',
       expectedQuality: ChordQualityToken.halfDiminished7,
     ),
 


### PR DESCRIPTION
Overriding the glyphs with our WhatChord Symbols is too heavy for the scale degree display.