### PR TITLE
Preview playback volume while adjusting Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 - Resetting Settings to defaults now returns to the home page and starts the
   guided tour.
 - Renamed the Settings volume control to Playback Volume, moved it above Audio
-  Monitor, and made it available even when Audio Monitor is off.
+  Monitor, made it available even when Audio Monitor is off, and added a short
+  note preview while adjusting it.
 - The audio monitor is now enabled by default so the guided tour, manual lookup,
   and connected MIDI controllers are audible without initial setup.
 - The input note line now scrolls automatically to keep newly played notes in

--- a/lib/features/audio/providers/audio_monitor_notifier.dart
+++ b/lib/features/audio/providers/audio_monitor_notifier.dart
@@ -27,6 +27,7 @@ final audioMonitorStatusProvider = Provider<AudioMonitorStatus>((ref) {
 class AudioMonitorNotifier extends Notifier<AudioMonitorState> {
   static const bool _debugLog = audioDebug;
   static const Duration _previewDuration = Duration(milliseconds: 1400);
+  static const Duration _volumePreviewDuration = Duration(milliseconds: 350);
   static const Duration _rolledPreviewStep = Duration(milliseconds: 180);
   static const Duration _rolledPreviewNoteDuration = Duration(
     milliseconds: 220,
@@ -96,6 +97,23 @@ class AudioMonitorNotifier extends Notifier<AudioMonitorState> {
     if (notes.isEmpty || _backgrounded) return;
 
     _enqueueAudioOperation(() => _playPreviewNotes(notes));
+  }
+
+  void playVolumePreviewNote(int midiNote) {
+    if (_backgrounded || !ref.read(audioMonitorSettingsNotifier).enabled) {
+      return;
+    }
+
+    _enqueueAudioOperation(
+      () => _playPreviewNotes([
+        midiNote.clamp(0, 127),
+      ], duration: _volumePreviewDuration),
+    );
+  }
+
+  void cancelPreviewNotes() {
+    _cancelPreviewTimers();
+    _enqueueAudioOperation(_finishPreview);
   }
 
   void playRolledPreviewNotes(Iterable<int> midiNotes) {
@@ -304,7 +322,10 @@ class AudioMonitorNotifier extends Notifier<AudioMonitorState> {
     await engine.stop();
   }
 
-  Future<void> _playPreviewNotes(List<int> midiNotes) async {
+  Future<void> _playPreviewNotes(
+    List<int> midiNotes, {
+    Duration duration = _previewDuration,
+  }) async {
     final generation = _previewSequence.restart();
 
     if (_backgrounded) return;
@@ -321,7 +342,7 @@ class AudioMonitorNotifier extends Notifier<AudioMonitorState> {
       await engine.noteOn(midiNote, velocity: audioMonitorFixedVelocity);
     }
 
-    _previewSequence.schedule(_previewDuration, (_) {
+    _previewSequence.schedule(duration, (_) {
       _enqueuePreviewControl(generation, _finishPreview);
     }, generation: generation);
   }

--- a/lib/features/settings/pages/settings_page.dart
+++ b/lib/features/settings/pages/settings_page.dart
@@ -25,9 +25,17 @@ class SettingsPage extends ConsumerStatefulWidget {
 class _SettingsPageState extends ConsumerState<SettingsPage> {
   bool _isAdjustingAudioVolume = false;
   Timer? _audioVolumeLabelDismissTimer;
+  Timer? _volumePreviewDebounceTimer;
   Timer? _volumeRepeatTimer;
   DateTime? _volumeRepeatStartedAt;
 
+  static const int _volumePreviewMidiNote = 60;
+  static const Duration _sliderVolumePreviewDebounce = Duration(
+    milliseconds: 125,
+  );
+  static const Duration _nudgeVolumePreviewDebounce = Duration(
+    milliseconds: 300,
+  );
   static const int _volumeNudgeStepPercent = 5;
   static const int _volumeFastNudgeStepPercent = 10;
   static const Duration _volumeRepeatInterval = Duration(milliseconds: 100);
@@ -39,8 +47,27 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   void dispose() {
     _audioVolumeLabelDismissTimer?.cancel();
     _audioVolumeLabelDismissTimer = null;
+    _volumePreviewDebounceTimer?.cancel();
+    _volumePreviewDebounceTimer = null;
+    ref.read(audioMonitorNotifier.notifier).cancelPreviewNotes();
     _stopVolumeRepeat();
     super.dispose();
+  }
+
+  void _scheduleVolumePreview(Duration debounce) {
+    _volumePreviewDebounceTimer?.cancel();
+    final monitor = ref.read(audioMonitorNotifier.notifier);
+    monitor.cancelPreviewNotes();
+    _volumePreviewDebounceTimer = Timer(debounce, () {
+      _volumePreviewDebounceTimer = null;
+      if (!mounted) return;
+      monitor.playVolumePreviewNote(_volumePreviewMidiNote);
+    });
+  }
+
+  void _showCurrentVolume() {
+    _showAudioVolumePercentLabel();
+    _scheduleVolumeLabelDismiss();
   }
 
   void _showAudioVolumePercentLabel() {
@@ -73,6 +100,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
 
     unawaited(notifier.setVolume(nextPercent / 100));
     unawaited(HapticFeedback.selectionClick());
+    _scheduleVolumePreview(_nudgeVolumePreviewDebounce);
   }
 
   void _startVolumeRepeat(int direction) {
@@ -163,7 +191,17 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Text('Playback Volume'),
+                    Semantics(
+                      button: true,
+                      label: 'Playback Volume',
+                      hint: 'Show current playback volume',
+                      onTapHint: 'Show current playback volume',
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: _showCurrentVolume,
+                        child: const Text('Playback Volume'),
+                      ),
+                    ),
                     AnimatedSwitcher(
                       duration: const Duration(milliseconds: 180),
                       switchInCurve: Curves.easeOut,
@@ -194,10 +232,12 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                                 min: 0,
                                 max: 1,
                                 divisions: 100,
-                                onChangeStart: (_) =>
-                                    _showAudioVolumePercentLabel(),
-                                onChangeEnd: (_) =>
-                                    _scheduleVolumeLabelDismiss(),
+                                onChangeStart: (_) {
+                                  _showAudioVolumePercentLabel();
+                                },
+                                onChangeEnd: (_) {
+                                  _scheduleVolumeLabelDismiss();
+                                },
                                 onChanged: (value) {
                                   _showAudioVolumePercentLabel();
                                   unawaited(
@@ -206,6 +246,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                                           audioMonitorSettingsNotifier.notifier,
                                         )
                                         .setVolume(value),
+                                  );
+                                  _scheduleVolumePreview(
+                                    _sliderVolumePreviewDebounce,
                                   );
                                 },
                               ),


### PR DESCRIPTION
Play a short, cancelable note after volume adjustments so users can gauge the result. Debounce slider and nudge interactions separately, and show the current percentage when the Playback Volume label is tapped.