### PR TITLE
Add manual chord lookup mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ### Added
 
+- Added a manual chord lookup mode for identifying chords without a MIDI device.
+  Tap the search icon on the input line to slide in a note pad, then tap notes
+  by name to build a chord. Notes are spelled to the current key, the first note
+  tapped is the bass, and repeated taps stack up the octaves. Tapped notes play
+  through the audio monitor when it is enabled.
 - Added Phrygian dominant, Lydian dominant, altered, harmonic major, double
   harmonic major, and augmented inverse scales to Explore Scales.
 

--- a/lib/features/audio/providers/app_audio_monitor_lifecycle_provider.dart
+++ b/lib/features/audio/providers/app_audio_monitor_lifecycle_provider.dart
@@ -4,8 +4,10 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:whatchord/features/input/input.dart';
+import 'package:whatchord/features/lookup/lookup.dart';
 
 import 'audio_monitor_notifier.dart';
+import 'audio_monitor_settings_notifier.dart';
 
 final appAudioMonitorLifecycleProvider = Provider<void>((ref) {
   ref.listen<AsyncValue<InputNoteEvent>>(inputNoteEventsProvider, (
@@ -15,6 +17,18 @@ final appAudioMonitorLifecycleProvider = Provider<void>((ref) {
     final event = next.asData?.value;
     if (event == null) return;
     ref.read(audioMonitorNotifier.notifier).onInputNoteEvent(event);
+  });
+
+  // Lookup notes are a held selection (for analysis), not a live event stream,
+  // so strike each newly tapped note as a transient preview instead of letting
+  // it ring indefinitely. Strike the actual stacked octave so repeats are
+  // audibly higher.
+  ref.listen<List<int>>(lookupVoicingProvider, (previous, next) {
+    final prev = previous ?? const <int>[];
+    if (next.length <= prev.length) return;
+    if (!ref.read(audioMonitorEnabledProvider)) return;
+
+    ref.read(audioMonitorNotifier.notifier).playPreviewNotes([next.last]);
   });
 
   final controller = _AudioMonitorLifecycleController(ref);

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:whatchord/features/demo/demo.dart';
 import 'package:whatchord/features/input/input.dart';
+import 'package:whatchord/features/lookup/lookup.dart';
 import 'package:whatchord/features/midi/midi.dart';
 import 'package:whatchord/features/onboarding/onboarding.dart';
 import 'package:whatchord/features/scales/scales.dart';
@@ -301,7 +302,7 @@ class _HomeLandscape extends ConsumerWidget {
                   Navigator.of(context).push(ScaleExplorerPage.route()),
             ),
             const Divider(height: 1),
-            KeyboardSection(config: config),
+            _BottomInputSection(config: config),
           ],
         ),
       ],
@@ -345,10 +346,54 @@ class _HomePortrait extends ConsumerWidget {
                   Navigator.of(context).push(ScaleExplorerPage.route()),
             ),
             const Divider(height: 1),
-            KeyboardSection(config: config),
+            _BottomInputSection(config: config),
           ],
         ),
       ],
+    );
+  }
+}
+
+/// Bottom input section. The keyboard stays mounted underneath; the lookup pad
+/// slides down from above to cover it (and back up to reveal it). Keeping the
+/// keyboard mounted means it never re-centers on the toggle.
+class _BottomInputSection extends ConsumerWidget {
+  const _BottomInputSection({required this.config});
+  final HomeLayoutConfig config;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final lookupActive = ref.watch(lookupActiveProvider);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final height = KeyboardSection.heightForWidth(
+          constraints.maxWidth,
+          config,
+        );
+
+        return SizedBox(
+          height: height,
+          child: ClipRect(
+            child: Stack(
+              children: [
+                KeyboardSection(config: config),
+                Positioned.fill(
+                  child: IgnorePointer(
+                    ignoring: !lookupActive,
+                    child: AnimatedSlide(
+                      offset: lookupActive ? Offset.zero : const Offset(0, -1),
+                      duration: const Duration(milliseconds: 260),
+                      curve: Curves.easeOutCubic,
+                      child: const LookupPad(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/home/widgets/keyboard_section.dart
+++ b/lib/features/home/widgets/keyboard_section.dart
@@ -11,24 +11,30 @@ class KeyboardSection extends ConsumerWidget {
   const KeyboardSection({super.key, required this.config});
   final HomeLayoutConfig config;
 
+  /// Resolved keyboard height for a given viewport width. Shared so the lookup
+  /// pad can occupy the exact same footprint when it swaps in.
+  static double heightForWidth(double width, HomeLayoutConfig config) {
+    final whiteKeyWidth = PianoGeometry.whiteKeyWidthForViewport(
+      viewportWidth: width,
+      visibleWhiteKeyCount: config.whiteKeyCount,
+    );
+
+    var height = whiteKeyWidth * config.whiteKeyAspectRatio;
+    if (config.tightenForStatusBar) height -= 4;
+
+    // Guardrails to prevent extremes.
+    return height.clamp(90.0, 200.0);
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final soundingNoteNumbers = ref.watch(soundingNoteNumbersProvider);
+    // Live notes only: the pad covers the keyboard in lookup mode, so it must
+    // not react to (and re-center on) the lookup voicing.
+    final soundingNoteNumbers = ref.watch(liveSoundingNoteNumbersProvider);
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final width = constraints.maxWidth;
-        final whiteKeyWidth = PianoGeometry.whiteKeyWidthForViewport(
-          viewportWidth: width,
-          visibleWhiteKeyCount: config.whiteKeyCount,
-        );
-
-        var height = whiteKeyWidth * config.whiteKeyAspectRatio;
-
-        if (config.tightenForStatusBar) height -= 4;
-
-        // Guardrails to prevent extremes.
-        height = height.clamp(90.0, 200.0);
+        final height = heightForWidth(constraints.maxWidth, config);
 
         return ScrollablePianoKeyboard(
           visibleWhiteKeyCount: config.whiteKeyCount,

--- a/lib/features/input/providers/input_idle_notifier.dart
+++ b/lib/features/input/providers/input_idle_notifier.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:whatchord/features/demo/demo.dart';
+import 'package:whatchord/features/lookup/lookup.dart';
 
 import 'sounding_note_numbers_providers.dart';
 
@@ -100,6 +101,20 @@ class InputIdleNotifier extends Notifier<InputIdleState> {
         markIdleNow();
       }
     });
+
+    // Reset idle immediately when lookup mode toggles, and whenever the lookup
+    // selection empties (clear or the last undo), so the input line and toggle
+    // reappear without waiting out the cooldown.
+    ref.listen<({bool active, int noteCount})>(
+      lookupModeProvider.select(
+        (s) => (active: s.active, noteCount: s.pitchClasses.length),
+      ),
+      (prev, next) {
+        final activeChanged = prev?.active != next.active;
+        final clearedWhileActive = next.active && next.noteCount == 0;
+        if (activeChanged || clearedWhileActive) markIdleNow();
+      },
+    );
 
     // Keep idle visuals deterministic whenever a new demo step is loaded,
     // including empty intro/outro steps that should show the idle glyph

--- a/lib/features/input/providers/sounding_note_numbers_providers.dart
+++ b/lib/features/input/providers/sounding_note_numbers_providers.dart
@@ -3,13 +3,15 @@ import 'dart:collection';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:whatchord/features/demo/demo.dart';
+import 'package:whatchord/features/lookup/lookup.dart';
 
 import '../adapters/demo_input_adapter.dart';
 import '../adapters/midi_input_adapter.dart';
 
-/// The unified source of truth for "what note numbers are currently down,"
-/// regardless of input source.
-final soundingNoteNumbersProvider = Provider<Set<int>>((ref) {
+/// Live input notes only (demo or MIDI), excluding manual lookup. The keyboard
+/// watches this so it stays put when the lookup pad slides over it, rather than
+/// re-centering on the lookup voicing.
+final liveSoundingNoteNumbersProvider = Provider<Set<int>>((ref) {
   final demoEnabled = ref.watch(demoModeProvider);
 
   final notes = demoEnabled
@@ -17,6 +19,17 @@ final soundingNoteNumbersProvider = Provider<Set<int>>((ref) {
       : ref.watch(midiNoteNumbersSource);
 
   return UnmodifiableSetView(notes);
+});
+
+/// The unified source of truth for "what note numbers are currently down,"
+/// regardless of input source. Lookup, demo, and live MIDI are mutually
+/// exclusive; lookup and demo override live MIDI when active.
+final soundingNoteNumbersProvider = Provider<Set<int>>((ref) {
+  if (ref.watch(lookupActiveProvider)) {
+    return UnmodifiableSetView(ref.watch(lookupNoteNumbersProvider));
+  }
+
+  return ref.watch(liveSoundingNoteNumbersProvider);
 });
 
 /// Sorted sounding note numbers (e.g. bassMidi = first),

--- a/lib/features/input/widgets/input_display/input_display.dart
+++ b/lib/features/input/widgets/input_display/input_display.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:whatchord/core/core.dart';
 import 'package:whatchord/features/demo/demo.dart';
+import 'package:whatchord/features/lookup/lookup.dart';
 import 'package:whatchord/features/midi/midi.dart';
 
 import '../../models/sounding_note.dart';
@@ -226,18 +227,24 @@ class _InputDisplayState extends ConsumerState<InputDisplay>
     final demoVariant = ref.watch(demoModeVariantProvider);
     final interactiveDemoEnabled =
         demoEnabled && demoVariant == DemoModeVariant.interactive;
+    final lookupActive = ref.watch(lookupActiveProvider);
     final showPrompt =
         _notes.isEmpty &&
-        ref.watch(inputIdleEligibleProvider) &&
-        !interactiveDemoEnabled;
+        (lookupActive ||
+            (ref.watch(inputIdleEligibleProvider) && !interactiveDemoEnabled));
     final isMidiConnected = ref.watch(
       midiConnectionStatusProvider.select((s) => s.isConnected),
     );
-    final showInlineMidiGuidance = !isMidiConnected;
-    final promptText = showInlineMidiGuidance
+    // Inline MIDI guidance only applies to live mode, not manual lookup.
+    final showInlineMidiGuidance = !lookupActive && !isMidiConnected;
+    final promptText = lookupActive
+        ? 'Tap some notes…'
+        : showInlineMidiGuidance
         ? 'Connect a MIDI device to begin…'
         : 'Play some notes…';
-    final promptSemantics = showInlineMidiGuidance
+    final promptSemantics = lookupActive
+        ? 'Tap some notes'
+        : showInlineMidiGuidance
         ? 'Connect a MIDI device to begin'
         : 'Play some notes';
     final VoidCallback? onPromptTap = showInlineMidiGuidance
@@ -258,49 +265,142 @@ class _InputDisplayState extends ConsumerState<InputDisplay>
         constraints: BoxConstraints(minHeight: minHeight),
         child: SizedBox(
           height: minHeight,
-          child: showPrompt
-              ? Row(
-                  children: [
-                    SizedBox(
-                      width: pedalSlotWidth,
-                      child: _buildAnimatedPedal(),
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Builder(
-                        builder: (context) {
+          child: Row(
+            children: [
+              Expanded(
+                child: showPrompt
+                    ? Row(
+                        children: [
+                          SizedBox(
+                            width: pedalSlotWidth,
+                            child: _buildAnimatedPedal(),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Builder(
+                              builder: (context) {
+                                WidgetsBinding.instance.addPostFrameCallback((
+                                  _,
+                                ) {
+                                  if (mounted) _updateScrollFade();
+                                });
+
+                                return Stack(
+                                  children: [
+                                    SingleChildScrollView(
+                                      controller: _scrollController,
+                                      scrollDirection: Axis.horizontal,
+                                      physics: const BouncingScrollPhysics(),
+                                      child: Align(
+                                        alignment: Alignment.centerLeft,
+                                        child: Semantics(
+                                          button: showInlineMidiGuidance,
+                                          onTapHint: showInlineMidiGuidance
+                                              ? 'Open MIDI settings'
+                                              : null,
+                                          child: GestureDetector(
+                                            behavior: HitTestBehavior.opaque,
+                                            onTap: onPromptTap,
+                                            child: Text(
+                                              promptText,
+                                              semanticsLabel: promptSemantics,
+                                              style: theme.textTheme.bodyLarge
+                                                  ?.copyWith(
+                                                    color: cs.onSurfaceVariant,
+                                                    letterSpacing: -0.1,
+                                                  ),
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                    if (_showLeadingFade)
+                                      Positioned(
+                                        left: 0,
+                                        top: 0,
+                                        bottom: 0,
+                                        width: _fadeWidth,
+                                        child: IgnorePointer(
+                                          child: DecoratedBox(
+                                            decoration: BoxDecoration(
+                                              gradient: LinearGradient(
+                                                begin: Alignment.centerLeft,
+                                                end: Alignment.centerRight,
+                                                colors: [
+                                                  cs.surface,
+                                                  cs.surface.withValues(
+                                                    alpha: 0,
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    if (_showTrailingFade)
+                                      Positioned(
+                                        right: 0,
+                                        top: 0,
+                                        bottom: 0,
+                                        width: _fadeWidth,
+                                        child: IgnorePointer(
+                                          child: DecoratedBox(
+                                            decoration: BoxDecoration(
+                                              gradient: LinearGradient(
+                                                begin: Alignment.centerRight,
+                                                end: Alignment.centerLeft,
+                                                colors: [
+                                                  cs.surface,
+                                                  cs.surface.withValues(
+                                                    alpha: 0,
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                  ],
+                                );
+                              },
+                            ),
+                          ),
+                        ],
+                      )
+                    : LayoutBuilder(
+                        builder: (context, constraints) {
                           WidgetsBinding.instance.addPostFrameCallback((_) {
                             if (mounted) _updateScrollFade();
                           });
 
                           return Stack(
                             children: [
-                              SingleChildScrollView(
+                              CustomScrollView(
                                 controller: _scrollController,
                                 scrollDirection: Axis.horizontal,
                                 physics: const BouncingScrollPhysics(),
-                                child: Align(
-                                  alignment: Alignment.centerLeft,
-                                  child: Semantics(
-                                    button: showInlineMidiGuidance,
-                                    onTapHint: showInlineMidiGuidance
-                                        ? 'Open MIDI settings'
-                                        : null,
-                                    child: GestureDetector(
-                                      behavior: HitTestBehavior.opaque,
-                                      onTap: onPromptTap,
-                                      child: Text(
-                                        promptText,
-                                        semanticsLabel: promptSemantics,
-                                        style: theme.textTheme.bodyLarge
-                                            ?.copyWith(
-                                              color: cs.onSurfaceVariant,
-                                              letterSpacing: -0.1,
-                                            ),
+                                slivers: [
+                                  SliverToBoxAdapter(
+                                    child: Padding(
+                                      padding: const EdgeInsets.only(right: 8),
+                                      child: SizedBox(
+                                        width: pedalSlotWidth,
+                                        child: _buildAnimatedPedal(),
                                       ),
                                     ),
                                   ),
-                                ),
+                                  SliverAnimatedList(
+                                    key: _notesKey,
+                                    initialItemCount: _notes.length,
+                                    itemBuilder: (context, index, animation) {
+                                      final note = _notes[index];
+                                      return _buildPaddedNoteChip(
+                                        note,
+                                        animation,
+                                      );
+                                    },
+                                  ),
+                                ],
                               ),
                               if (_showLeadingFade)
                                 Positioned(
@@ -348,88 +448,35 @@ class _InputDisplayState extends ConsumerState<InputDisplay>
                           );
                         },
                       ),
-                    ),
-                  ],
-                )
-              : LayoutBuilder(
-                  builder: (context, constraints) {
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      if (mounted) _updateScrollFade();
-                    });
-
-                    return Stack(
-                      children: [
-                        CustomScrollView(
-                          controller: _scrollController,
-                          scrollDirection: Axis.horizontal,
-                          physics: const BouncingScrollPhysics(),
-                          slivers: [
-                            SliverToBoxAdapter(
-                              child: Padding(
-                                padding: const EdgeInsets.only(right: 8),
-                                child: SizedBox(
-                                  width: pedalSlotWidth,
-                                  child: _buildAnimatedPedal(),
-                                ),
-                              ),
-                            ),
-                            SliverAnimatedList(
-                              key: _notesKey,
-                              initialItemCount: _notes.length,
-                              itemBuilder: (context, index, animation) {
-                                final note = _notes[index];
-                                return _buildPaddedNoteChip(note, animation);
-                              },
-                            ),
-                          ],
-                        ),
-                        if (_showLeadingFade)
-                          Positioned(
-                            left: 0,
-                            top: 0,
-                            bottom: 0,
-                            width: _fadeWidth,
-                            child: IgnorePointer(
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(
-                                  gradient: LinearGradient(
-                                    begin: Alignment.centerLeft,
-                                    end: Alignment.centerRight,
-                                    colors: [
-                                      cs.surface,
-                                      cs.surface.withValues(alpha: 0),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        if (_showTrailingFade)
-                          Positioned(
-                            right: 0,
-                            top: 0,
-                            bottom: 0,
-                            width: _fadeWidth,
-                            child: IgnorePointer(
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(
-                                  gradient: LinearGradient(
-                                    begin: Alignment.centerRight,
-                                    end: Alignment.centerLeft,
-                                    colors: [
-                                      cs.surface,
-                                      cs.surface.withValues(alpha: 0),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                      ],
-                    );
-                  },
-                ),
+              ),
+              _buildModeToggle(context, lookupActive: lookupActive),
+            ],
+          ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildModeToggle(BuildContext context, {required bool lookupActive}) {
+    final cs = Theme.of(context).colorScheme;
+    // No outline, so nudge it toward the screen edge to reclaim a little width.
+    return Transform.translate(
+      offset: const Offset(8, 4),
+      child: IconButton(
+        icon: Icon(lookupActive ? Icons.piano : Icons.search),
+        tooltip: lookupActive ? 'Back to keyboard' : 'Look up a chord',
+        style: IconButton.styleFrom(
+          foregroundColor: cs.primary,
+          shape: const CircleBorder(),
+        ),
+        onPressed: () {
+          final notifier = ref.read(lookupModeProvider.notifier);
+          if (lookupActive) {
+            notifier.exit();
+          } else {
+            notifier.enter();
+          }
+        },
       ),
     );
   }

--- a/lib/features/lookup/lookup.dart
+++ b/lib/features/lookup/lookup.dart
@@ -1,0 +1,3 @@
+export 'lookup_voicing.dart';
+export 'providers/lookup_mode_notifier.dart';
+export 'widgets/lookup_pad.dart';

--- a/lib/features/lookup/lookup_voicing.dart
+++ b/lib/features/lookup/lookup_voicing.dart
@@ -1,0 +1,42 @@
+/// Pure helpers for turning entered pitch classes into a MIDI voicing.
+///
+/// The selection is an ordered list (first entry is the bass). We build an
+/// ascending stack: each note after the bass is placed at the lowest octave
+/// strictly above the previous note. This preserves the order notes were
+/// tapped (MIDI order tracks press order) and lets repeats climb to the next
+/// octave instead of collapsing. Chord identity is unaffected since analysis
+/// works on pitch classes.
+class LookupVoicing {
+  const LookupVoicing._();
+
+  /// Bass octave (C3..B3). The first note lands here.
+  static const int bassOctaveBase = 48;
+
+  /// Highest note we will climb to (C8), to keep voicings on the keyboard.
+  static const int _maxMidi = 108;
+
+  /// Builds the ascending MIDI voicing for [orderedPitchClasses].
+  static List<int> midiFromPitchClasses(List<int> orderedPitchClasses) {
+    final result = <int>[];
+    for (final raw in orderedPitchClasses) {
+      final pc = raw % 12;
+      if (result.isEmpty) {
+        result.add(bassOctaveBase + pc);
+        continue;
+      }
+
+      final prev = result.last;
+      var midi = prev - (prev % 12) + pc;
+      while (midi <= prev) {
+        midi += 12;
+      }
+      // Stop climbing past the top of the keyboard; further repeats reuse the
+      // highest octave for this pitch class.
+      while (midi > _maxMidi) {
+        midi -= 12;
+      }
+      result.add(midi);
+    }
+    return result;
+  }
+}

--- a/lib/features/lookup/providers/lookup_mode_notifier.dart
+++ b/lib/features/lookup/providers/lookup_mode_notifier.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:whatchord/features/demo/demo.dart';
+import 'package:whatchord/features/midi/midi_input_source.dart';
+
+import '../lookup_voicing.dart';
+
+/// Manual chord-lookup mode: the user taps note names to identify a chord
+/// without a MIDI device. Lookup, demo, and live MIDI are mutually exclusive
+/// input sources; entering lookup turns demo off, and demo or live MIDI input
+/// turns lookup off.
+@immutable
+class LookupState {
+  const LookupState({required this.active, required this.pitchClasses});
+
+  static const empty = LookupState(active: false, pitchClasses: <int>[]);
+
+  final bool active;
+
+  /// Entered pitch classes in selection order; the first entry is the bass.
+  final List<int> pitchClasses;
+
+  LookupState copyWith({bool? active, List<int>? pitchClasses}) => LookupState(
+    active: active ?? this.active,
+    pitchClasses: pitchClasses ?? this.pitchClasses,
+  );
+}
+
+final lookupModeProvider = NotifierProvider<LookupModeNotifier, LookupState>(
+  LookupModeNotifier.new,
+);
+
+/// Convenience boolean for widgets that only care whether lookup is active.
+final lookupActiveProvider = Provider<bool>(
+  (ref) => ref.watch(lookupModeProvider.select((s) => s.active)),
+);
+
+/// Ordered MIDI voicing for the current selection (ascending; first = bass).
+final lookupVoicingProvider = Provider<List<int>>((ref) {
+  final state = ref.watch(lookupModeProvider);
+  if (!state.active) return const <int>[];
+  return LookupVoicing.midiFromPitchClasses(state.pitchClasses);
+});
+
+/// Synthesized MIDI note numbers for the current lookup selection.
+final lookupNoteNumbersProvider = Provider<Set<int>>((ref) {
+  return ref.watch(lookupVoicingProvider).toSet();
+});
+
+class LookupModeNotifier extends Notifier<LookupState> {
+  @override
+  LookupState build() {
+    // Modes are mutually exclusive: demo turning on exits lookup.
+    ref.listen<bool>(demoModeProvider, (prev, next) {
+      if (next && state.active) exit();
+    });
+
+    // Live MIDI input always wins: any sounding note exits lookup.
+    ref.listen<int>(midiSoundingNoteNumbersProvider.select((s) => s.length), (
+      prev,
+      next,
+    ) {
+      if (next > 0 && state.active) exit();
+    });
+
+    return LookupState.empty;
+  }
+
+  void enter() {
+    if (state.active) return;
+    ref.read(demoModeProvider.notifier).setEnabled(false);
+    state = const LookupState(active: true, pitchClasses: <int>[]);
+  }
+
+  void exit() {
+    if (!state.active) return;
+    state = LookupState.empty;
+  }
+
+  /// Appends a note to the selection. Repeats are allowed (each tap adds and
+  /// re-strikes); use [removeLast] or [clear] to remove. The first note added
+  /// is the bass.
+  void addNote(int pitchClass) {
+    if (!state.active) return;
+    state = state.copyWith(
+      pitchClasses: [...state.pitchClasses, pitchClass % 12],
+    );
+  }
+
+  void clear() {
+    if (!state.active || state.pitchClasses.isEmpty) return;
+    state = state.copyWith(pitchClasses: const <int>[]);
+  }
+
+  void removeLast() {
+    if (!state.active || state.pitchClasses.isEmpty) return;
+    final next = state.pitchClasses.sublist(0, state.pitchClasses.length - 1);
+    state = state.copyWith(pitchClasses: next);
+  }
+}

--- a/lib/features/lookup/widgets/lookup_pad.dart
+++ b/lib/features/lookup/widgets/lookup_pad.dart
@@ -1,0 +1,342 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:whatchord/core/core.dart';
+import 'package:whatchord/features/theory/theory.dart';
+
+import '../providers/lookup_mode_notifier.dart';
+
+/// Manual chord-lookup pad. Replaces the keyboard while lookup mode is active.
+///
+/// Two rows of buttons: the seven naturals in one row and the five accidentals
+/// in the other, offset by half a button so each accidental sits between its
+/// neighboring naturals. Sharps sit above the naturals; in flat keys the
+/// accidentals drop below. Tapping adds a note (repeats allowed); the first
+/// note added is the bass. Note names follow the current key.
+class LookupPad extends ConsumerWidget {
+  const LookupPad({super.key});
+
+  // (x position in button-widths, pitch class).
+  static const List<(double, int)> _naturals = [
+    (0, 0),
+    (1, 2),
+    (2, 4),
+    (3, 5),
+    (4, 7),
+    (5, 9),
+    (6, 11),
+  ];
+  static const List<(double, int)> _accidentals = [
+    (0.5, 1),
+    (1.5, 3),
+    (3.5, 6),
+    (4.5, 8),
+    (5.5, 10),
+  ];
+
+  static const double minTapTarget = 48;
+
+  // Each button carries a 2px inset on every side, so adjacent buttons (rows
+  // and columns alike) sit a consistent 4px apart. The cell is the button plus
+  // its inset; rows grow with available height between the 48px tap-target
+  // floor and a cap so they do not balloon to fill the whole section.
+  static const double _minCellHeight = minTapTarget + 4;
+  // Cap high enough that rows fill the (limited) available height on phones
+  // rather than centering with a gap; the keyboard's 200px ceiling and the
+  // bottom safe-area inset are the real limiters.
+  static const double _maxCellHeight = 120;
+  static const double _actionWidth = minTapTarget + 4;
+
+  // Soft top shadow so the pad reads as a raised panel and adds a little
+  // thickness to the separator as it slides down over the keyboard.
+  static const double _topShadowHeight = 10;
+  static const double _topShadowOpacity = 0.12;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cs = Theme.of(context).colorScheme;
+    final pcs = ref.watch(lookupModeProvider.select((s) => s.pitchClasses));
+    final names = ref.watch(pitchClassNamesProvider);
+    final prefersFlats = ref.watch(
+      selectedTonalityProvider.select((t) => t.keySignature.prefersFlats),
+    );
+    final notifier = ref.read(lookupModeProvider.notifier);
+
+    final counts = <int, int>{};
+    for (final pc in pcs) {
+      counts[pc] = (counts[pc] ?? 0) + 1;
+    }
+    final bassPc = pcs.isEmpty ? null : pcs.first;
+
+    String labelFor(int pc) =>
+        noteDisplayLabel(normalizeNoteNameToAscii(names[pc]));
+
+    // Keep the buttons clear of the screen's safe areas (home indicator and
+    // bottom rounded corners, plus side cutouts in landscape where the section
+    // is full-bleed). The gray panel still draws edge-to-edge; only the buttons
+    // inset. The bottom inset already provides its margin, so don't stack an
+    // extra one on top of it.
+    final safeArea = MediaQuery.paddingOf(context);
+    final bottomPadding = safeArea.bottom > 8 ? safeArea.bottom : 8.0;
+    // Symmetric side inset (largest cutout applied to both sides) to match the
+    // app bar and tonality bar.
+    final sideInset =
+        8 + (safeArea.left > safeArea.right ? safeArea.left : safeArea.right);
+
+    return ColoredBox(
+      color: cs.surfaceContainerLow,
+      child: Stack(
+        children: [
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              sideInset,
+              6,
+              sideInset,
+              bottomPadding,
+            ),
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                // Rows grow with available height (capped), vertically
+                // centered; shrink below the floor only if the slot is too
+                // short to fit them.
+                final cellHeight = (constraints.maxHeight / 2).clamp(
+                  _minCellHeight,
+                  _maxCellHeight,
+                );
+                final blockHeight = (cellHeight * 2).clamp(
+                  0.0,
+                  constraints.maxHeight,
+                );
+                final rowHeight = blockHeight / 2;
+                final gridWidth = constraints.maxWidth - _actionWidth - 8;
+                final buttonWidth = gridWidth / _naturals.length;
+
+                Widget rowOf(List<(double, int)> keys) => SizedBox(
+                  height: rowHeight,
+                  child: Stack(
+                    children: [
+                      for (final (x, pc) in keys)
+                        Positioned(
+                          left: x * buttonWidth,
+                          top: 0,
+                          bottom: 0,
+                          width: buttonWidth,
+                          child: _NoteButton(
+                            label: labelFor(pc),
+                            count: counts[pc] ?? 0,
+                            isBass: pc == bassPc,
+                            onTap: () => notifier.addNote(pc),
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+
+                final naturals = rowOf(_naturals);
+                final accidentals = rowOf(_accidentals);
+
+                return Center(
+                  child: SizedBox(
+                    height: blockHeight,
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Expanded(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: prefersFlats
+                                ? [naturals, accidentals]
+                                : [accidentals, naturals],
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        _PadActions(
+                          enabled: pcs.isNotEmpty,
+                          onUndo: notifier.removeLast,
+                          onClear: notifier.clear,
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          // A line matching the separator above (so it reads as a slightly
+          // thicker divider once the pad slides down) plus a soft shadow so the
+          // pad reads as a raised panel.
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: IgnorePointer(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Divider(height: 1),
+                  Container(
+                    height: _topShadowHeight,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Colors.black.withValues(alpha: _topShadowOpacity),
+                          Colors.black.withValues(alpha: 0),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NoteButton extends StatelessWidget {
+  const _NoteButton({
+    required this.label,
+    required this.count,
+    required this.isBass,
+    required this.onTap,
+  });
+
+  final String label;
+
+  /// How many times this pitch class is in the selection (0 if unselected).
+  final int count;
+  final bool isBass;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final selected = count > 0;
+
+    final Color bg;
+    final Color fg;
+    final BorderSide side;
+    if (isBass) {
+      bg = cs.primary;
+      fg = cs.onPrimary;
+      side = BorderSide.none;
+    } else if (selected) {
+      bg = cs.primaryContainer;
+      fg = cs.onPrimaryContainer;
+      side = SelectionColors.selectedChipBorder(cs);
+    } else {
+      bg = cs.surfaceContainerLowest;
+      fg = cs.onSurface;
+      side = SelectionColors.restChipBorder(cs);
+    }
+
+    final semanticLabel = isBass
+        ? '$label, bass'
+        : count > 1
+        ? '$label, added $count times'
+        : selected
+        ? '$label, selected'
+        : label;
+
+    return Padding(
+      padding: const EdgeInsets.all(2),
+      child: Semantics(
+        button: true,
+        selected: selected,
+        label: semanticLabel,
+        onTap: onTap,
+        excludeSemantics: true,
+        child: Material(
+          color: bg,
+          clipBehavior: Clip.antiAlias,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+            side: side,
+          ),
+          child: InkWell(
+            onTap: onTap,
+            child: Stack(
+              children: [
+                Center(
+                  child: Text(
+                    label,
+                    style: TextStyle(
+                      color: fg,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 15,
+                    ),
+                  ),
+                ),
+                if (count > 1)
+                  Positioned(
+                    top: 3,
+                    right: 4,
+                    child: Text(
+                      '×$count',
+                      style: TextStyle(
+                        color: fg.withValues(alpha: 0.75),
+                        fontSize: 10,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PadActions extends StatelessWidget {
+  const _PadActions({
+    required this.enabled,
+    required this.onUndo,
+    required this.onClear,
+  });
+
+  final bool enabled;
+  final VoidCallback onUndo;
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget action(IconData icon, String tooltip, VoidCallback onPressed) {
+      return Expanded(
+        child: Padding(
+          padding: const EdgeInsets.all(2),
+          child: Tooltip(
+            message: tooltip,
+            child: OutlinedButton(
+              onPressed: enabled ? onPressed : null,
+              style: OutlinedButton.styleFrom(
+                padding: EdgeInsets.zero,
+                minimumSize: const Size.square(LookupPad.minTapTarget),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: Icon(icon, size: 20, semanticLabel: tooltip),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return SizedBox(
+      width: LookupPad.minTapTarget + 4,
+      child: Column(
+        children: [
+          action(Icons.backspace_outlined, 'Undo', onUndo),
+          action(Icons.clear, 'Clear', onClear),
+        ],
+      ),
+    );
+  }
+}

--- a/test/lookup_voicing_test.dart
+++ b/test/lookup_voicing_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:whatchord/features/lookup/lookup_voicing.dart';
+
+void main() {
+  group('LookupVoicing.midiFromPitchClasses', () {
+    test('returns empty for no notes', () {
+      expect(LookupVoicing.midiFromPitchClasses(const []), isEmpty);
+    });
+
+    test('places the first note as the bass in octave 3', () {
+      expect(LookupVoicing.midiFromPitchClasses(const [0]), [48]);
+    });
+
+    test('stacks a close triad ascending above the bass', () {
+      // C E G -> C3 E3 G3.
+      expect(LookupVoicing.midiFromPitchClasses(const [0, 4, 7]), [48, 52, 55]);
+    });
+
+    test('preserves press order, spreading upward', () {
+      // C G E -> C3 G3 E4 (E lands above G, not below).
+      expect(LookupVoicing.midiFromPitchClasses(const [0, 7, 4]), [48, 55, 64]);
+    });
+
+    test('repeats climb to the next octave', () {
+      // C C C -> C3 C4 C5.
+      expect(LookupVoicing.midiFromPitchClasses(const [0, 0, 0]), [48, 60, 72]);
+    });
+
+    test('result is strictly ascending so MIDI order tracks press order', () {
+      final midi = LookupVoicing.midiFromPitchClasses(const [11, 0, 4, 0]);
+      for (var i = 1; i < midi.length; i++) {
+        expect(midi[i], greaterThan(midi[i - 1]));
+      }
+    });
+
+    test('normalizes pitch classes modulo 12', () {
+      expect(LookupVoicing.midiFromPitchClasses(const [12, 16]), [48, 52]);
+    });
+
+    test('does not climb past the top of the keyboard', () {
+      final midi = LookupVoicing.midiFromPitchClasses(List<int>.filled(12, 0));
+      expect(midi.every((m) => m <= 108), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Let users identify chords without a MIDI device. A search icon on the input line slides a note pad down over the keyboard; tapping note names builds a chord that flows through the normal analysis pipeline.

Design notes:

- Lookup is a third input source alongside demo and live MIDI, all mutually exclusive. It plugs in at soundingNoteNumbersProvider, so the identity card, analysis, tonality, and audio all work unchanged.
- The selection is an ordered, ascending voicing: first tap is the bass, each later tap lands at the lowest octave above the previous, so press order is preserved and repeats climb octaves. Chord identity is unaffected since analysis is pitch-class based.
- Note names follow the current key; accidentals sit above the naturals, or below them in flat keys.
- Tapped notes are struck as transient previews through the audio monitor (when enabled) rather than ringing indefinitely.
- The keyboard stays mounted under the pad (watching a live-only notes provider) so it never re-centers when toggling modes.