### PR TITLE
Collapse altered stacked extensions into 13/11 headline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ### Fixed
 
+- Collapsed stacked extensions into a thirteenth or eleventh headline even when
+  the ninth or eleventh is altered, so voicings such as B13(#9,#11) no longer
+  display as B7(#9,#11,add13).
 - Improved relative-major and relative-minor ambiguity handling so root-position
   minor seventh chords such as Am7 are preferred over equivalent major-sixth
   slash readings such as C6/A.

--- a/lib/features/theory/domain/analysis/chord_analyzer.dart
+++ b/lib/features/theory/domain/analysis/chord_analyzer.dart
@@ -718,17 +718,27 @@ abstract final class ChordAnalyzer {
     if ((extrasMask & (1 << 6)) != 0) out.add(ChordExtension.sharp11);
     if ((extrasMask & (1 << 8)) != 0) out.add(ChordExtension.flat13);
 
-    // Natural extensions/add tones.
+    // Natural extensions/add tones. A natural 11 or 13 reads as a stacked upper
+    // extension (eligible to headline as 11/13) when the chord has a seventh and
+    // some ninth beneath it in the stack, even if that ninth is altered: B7 with
+    // #9, #11, and a natural 13 is B13(#9,#11), not B7(#9,#11,add13). Without any
+    // ninth the tone is unanchored and reads as an added tone (add11/add13).
+    const ninthBits = (1 << 1) | (1 << 2) | (1 << 3); // b9, 9, #9
     final has9 = (extrasMask & (1 << 2)) != 0;
+    final hasAnyNinth = (extrasMask & ninthBits) != 0;
     final has11 = (extrasMask & (1 << 5)) != 0;
     final has13 = (extrasMask & (1 << 9)) != 0;
 
     if (has9) out.add(has7 ? ChordExtension.nine : ChordExtension.add9);
     if (has11) {
-      out.add(has7 && has9 ? ChordExtension.eleven : ChordExtension.add11);
+      out.add(
+        has7 && hasAnyNinth ? ChordExtension.eleven : ChordExtension.add11,
+      );
     }
     if (has13) {
-      out.add(has7 && has9 ? ChordExtension.thirteen : ChordExtension.add13);
+      out.add(
+        has7 && hasAnyNinth ? ChordExtension.thirteen : ChordExtension.add13,
+      );
     }
 
     return out;

--- a/test/chord_analyzer_golden_test.dart
+++ b/test/chord_analyzer_golden_test.dart
@@ -295,6 +295,22 @@ void main() {
       },
     ),
 
+    // A natural thirteenth over a full stack still headlines as 13 even when the
+    // intervening ninth/eleventh are altered: C7(#9,#11,add13) collapses to
+    // C13(#9,#11).
+    golden(
+      description: 'thirteenth headline with altered ninth and eleventh',
+      expectedSymbol: 'C13(#9,#11)',
+      pcs: ['C', 'E', 'G', 'Bb', 'D#', 'F#', 'A'],
+      expectedRoot: 'C',
+      expectedQuality: ChordQualityToken.dominant7,
+      expectedExtensions: {
+        ChordExtension.sharp9,
+        ChordExtension.sharp11,
+        ChordExtension.thirteen,
+      },
+    ),
+
     // Dominant 7 suspended 4 with 9 should promote to the combined headline.
     golden(
       description: 'dominant ninth suspended fourth',


### PR DESCRIPTION
A natural 11th or 13th now reads as a stacked extension eligible for headline promotion whenever a seventh and some ninth sit beneath it, even if that ninth is altered. Voicings like B7(#9,#11,add13) now display as B13(#9,#11). The stacking gate previously required a natural ninth, so altered-ninth stacks fell through to add-tones.

See:
- https://www.reddit.com/r/musictheory/comments/1q3cakn/what_chord_is_this_seems_to_be_some_sort_of/