### PR TITLE
Prevent Try page worker redirect loop

### DIFF
--- a/docs/site/wrangler.toml
+++ b/docs/site/wrangler.toml
@@ -5,6 +5,9 @@ main = "worker/index.js"
 [assets]
 directory = "."
 binding = "ASSETS"
+# Keep .html asset paths available for the Worker and for the rest of the site.
+# The public extensionless /try route is handled explicitly below.
+html_handling = "none"
 # Only the Try page needs server-side logic (dynamic social-preview metadata);
 # every other path is served straight from static assets.
 run_worker_first = ["/try"]


### PR DESCRIPTION
Keep HTML asset paths available so the worker can fetch try.html without being redirected back through /try.