### PR TITLE
Restore homepage root routing

### DIFF
--- a/docs/site/worker/index.js
+++ b/docs/site/worker/index.js
@@ -15,6 +15,12 @@ export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
+    if (url.pathname === "/") {
+      return env.ASSETS.fetch(
+        new Request(new URL("/index.html", url.origin), request),
+      );
+    }
+
     // Always start from the real static asset so non-meta content is untouched.
     const asset = await env.ASSETS.fetch(
       new Request(new URL("/try.html", url.origin), request),

--- a/docs/site/wrangler.toml
+++ b/docs/site/wrangler.toml
@@ -6,8 +6,8 @@ main = "worker/index.js"
 directory = "."
 binding = "ASSETS"
 # Keep .html asset paths available for the Worker and for the rest of the site.
-# The public extensionless /try route is handled explicitly below.
+# The public root and extensionless /try routes are handled explicitly below.
 html_handling = "none"
-# Only the Try page needs server-side logic (dynamic social-preview metadata);
-# every other path is served straight from static assets.
-run_worker_first = ["/try"]
+# The root needs explicit index.html routing; the Try page needs server-side
+# logic for dynamic social-preview metadata.
+run_worker_first = ["/", "/try"]


### PR DESCRIPTION
Explicitly serve index.html for the site root while keeping dynamic social-preview handling limited to the Try page.