### PR TITLE
Fix recursive routing for shared chord links

### DIFF
--- a/docs/site/articles/choco-chord-coverage.html
+++ b/docs/site/articles/choco-chord-coverage.html
@@ -401,7 +401,7 @@
             >
             <p class="cta-secondary">
               Curious how it names them?
-              <a href="../try.html">Try identifying chords in your browser →</a>
+              <a href="/try">Try identifying chords in your browser →</a>
             </p>
           </div>
 

--- a/docs/site/articles/chord-naming.html
+++ b/docs/site/articles/chord-naming.html
@@ -393,7 +393,7 @@
             </div>
             <p class="cta-secondary">
               Prefer not to install?
-              <a href="../try.html">Try identifying chords in your browser →</a>
+              <a href="/try">Try identifying chords in your browser →</a>
             </p>
           </div>
 

--- a/docs/site/articles/under-the-hood.html
+++ b/docs/site/articles/under-the-hood.html
@@ -1055,7 +1055,7 @@ pcs: B♭ C E F♯  |  bass: F♯ (pc 6)  |  key: C major
             >
             <p class="cta-secondary">
               Prefer not to install?
-              <a href="../try.html">Try identifying chords in your browser →</a>
+              <a href="/try">Try identifying chords in your browser →</a>
             </p>
           </div>
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -251,7 +251,7 @@
               No download required. Type a few notes and the same engine that
               powers the app will name the voicing and its close alternatives.
             </p>
-            <a class="btn btn-primary" href="try.html"
+            <a class="btn btn-primary" href="/try"
               >Open the chord identifier →</a
             >
           </div>

--- a/docs/site/js/try.js
+++ b/docs/site/js/try.js
@@ -154,7 +154,7 @@
   }
 
   els.copyLink.addEventListener("click", function () {
-    var url = location.origin + location.pathname + buildQuery();
+    var url = location.origin + "/try" + buildQuery();
     var done = function () {
       els.copyLabel.textContent = "Copied!";
       setTimeout(function () {
@@ -182,11 +182,11 @@
     if (state.notation !== DEFAULT_NOTATION)
       params.set("notation", state.notation);
     var q = params.toString();
-    return q ? "?" + q : location.pathname;
+    return q ? "?" + q : "";
   }
 
   function syncUrl() {
-    history.replaceState(null, "", buildQuery());
+    history.replaceState(null, "", "/try" + buildQuery());
   }
 
   // Applies URL params and returns the pitch class to preselect in the key

--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -17,7 +17,7 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:url"
-      content="https://whatchord.earthmanmuons.com/try.html"
+      content="https://whatchord.earthmanmuons.com/try"
     />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Try WhatChord - Identify a Chord" />

--- a/docs/site/wrangler.toml
+++ b/docs/site/wrangler.toml
@@ -7,4 +7,4 @@ directory = "."
 binding = "ASSETS"
 # Only the Try page needs server-side logic (dynamic social-preview metadata);
 # every other path is served straight from static assets.
-run_worker_first = ["/try", "/try.html"]
+run_worker_first = ["/try"]


### PR DESCRIPTION
Allow the Try page worker to fetch its static HTML asset without invoking itself recursively.