### PR TITLE
Keep note chip footprints steady across border weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 - Fixed the Settings color palette picker throwing an exception when opened, so
   the picker once again shows the selected palette highlight.
+- Fixed note chips shifting their neighbors by a hair when a note's outline
+  thickened (such as when a note becomes sustained); the chips now hold a steady
+  position.
 
 ### Removed
 

--- a/lib/core/widgets/note_chip.dart
+++ b/lib/core/widgets/note_chip.dart
@@ -88,6 +88,13 @@ class NoteChip extends StatelessWidget {
       NoteChipState.plain => SelectionColors.restChipBorder(cs),
     };
 
+    // A BoxDecoration border adds its width to the chip's layout size, so a
+    // heavier border (e.g. when sustained) would otherwise grow the box and
+    // nudge neighboring chips. Trim the inner padding by the extra width past
+    // the thinnest border so every state keeps a plain chip's footprint.
+    const baseBorderWidth = 1.0;
+    final borderInset = border.width - baseBorderWidth;
+
     return Semantics(
       container: true,
       label: semanticLabel,
@@ -123,8 +130,8 @@ class NoteChip extends StatelessWidget {
                 border: Border.fromBorderSide(border),
               ),
               padding: EdgeInsets.symmetric(
-                horizontal: horizontalPadding,
-                vertical: (6 * verticalScale) + extraVertical,
+                horizontal: horizontalPadding - borderInset,
+                vertical: (6 * verticalScale) + extraVertical - borderInset,
               ),
               child: SizedBox(
                 width: chipTextWidth,


### PR DESCRIPTION
A BoxDecoration border adds its width to layout, so a chip's heavier outline (e.g. when sustained) grew the box and nudged its neighbors. Reserve the thinnest border and trim the inner padding by the extra width so every state keeps a plain chip's footprint and tight spacing.