### PR TITLE
Show harmonic minor context in scale degree strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 - Use bundled Inter and WhatChord Symbols fonts for more consistent typography
   across iOS and Android.
+- Show harmonic-minor scale-degree context across the full degree strip when a
+  chord is interpreted through harmonic minor, so labels such as V7 sit in a
+  coherent minor-key context.
 - Use ChoCo corpus-derived common-name frequency as a narrow late tie-breaker
   for otherwise equivalent chord names, so voicings such as C D F A over A now
   prefer Dm7/A over F6/A.

--- a/lib/features/theory/domain/models/scale_degree.dart
+++ b/lib/features/theory/domain/models/scale_degree.dart
@@ -36,6 +36,22 @@ enum ScaleDegree {
     };
   }
 
+  String romanNumeralForSource(ScaleDegreeSource source) {
+    return switch (source) {
+      ScaleDegreeSource.major => romanNumeralForMode(TonalityMode.major),
+      ScaleDegreeSource.naturalMinor => romanNumeralForMode(TonalityMode.minor),
+      ScaleDegreeSource.harmonicMinor => switch (this) {
+        ScaleDegree.one => 'i',
+        ScaleDegree.two => 'ii°',
+        ScaleDegree.three => '♭III+',
+        ScaleDegree.four => 'iv',
+        ScaleDegree.five => 'V',
+        ScaleDegree.six => '♭VI',
+        ScaleDegree.seven => 'vii°',
+      },
+    };
+  }
+
   String spokenScaleDegreeForMode(TonalityMode mode) {
     if (mode == TonalityMode.major) {
       return switch (this) {

--- a/lib/features/theory/domain/services/scale_degree_classifier.dart
+++ b/lib/features/theory/domain/services/scale_degree_classifier.dart
@@ -417,21 +417,7 @@ abstract final class ScaleDegreeClassifier {
     ScaleDegreeSource source,
     ChordQualityToken quality,
   ) {
-    final base = switch (source) {
-      ScaleDegreeSource.major => degree.romanNumeralForMode(TonalityMode.major),
-      ScaleDegreeSource.naturalMinor => degree.romanNumeralForMode(
-        TonalityMode.minor,
-      ),
-      ScaleDegreeSource.harmonicMinor => switch (degree) {
-        ScaleDegree.one => 'i',
-        ScaleDegree.two => 'ii°',
-        ScaleDegree.three => '♭III+',
-        ScaleDegree.four => 'iv',
-        ScaleDegree.five => 'V',
-        ScaleDegree.six => '♭VI',
-        ScaleDegree.seven => 'vii°',
-      },
-    };
+    final base = degree.romanNumeralForSource(source);
 
     return switch (quality) {
       ChordQualityToken.dominant7 => '${base}7',

--- a/lib/features/theory/presentation/widgets/scale_degrees.dart
+++ b/lib/features/theory/presentation/widgets/scale_degrees.dart
@@ -216,7 +216,16 @@ class _ScaleDegreesState extends State<ScaleDegrees> {
   String _labelForDegree(ScaleDegree degree) {
     final current = widget.current;
     if (current?.degree == degree) return current!.romanNumeral;
-    return degree.romanNumeralForMode(widget.mode);
+    return degree.romanNumeralForSource(_displaySource);
+  }
+
+  ScaleDegreeSource get _displaySource {
+    final currentSource = widget.current?.source;
+    if (currentSource == ScaleDegreeSource.harmonicMinor) {
+      return ScaleDegreeSource.harmonicMinor;
+    }
+    if (widget.mode == TonalityMode.major) return ScaleDegreeSource.major;
+    return ScaleDegreeSource.naturalMinor;
   }
 
   String _titleCase(String value) {

--- a/test/scale_degree_golden_test.dart
+++ b/test/scale_degree_golden_test.dart
@@ -61,6 +61,20 @@ ScaleDegreeCase deg({
 }
 
 void main() {
+  group('ScaleDegree source labels', () {
+    test('uses conventional harmonic-minor degree labels', () {
+      expect(
+        ScaleDegree.values
+            .map(
+              (degree) =>
+                  degree.romanNumeralForSource(ScaleDegreeSource.harmonicMinor),
+            )
+            .toList(),
+        ['i', 'ii°', '♭III+', 'iv', 'V', '♭VI', 'vii°'],
+      );
+    });
+  });
+
   final cases = <ScaleDegreeCase>[
     // -------------------------
     // C major: triads + 7ths


### PR DESCRIPTION
When the current scale-degree analysis comes from harmonic minor, render the inactive degree labels from the same source so the strip stays visually coherent.

Move source-aware Roman numeral baselines onto ScaleDegree so the classifier and presentation layer share the same harmonic-minor labels.