### PR TITLE
Guard Try page note input

### DIFF
--- a/docs/site/js/chord-id.js
+++ b/docs/site/js/chord-id.js
@@ -52,7 +52,7 @@ return a}var hunkHelpers=function(){var t=function(a,b,c,d,e){return function(f,
 return{inherit:inherit,inheritMany:inheritMany,mixin:mixinEasy,mixinHard:mixinHard,installStaticTearOff:installStaticTearOff,installInstanceTearOff:installInstanceTearOff,_instance_0u:t(0,0,null,["$0"],0),_instance_1u:t(0,1,null,["$1"],0),_instance_2u:t(0,2,null,["$2"],0),_instance_0i:t(1,0,null,["$0"],0),_instance_1i:t(1,1,null,["$1"],0),_instance_2i:t(1,2,null,["$2"],0),_static_0:s(0,null,["$0"],0),_static_1:s(1,null,["$1"],0),_static_2:s(2,null,["$2"],0),makeConstList:makeConstList,lazy:lazy,lazyFinal:lazyFinal,updateHolder:updateHolder,convertToFastObject:convertToFastObject,updateTypes:updateTypes,setOrUpdateInterceptorsByTag:setOrUpdateInterceptorsByTag,setOrUpdateLeafTags:setOrUpdateLeafTags}}()
 function initializeDeferredHunk(a){x=v.types.length
 a(hunkHelpers,v,w,$)}var J={
-h8(a,b){if(a<0||a>4294967295)throw A.c(A.ak(a,0,4294967295,"length",null))
+h8(a,b){if(a<0||a>4294967295)throw A.c(A.al(a,0,4294967295,"length",null))
 return J.dV(new Array(a),b)},
 ct(a,b){if(a<0)throw A.c(A.db("Length must be a non-negative integer: "+a))
 return A.k(new Array(a),b.i("j<0>"))},
@@ -72,7 +72,7 @@ for(t=a.length;b>0;b=s){s=b-1
 if(!(s<t))return A.a(a,s)
 r=a.charCodeAt(s)
 if(r!==32&&r!==13&&!J.dW(r))break}return b},
-au(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.b2.prototype
+av(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.b2.prototype
 return J.bV.prototype}if(typeof a=="string")return J.a8.prototype
 if(a==null)return J.b3.prototype
 if(typeof a=="boolean")return J.bU.prototype
@@ -100,17 +100,17 @@ if(!(a instanceof A.o))return J.a6.prototype
 return a},
 U(a,b){if(a==null)return b==null
 if(typeof a!="object")return b!=null&&a===b
-return J.au(a).A(a,b)},
+return J.av(a).A(a,b)},
 aX(a,b){return J.dA(a).l(a,b)},
 dI(a,b){return J.eK(a).au(a,b)},
 f4(a,b){return J.jr(a).B(a,b)},
 f5(a,b){return J.dA(a).G(a,b)},
-t(a){return J.au(a).gv(a)},
+t(a){return J.av(a).gv(a)},
 da(a){return J.dA(a).gt(a)},
 bz(a){return J.jq(a).gp(a)},
-f6(a){return J.au(a).gJ(a)},
+f6(a){return J.av(a).gJ(a)},
 f7(a,b,c){return J.eK(a).C(a,b,c)},
-bA(a){return J.au(a).j(a)},
+bA(a){return J.av(a).j(a)},
 bS:function bS(){},
 bU:function bU(){},
 b3:function b3(){},
@@ -160,7 +160,7 @@ _.$ti=c},
 H:function H(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-al:function al(a,b,c){this.a=a
+am:function am(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
 bo:function bo(a,b,c){this.a=a
@@ -197,7 +197,7 @@ if(s==="NaN"||s==="+NaN"||s==="-NaN")return t
 return null}return t},
 c_(a){var t,s,r,q
 if(a instanceof A.o)return A.K(A.cf(a),null)
-t=J.au(a)
+t=J.av(a)
 if(t===B.bx||t===B.by||u.A.b(a)){s=B.aW(a)
 if(s!=="Object"&&s!=="")return s
 r=a.constructor
@@ -214,7 +214,7 @@ if(r!=null)return r}return"Instance of '"+A.c_(a)+"'"},
 z(a){var t
 if(0<=a){if(a<=65535)return String.fromCharCode(a)
 if(a<=1114111){t=a-65536
-return String.fromCharCode((B.a.ap(t,10)|55296)>>>0,t&1023|56320)}}throw A.c(A.ak(a,0,1114111,null,null))},
+return String.fromCharCode((B.a.ap(t,10)|55296)>>>0,t&1023|56320)}}throw A.c(A.al(a,0,1114111,null,null))},
 a(a,b){if(a==null)J.bz(a)
 throw A.c(A.eH(a,b))},
 eH(a,b){var t,s="index"
@@ -270,18 +270,18 @@ dk(a,b){var t=b==null,s=t?null:b.method
 return new A.bW(a,s,t?null:b.receiver)},
 dF(a){if(a==null)return new A.cE(a)
 if(typeof a!=="object")return a
-if("dartException" in a)return A.ax(a,a.dartException)
+if("dartException" in a)return A.ay(a,a.dartException)
 return A.jf(a)},
-ax(a,b){if(u.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
+ay(a,b){if(u.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
 return b},
 jf(a){var t,s,r,q,p,o,n,m,l,k,j,i,h
 if(!("message" in a))return a
 t=a.message
 if("number" in a&&typeof a.number=="number"){s=a.number
 r=s&65535
-if((B.a.ap(s,16)&8191)===10)switch(r){case 438:return A.ax(a,A.dk(A.q(t)+" (Error "+r+")",null))
+if((B.a.ap(s,16)&8191)===10)switch(r){case 438:return A.ay(a,A.dk(A.q(t)+" (Error "+r+")",null))
 case 445:case 5007:A.q(t)
-return A.ax(a,new A.bc())}}if(a instanceof TypeError){q=$.eR()
+return A.ay(a,new A.bc())}}if(a instanceof TypeError){q=$.eR()
 p=$.eS()
 o=$.eT()
 n=$.eU()
@@ -292,13 +292,13 @@ $.eV()
 j=$.f_()
 i=$.eZ()
 h=q.F(t)
-if(h!=null)return A.ax(a,A.dk(A.T(t),h))
+if(h!=null)return A.ay(a,A.dk(A.T(t),h))
 else{h=p.F(t)
 if(h!=null){h.method="call"
-return A.ax(a,A.dk(A.T(t),h))}else if(o.F(t)!=null||n.F(t)!=null||m.F(t)!=null||l.F(t)!=null||k.F(t)!=null||n.F(t)!=null||j.F(t)!=null||i.F(t)!=null){A.T(t)
-return A.ax(a,new A.bc())}}return A.ax(a,new A.c5(typeof t=="string"?t:""))}if(a instanceof RangeError){if(typeof t=="string"&&t.indexOf("call stack")!==-1)return new A.bi()
+return A.ay(a,A.dk(A.T(t),h))}else if(o.F(t)!=null||n.F(t)!=null||m.F(t)!=null||l.F(t)!=null||k.F(t)!=null||n.F(t)!=null||j.F(t)!=null||i.F(t)!=null){A.T(t)
+return A.ay(a,new A.bc())}}return A.ay(a,new A.c5(typeof t=="string"?t:""))}if(a instanceof RangeError){if(typeof t=="string"&&t.indexOf("call stack")!==-1)return new A.bi()
 t=function(b){try{return String(b)}catch(g){}return null}(a)
-return A.ax(a,new A.Q(!1,null,null,typeof t=="string"?t.replace(/^RangeError:\s*/,""):t))}if(typeof InternalError=="function"&&a instanceof InternalError)if(typeof t=="string"&&t==="too much recursion")return new A.bi()
+return A.ay(a,new A.Q(!1,null,null,typeof t=="string"?t.replace(/^RangeError:\s*/,""):t))}if(typeof InternalError=="function"&&a instanceof InternalError)if(typeof t=="string"&&t==="too much recursion")return new A.bi()
 return a},
 dC(a){if(a==null)return J.t(a)
 if(typeof a=="object")return A.bd(a)
@@ -337,7 +337,7 @@ default:t=null}if(t!=null)return t.bind(a)
 return function(c,d,e){return function(f,g,h,i){return e(c,d,f,g,h,i)}}(a,b,A.ie)},
 h5(a1){var t,s,r,q,p,o,n,m,l,k,j=a1.co,i=a1.iS,h=a1.iI,g=a1.nDA,f=a1.aI,e=a1.fs,d=a1.cs,c=e[0],b=d[0],a=j[c],a0=a1.fT
 a0.toString
-t=i?Object.create(new A.c1().constructor.prototype):Object.create(new A.ay(null,null).constructor.prototype)
+t=i?Object.create(new A.c1().constructor.prototype):Object.create(new A.az(null,null).constructor.prototype)
 t.$initialize=t.constructor
 s=i?function static_tear_off(){this.$initialize()}:function tear_off(a2,a3){this.$initialize(a2,a3)}
 t.constructor=s
@@ -393,7 +393,7 @@ dz(a){return A.h5(a)},
 f8(a,b){return A.bv(v.typeUniverse,A.cf(a.a),b)},
 dM(a){return a.a},
 f9(a){return a.b},
-dJ(a){var t,s,r,q=new A.ay("receiver","interceptor"),p=Object.getOwnPropertyNames(q)
+dJ(a){var t,s,r,q=new A.az("receiver","interceptor"),p=Object.getOwnPropertyNames(q)
 p.$flags=1
 t=p
 for(p=t.length,s=0;s<p;++s){r=t[s]
@@ -446,14 +446,14 @@ b0:function b0(){},
 aC:function aC(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-an:function an(a,b,c){var _=this
+ao:function ao(a,b,c){var _=this
 _.a=a
 _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
 aB:function aB(){},
-ae:function ae(a,b,c){this.a=a
+af:function af(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
 M:function M(a,b){this.a=a
@@ -477,7 +477,7 @@ bL:function bL(){},
 bM:function bM(){},
 c3:function c3(){},
 c1:function c1(){},
-ay:function ay(a,b){this.a=a
+az:function az(a,b){this.a=a
 this.b=b},
 c0:function c0(a){this.a=a},
 R:function R(a){var _=this
@@ -490,9 +490,9 @@ cy:function cy(a,b){var _=this
 _.a=a
 _.b=b
 _.d=_.c=null},
-ah:function ah(a,b){this.a=a
+ai:function ai(a,b){this.a=a
 this.$ti=b},
-ag:function ag(a,b,c,d){var _=this
+ah:function ah(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
@@ -555,14 +555,14 @@ jz(a,b){var t,s=b.length
 for(t=0;t<s;++t)if(!a[t].b(b[t]))return!1
 return!0},
 F(a){return A.cW(v.typeUniverse,a,!1)},
-as(a0,a1,a2,a3){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=a1.w
+at(a0,a1,a2,a3){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=a1.w
 switch(a){case 5:case 1:case 2:case 3:case 4:return a1
 case 6:t=a1.x
-s=A.as(a0,t,a2,a3)
+s=A.at(a0,t,a2,a3)
 if(s===t)return a1
 return A.ej(a0,s,!0)
 case 7:t=a1.x
-s=A.as(a0,t,a2,a3)
+s=A.at(a0,t,a2,a3)
 if(s===t)return a1
 return A.ei(a0,s,!0)
 case 8:r=a1.y
@@ -570,7 +570,7 @@ q=A.aT(a0,r,a2,a3)
 if(q===r)return a1
 return A.bt(a0,a1.x,q)
 case 9:p=a1.x
-o=A.as(a0,p,a2,a3)
+o=A.at(a0,p,a2,a3)
 n=a1.y
 m=A.aT(a0,n,a2,a3)
 if(o===p&&m===n)return a1
@@ -581,7 +581,7 @@ j=A.aT(a0,k,a2,a3)
 if(j===k)return a1
 return A.ek(a0,l,j)
 case 11:i=a1.x
-h=A.as(a0,i,a2,a3)
+h=A.at(a0,i,a2,a3)
 g=a1.y
 f=A.jc(a0,g,a2,a3)
 if(h===i&&f===g)return a1
@@ -590,7 +590,7 @@ case 12:e=a1.y
 a3+=e.length
 d=A.aT(a0,e,a2,a3)
 p=a1.x
-o=A.as(a0,p,a2,a3)
+o=A.at(a0,p,a2,a3)
 if(d===e&&o===p)return a1
 return A.du(a0,o,d,!0)
 case 13:c=a1.x
@@ -601,14 +601,14 @@ return b
 default:throw A.c(A.bE("Attempted to substitute unexpected RTI kind "+a))}},
 aT(a,b,c,d){var t,s,r,q,p=b.length,o=A.cX(p)
 for(t=!1,s=0;s<p;++s){r=b[s]
-q=A.as(a,r,c,d)
+q=A.at(a,r,c,d)
 if(q!==r)t=!0
 o[s]=q}return t?o:b},
 jd(a,b,c,d){var t,s,r,q,p,o,n=b.length,m=A.cX(n)
 for(t=!1,s=0;s<n;s+=3){r=b[s]
 q=b[s+1]
 p=b[s+2]
-o=A.as(a,p,c,d)
+o=A.at(a,p,c,d)
 if(o!==p)t=!0
 m.splice(s,3,r,q,o)}return t?m:b},
 jc(a,b,c,d){var t,s=b.a,r=A.aT(a,s,c,d),q=b.b,p=A.aT(a,q,c,d),o=b.c,n=A.jd(a,o,c,d)
@@ -628,7 +628,7 @@ if(A.e4(b))if(a instanceof A.a7){t=A.eG(a)
 if(t!=null)return t}return A.cf(a)},
 cf(a){if(a instanceof A.o)return A.b(a)
 if(Array.isArray(a))return A.O(a)
-return A.dw(J.au(a))},
+return A.dw(J.av(a))},
 O(a){var t=a[v.arrayRti],s=u.b
 if(t==null)return s
 if(t.constructor!==s.constructor)return s
@@ -645,7 +645,7 @@ jt(a){var t,s=v.types,r=s[a]
 if(typeof r=="string"){t=A.cW(v.typeUniverse,r,!1)
 s[a]=t
 return t}return r},
-js(a){return A.at(A.b(a))},
+js(a){return A.au(A.b(a))},
 dy(a){var t
 if(a instanceof A.X)return A.jn(a.$r,a.aa())
 t=a instanceof A.a7?A.eG(a):null
@@ -653,7 +653,7 @@ if(t!=null)return t
 if(u.R.b(a))return J.f6(a).a
 if(Array.isArray(a))return A.O(a)
 return A.cf(a)},
-at(a){var t=a.r
+au(a){var t=a.r
 return t==null?a.r=new A.ce(a):t},
 jn(a,b){var t,s,r=b,q=r.length
 if(q===0)return u.F
@@ -661,13 +661,13 @@ if(0>=q)return A.a(r,0)
 t=A.bv(v.typeUniverse,A.dy(r[0]),"@<0>")
 for(s=1;s<q;++s){if(!(s<r.length))return A.a(r,s)
 t=A.el(v.typeUniverse,t,A.dy(r[s]))}return A.bv(v.typeUniverse,t,a)},
-ks(a){return A.at(A.cW(v.typeUniverse,a,!1))},
+ks(a){return A.au(A.cW(v.typeUniverse,a,!1))},
 ib(a){var t=this
 t.b=A.j9(t)
 return t.b(a)},
 j9(a){var t,s,r,q,p
 if(a===u.K)return A.il
-if(A.av(a))return A.iq
+if(A.aw(a))return A.iq
 t=a.w
 if(t===6)return A.i9
 if(t===1)return A.ey
@@ -675,7 +675,7 @@ if(t===7)return A.ig
 s=A.j8(a)
 if(s!=null)return s
 if(t===8){r=a.x
-if(a.y.every(A.av)){a.f="$i"+r
+if(a.y.every(A.aw)){a.f="$i"+r
 if(r==="aa")return A.ij
 if(a===u.m)return A.ii
 return A.ip}}else if(t===10){q=A.jm(a.x,a.y)
@@ -686,7 +686,7 @@ if(a===u.i||a===u.H)return A.ik
 if(a===u.N)return A.io
 if(a===u.y)return A.dx}return null},
 ia(a){var t=this,s=A.i6
-if(A.av(t))s=A.i_
+if(A.aw(t))s=A.i_
 else if(t===u.K)s=A.dv
 else if(A.aV(t)){s=A.i8
 if(t===u.D)s=A.hW
@@ -711,14 +711,14 @@ ip(a){var t,s=this
 if(a==null)return A.aV(s)
 t=s.f
 if(a instanceof A.o)return!!a[t]
-return!!J.au(a)[t]},
+return!!J.av(a)[t]},
 ij(a){var t,s=this
 if(a==null)return A.aV(s)
 if(typeof a!="object")return!1
 if(Array.isArray(a))return!0
 t=s.f
 if(a instanceof A.o)return!!a[t]
-return!!J.au(a)[t]},
+return!!J.av(a)[t]},
 ii(a){var t=this
 if(a==null)return!1
 if(typeof a=="object"){if(a instanceof A.o)return!!a[t.f]
@@ -898,7 +898,7 @@ return t},
 hM(a,b,c,d){var t,s,r
 if(d){t=b.w
 s=!0
-if(!A.av(b))if(!(b===u.P||b===u.T))if(t!==6)s=t===7&&A.aV(b.x)
+if(!A.aw(b))if(!(b===u.P||b===u.T))if(t!==6)s=t===7&&A.aV(b.x)
 if(s)return b
 else if(t===1)return u.P}r=new A.S(null,null)
 r.w=6
@@ -912,7 +912,7 @@ a.eC.set(s,t)
 return t},
 hK(a,b,c,d){var t,s
 if(d){t=b.w
-if(A.av(b)||b===u.K)return b
+if(A.aw(b)||b===u.K)return b
 else if(t===1)return A.bt(a,"dT",[b])
 else if(b===u.P||b===u.T)return u.O}s=new A.S(null,null)
 s.w=7
@@ -995,7 +995,7 @@ hL(a,b,c,d,e){var t,s,r,q,p,o,n,m
 if(e){t=c.length
 s=A.cX(t)
 for(r=0,q=0;q<t;++q){p=c[q]
-if(p.w===1){s[q]=p;++r}}if(r>0){o=A.as(a,b,s,0)
+if(p.w===1){s[q]=p;++r}}if(r>0){o=A.at(a,b,s,0)
 n=A.aT(a,c,s,0)
 return A.du(a,o,n,c!==n)}}m=new A.S(null,null)
 m.w=12
@@ -1015,7 +1015,7 @@ case 58:l.push(!1)
 break
 case 33:l.push(!0)
 break
-case 59:l.push(A.ar(a.u,a.e,l.pop()))
+case 59:l.push(A.as(a.u,a.e,l.pop()))
 break
 case 94:l.push(A.hN(a.u,l.pop()))
 break
@@ -1033,10 +1033,10 @@ break
 case 38:A.hE(a,l)
 break
 case 63:q=a.u
-l.push(A.ej(q,A.ar(q,a.e,l.pop()),a.n))
+l.push(A.ej(q,A.as(q,a.e,l.pop()),a.n))
 break
 case 47:q=a.u
-l.push(A.ei(q,A.ar(q,a.e,l.pop()),a.n))
+l.push(A.ei(q,A.as(q,a.e,l.pop()),a.n))
 break
 case 40:l.push(-3)
 l.push(a.p)
@@ -1070,7 +1070,7 @@ a.p=l.length
 s=o+1
 break
 default:throw"Bad character "+r}}}n=l.pop()
-return A.ar(a.u,a.e,n)},
+return A.as(a.u,a.e,n)},
 hD(a,b,c,d){var t,s,r=b-48
 for(t=c.length;a<t;++a){s=c.charCodeAt(a)
 if(!(s>=48&&s<=57))break
@@ -1091,7 +1091,7 @@ d.push(A.bv(t,p,o))}else d.push(q)
 return n},
 hF(a,b){var t,s=a.u,r=A.ec(a,b),q=b.pop()
 if(typeof q=="string")b.push(A.bt(s,q,r))
-else{t=A.ar(s,a.e,q)
+else{t=A.as(s,a.e,q)
 switch(t.w){case 11:b.push(A.du(s,t,r,a.n))
 break
 default:b.push(A.dt(s,t,r))
@@ -1108,7 +1108,7 @@ p=b.pop()
 switch(p){case-3:p=b.pop()
 if(o==null)o=q.sEA
 if(n==null)n=q.sEA
-s=A.ar(q,a.e,p)
+s=A.as(q,a.e,p)
 r=new A.c9()
 r.a=t
 r.b=o
@@ -1126,13 +1126,13 @@ ec(a,b){var t=b.splice(a.p)
 A.eg(a.u,a.e,t)
 a.p=b.pop()
 return t},
-ar(a,b,c){if(typeof c=="string")return A.bt(a,c,a.sEA)
+as(a,b,c){if(typeof c=="string")return A.bt(a,c,a.sEA)
 else if(typeof c=="number"){b.toString
 return A.hG(a,b,c)}else return c},
 eg(a,b,c){var t,s=c.length
-for(t=0;t<s;++t)c[t]=A.ar(a,b,c[t])},
+for(t=0;t<s;++t)c[t]=A.as(a,b,c[t])},
 hH(a,b,c){var t,s=c.length
-for(t=2;t<s;t+=3)c[t]=A.ar(a,b,c[t])},
+for(t=2;t<s;t+=3)c[t]=A.as(a,b,c[t])},
 hG(a,b,c){var t,s,r=b.w
 if(r===9){if(c===0)return b.x
 t=b.y
@@ -1152,10 +1152,10 @@ if(t==null){t=A.B(a,b,null,c,null)
 s.set(c,t)}return t},
 B(a,b,c,d,e){var t,s,r,q,p,o,n,m,l,k,j
 if(b===d)return!0
-if(A.av(d))return!0
+if(A.aw(d))return!0
 t=b.w
 if(t===4)return!0
-if(A.av(b))return!1
+if(A.aw(b))return!1
 if(b.w===1)return!0
 s=t===13
 if(s)if(A.B(a,c[b.x],c,d,e))return!0
@@ -1241,9 +1241,9 @@ if(b.x!==d.x)return!1
 for(t=0;t<q;++t)if(!A.B(a,s[t],c,r[t],e))return!1
 return!0},
 aV(a){var t=a.w,s=!0
-if(!(a===u.P||a===u.T))if(!A.av(a))if(t!==6)s=t===7&&A.aV(a.x)
+if(!(a===u.P||a===u.T))if(!A.aw(a))if(t!==6)s=t===7&&A.aV(a.x)
 return s},
-av(a){var t=a.w
+aw(a){var t=a.w
 return t===2||t===3||t===4||t===5||a===u.X},
 em(a,b){var t,s,r=Object.keys(b),q=r.length
 for(t=0;t<q;++t){s=r[t]
@@ -1262,13 +1262,13 @@ br:function br(a){this.a=a},
 hc(a,b){return new A.R(a.i("@<0>").Z(b).i("R<1,2>"))},
 dn(a,b,c){return b.i("@<0>").Z(c).i("dm<1,2>").a(A.jp(a,new A.R(b.i("@<0>").Z(c).i("R<1,2>"))))},
 aH(a,b){return new A.R(a.i("@<0>").Z(b).i("R<1,2>"))},
-hd(a){return new A.ao(a.i("ao<0>"))},
-dZ(a){return new A.ao(a.i("ao<0>"))},
+hd(a){return new A.ap(a.i("ap<0>"))},
+dZ(a){return new A.ap(a.i("ap<0>"))},
 ds(){var t=Object.create(null)
 t["<non-identifier-key>"]=t
 delete t["<non-identifier-key>"]
 return t},
-aP(a,b,c){var t=new A.ap(a,b,c.i("ap<0>"))
+aP(a,b,c){var t=new A.aq(a,b,c.i("aq<0>"))
 t.c=a.e
 return t},
 e_(a,b){var t=A.hd(b)
@@ -1285,14 +1285,14 @@ a.T(0,new A.cA(s,t))
 t.a+="}"}finally{if(0>=$.L.length)return A.a($.L,-1)
 $.L.pop()}s=t.a
 return s.charCodeAt(0)==0?s:s},
-ao:function ao(a){var _=this
+ap:function ap(a){var _=this
 _.a=0
 _.f=_.e=_.d=_.c=_.b=null
 _.r=0
 _.$ti=a},
 ca:function ca(a){this.a=a
 this.b=null},
-ap:function ap(a,b,c){var _=this
+aq:function aq(a,b,c){var _=this
 _.a=a
 _.b=b
 _.d=_.c=null
@@ -1351,9 +1351,9 @@ bE(a){return new A.bD(a)},
 db(a){return new A.Q(!1,null,null,a)},
 bC(a,b,c){return new A.Q(!0,a,b,c)},
 e2(a,b){return new A.be(null,null,!0,a,b,"Value not in range")},
-ak(a,b,c,d,e){return new A.be(b,c,!0,a,d,"Invalid value")},
-hi(a,b,c){if(0>a||a>c)throw A.c(A.ak(a,0,c,"start",null))
-if(b!=null){if(a>b||b>c)throw A.c(A.ak(b,a,c,"end",null))
+al(a,b,c,d,e){return new A.be(b,c,!0,a,d,"Invalid value")},
+hi(a,b,c){if(0>a||a>c)throw A.c(A.al(a,0,c,"start",null))
+if(b!=null){if(a>b||b>c)throw A.c(A.al(b,a,c,"end",null))
 return b}return c},
 dq(a,b){return a},
 dh(a,b,c,d){return new A.bR(b,!0,a,d,"Index out of range")},
@@ -1407,7 +1407,7 @@ if(n==null){l+=5
 n="..."}}if(n!=null)B.c.l(b,n)
 B.c.l(b,r)
 B.c.l(b,s)},
-aj(a,b,c,d,e,f){var t
+ak(a,b,c,d,e,f){var t
 if(B.e===c){t=J.t(a)
 b=J.t(b)
 return A.bl(A.A(A.A($.aW(),t),b))}if(B.e===d){t=J.t(a)
@@ -1464,7 +1464,7 @@ cO:function cO(a){this.a=a},
 cs:function cs(a,b){this.a=a
 this.b=b},
 e:function e(){},
-ai:function ai(a,b,c){this.a=a
+aj:function aj(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
 bb:function bb(){},
@@ -1483,7 +1483,7 @@ p=r&&q}else p=!1
 o=c8&&A.fc(b4)
 t=b4.e
 n=new A.h(t,A.b(t).i("h<2>")).h(0,B.i)
-m=b7.h(0,B.x)||b7.h(0,B.I)
+m=b7.h(0,B.x)||b7.h(0,B.J)
 l=n&&m
 k=A.aA(b5)
 j=A.V(b5)
@@ -1502,9 +1502,9 @@ a2=A.fp(b4,b6)
 a3=!1
 if(b6)if(b5===B.l||b5===B.r||b5===B.t||b5===B.V){a3=b8.a
 a3=a3[1]===0&&a3[2]===0}a4=A.fr(b4,b6)
-c5=b5===B.K||b5===B.a3||b5===B.W||!c5||b5===B.z||b5===B.aa||b5===B.a5||b5===B.N||b5===B.O
+c5=b5===B.L||b5===B.a3||b5===B.W||!c5||b5===B.z||b5===B.ab||b5===B.a5||b5===B.O||b5===B.P
 a5=A.dO(b4,B.w,B.a7,B.f,B.m)
-a6=A.dO(b4,B.M,B.ag,B.f,B.m)
+a6=A.dO(b4,B.N,B.ah,B.f,B.m)
 a7=A.ff(b4)
 a8=A.fm(b4)
 b7=b7.a
@@ -1545,20 +1545,20 @@ if(t.a!==1)return!1
 if(!t.h(0,B.q))return!1
 t=a.e
 s=new A.h(t,A.b(t).i("h<2>"))
-return s.h(0,B.n)&&s.h(0,B.k)&&s.h(0,B.f)&&s.h(0,B.ae)},
+return s.h(0,B.n)&&s.h(0,B.k)&&s.h(0,B.f)&&s.h(0,B.af)},
 fq(a,b){var t,s=!0
 if(b)if(a.c===B.A){s=a.d
 s=s.a!==1||!s.h(0,B.x)}if(s)return!1
 s=a.e
 t=new A.h(s,A.b(s).i("h<2>"))
-return t.h(0,B.n)&&t.h(0,B.k)&&t.h(0,B.j)&&t.h(0,B.af)},
+return t.h(0,B.n)&&t.h(0,B.k)&&t.h(0,B.j)&&t.h(0,B.ag)},
 fh(a){var t,s
 if(a.c===B.t){t=a.d
 t=t.a!==1||!t.h(0,B.D)}else t=!0
 if(t)return!1
 t=a.e
 s=new A.h(t,A.b(t).i("h<2>"))
-return s.h(0,B.n)&&s.h(0,B.i)&&s.h(0,B.f)&&s.h(0,B.a6)&&s.h(0,B.ah)},
+return s.h(0,B.n)&&s.h(0,B.i)&&s.h(0,B.f)&&s.h(0,B.a6)&&s.h(0,B.ai)},
 fg(a){var t,s,r,q=a.c,p=q===B.l
 if(!p&&q!==B.r)return!1
 if(a.d.aX(0,new A.cg(q)))return!1
@@ -1574,7 +1574,7 @@ t=a.e
 s=new A.h(t,A.b(t).i("h<2>"))
 return s.h(0,B.n)&&s.h(0,B.i)&&s.h(0,B.f)},
 fs(a,b){if(b===B.l&&a===B.x)return!0
-return a===B.w||a===B.M||a===B.U||a===B.q||a===B.C},
+return a===B.w||a===B.N||a===B.U||a===B.q||a===B.C},
 fn(a,b){var t
 if(!A.aA(a.c))return!1
 if(b)return!1
@@ -1590,7 +1590,7 @@ if(r.a!==1||!r.h(0,B.p))return!1
 if(A.aU(s,t)!==2)return!1
 t=a.e
 q=new A.h(t,A.b(t).i("h<2>"))
-p=q.h(0,B.i)||q.h(0,B.k)||q.h(0,B.Q)||q.h(0,B.R)
+p=q.h(0,B.i)||q.h(0,B.k)||q.h(0,B.R)||q.h(0,B.S)
 o=q.h(0,B.j)||q.h(0,B.G)
 return q.h(0,B.n)&&p&&q.h(0,B.f)&&o},
 fj(a){var t,s,r,q
@@ -1614,9 +1614,9 @@ s=t===B.a3
 if(!s&&t!==B.W)return!1
 r=a.e
 q=new A.h(r,A.b(r).i("h<2>"))
-return(s?q.h(0,B.Q):q.h(0,B.R))&&q.h(0,B.j)},
+return(s?q.h(0,B.R):q.h(0,B.S))&&q.h(0,B.j)},
 fr(a,b){var t,s,r=a.c
-if(r===B.ab||r===B.ac)return!0
+if(r===B.ac||r===B.ad)return!0
 if(A.V(r)===B.o&&!b){t=a.e
 s=new A.h(t,A.b(t).i("h<2>"))
 if(!(s.h(0,B.f)||s.h(0,B.B)||s.h(0,B.F)))return!0}return!1},
@@ -1634,19 +1634,19 @@ r=A.fd(a.e.u(0,A.aU(s,t)))
 for(t=a.d,t=A.aP(t,t.r,A.b(t).c),s=t.$ti.c;t.k();){q=t.d
 if(q==null)q=s.a(q)
 if(q===r)continue
-if(q===B.w||q===B.M||q===B.q||q===B.C)return!0}return!1},
+if(q===B.w||q===B.N||q===B.q||q===B.C)return!0}return!1},
 fd(a){var t
 A:{if(B.a7===a){t=B.w
-break A}if(B.ag===a){t=B.M
-break A}if(B.ae===a){t=B.q
+break A}if(B.ah===a){t=B.N
+break A}if(B.af===a){t=B.q
 break A}if(B.aF===a){t=B.C
 break A}if(B.aJ===a){t=B.p
-break A}if(B.aE===a){t=B.I
-break A}if(B.aG===a){t=B.J
-break A}if(B.ah===a){t=B.D
+break A}if(B.aE===a){t=B.J
+break A}if(B.aG===a){t=B.K
+break A}if(B.ai===a){t=B.D
 break A}if(B.bw===a){t=B.U
 break A}if(B.aK===a){t=B.U
-break A}if(B.af===a){t=B.x
+break A}if(B.ag===a){t=B.x
 break A}if(B.aH===a){t=B.T
 break A}t=null
 break A}return t},
@@ -1704,7 +1704,7 @@ _.x1=c0
 _.x2=c1
 _.xr=c2},
 cg:function cg(a){this.a=a},
-fE(a,b,c){var t,s,r,q,p=A.aj((a.a|a.b<<12|a.c<<16)>>>0,b,c,B.e,B.e,B.e),o=$.eO(),n=o.u(0,p)
+fE(a,b,c){var t,s,r,q,p=A.ak((a.a|a.b<<12|a.c<<16)>>>0,b,c,B.e,B.e,B.e),o=$.eO(),n=o.u(0,p)
 if(n!=null){o.aw(0,p)
 o.q(0,p,n)
 return n}t=A.fv(a,b,!1)
@@ -1716,10 +1716,10 @@ s=A.aI(new A.H(new A.bk(t,0,c,s),s.i("G(I.E)").a(new A.cj()),r),r.i("I.E"))
 s.$flags=1
 q=s
 o.q(0,p,q)
-if(o.a>512)o.aw(0,new A.ah(o,A.b(o).i("ah<1>")).gS(0))
+if(o.a>512)o.aw(0,new A.ai(o,A.b(o).i("ai<1>")).gS(0))
 return q},
 fv(a,b,c){var t,s,r,q,p,o,n,m,l,k,j,i,h=a.a
-if(h===0)return B.bU
+if(h===0)return B.bV
 t=A.k([],u.r)
 for(s=a.b,r=a.c,q=0;q<12;++q){if((h&B.a.M(1,q))>>>0===0)continue
 p=A.fB(h,q)
@@ -1729,7 +1729,7 @@ k=A.fC(o,b,r,null,p,q,l)
 if(k==null)continue
 j=l.a
 i=k.b
-B.c.l(t,new A.am(new A.G(new A.bG(q,s,j,i,A.h0(i,j,p),p),k.a)))}}return A.fH(t,new A.ch(),b.a,u.o)},
+B.c.l(t,new A.an(new A.G(new A.bG(q,s,j,i,A.h0(i,j,p),p),k.a)))}}return A.fH(t,new A.ch(),b.a,u.o)},
 fC(b2,b3,b4,b5,b6,b7,b8){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0=null,b1=new A.ci(b5)
 if((b6&1)===0)return b0
 t=b8.b|1
@@ -1750,12 +1750,12 @@ h=A.dZ(u.G)
 if((k&2)!==0)h.l(0,i||A.aA(j)?B.w:B.b1)
 if((k&8)!==0){if(!i)g=!(j===B.l||j===B.t||j===B.a_)
 else g=!0
-h.l(0,g?B.M:B.U)}if((k&64)!==0)h.l(0,B.q)
+h.l(0,g?B.N:B.U)}if((k&64)!==0)h.l(0,B.q)
 if((k&256)!==0)h.l(0,B.C)
 f=(k&14)!==0
 if((k&4)!==0)h.l(0,i?B.p:B.D)
-if((k&32)!==0)h.l(0,i&&f?B.I:B.x)
-if((k&512)!==0)h.l(0,i&&f?B.J:B.T)
+if((k&32)!==0)h.l(0,i&&f?B.J:B.x)
+if((k&512)!==0)h.l(0,i&&f?B.K:B.T)
 e=A.dP(h)&&(k&330)!==0
 g=A.bx(k)
 d=g-(e?1:0)
@@ -1776,7 +1776,7 @@ else if((k&a2)>>>0!==0)a3=A.V(j)===B.o&&h.a!==0?0.75:0.25
 else a3=-0.25
 a4=c+b+a+a0+a1+a3
 b1.$3$detail("bass fit",a3,"interval="+b2)
-if((j===B.Y||j===B.K)&&b2===8){a4-=3
+if((j===B.Y||j===B.L)&&b2===8){a4-=3
 b1.$2("m#5 bass",-3)}if(A.fz(b2,j)){a4-=2
 b1.$2("sus-tone bass",-2)}A:{g=B.E===j
 a5=0.3
@@ -1796,7 +1796,7 @@ b1.$3$detail("sixNo5",-0.6,"n="+b4)}a8=o>0?Math.sqrt(o):1
 a9=a4/a8
 if(b5!=null)b1.$3$detail("normalize",0,"raw="+B.u.K(a4,2)+" denom="+B.u.K(a8,2)+" => "+B.u.K(a9,2))
 return new A.cV(a9,h)},
-dP(a){return a.h(0,B.w)||a.h(0,B.M)||a.h(0,B.q)||a.h(0,B.C)},
+dP(a){return a.h(0,B.w)||a.h(0,B.N)||a.h(0,B.q)||a.h(0,B.C)},
 fx(a,b,c){var t=c.a
 if(A.fD(a,b)&&A.fA(t,b))return 8
 if(!(t===B.m||t===B.y||t===B.z))return 0
@@ -1816,13 +1816,13 @@ return(c&128)===0},
 fz(a,b){switch(b.a){case 6:case 12:case 17:return a===2
 case 7:case 13:case 18:return a===5
 default:return!1}},
-fw(a,b){if(!(b===B.y||b===B.N))return!1
-return a.h(0,B.J)||a.h(0,B.T)},
+fw(a,b){if(!(b===B.y||b===B.O))return!1
+return a.h(0,B.K)||a.h(0,B.T)},
 fu(a,b,c){if(c!==B.m)return 0
 if(a!==0)return 0
 if(!b.h(0,B.p))return 0
 if(!b.h(0,B.q))return 0
-if(!b.h(0,B.J))return 0.8
+if(!b.h(0,B.K))return 0.8
 return 2.1},
 ft(a,b,c,d){var t,s=c===B.l
 if(!(s||c===B.r))return 0
@@ -1841,7 +1841,7 @@ this.c=c},
 cj:function cj(){},
 ch:function ch(){},
 ci:function ci(a){this.a=a},
-am:function am(a){this.a=a},
+an:function an(a){this.a=a},
 cV:function cV(a,b){this.a=a
 this.b=b},
 fH(a,b,c,a0){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d=a.length
@@ -1933,7 +1933,7 @@ p=r?s:t
 if(q<100)return o
 if(p>0&&q/p<2)return o
 return r?-1:1},
-es(a){var t=B.bY.u(0,A.i3(a))
+es(a){var t=B.bZ.u(0,A.i3(a))
 return t==null?0:t},
 i3(a){var t,s=a.d
 if(s.a===0)return a.c.b
@@ -1967,7 +1967,7 @@ if(p===d.w)return null
 t=p?b:a
 s=!(p?d:c).a
 r=s&&t.a.c===B.W
-q=s&&t.a.c===B.ad
+q=s&&t.a.c===B.ae
 if(!r&&!q)return null
 if((p?a:b).b+1.3<t.b)return null
 return p?-1:1},
@@ -1976,7 +1976,7 @@ if(q===d.x)return null
 t=q?b:a
 s=!0
 if(!(q?d:c).a){r=t.a
-if(r.c===B.K){s=r.d
+if(r.c===B.L){s=r.d
 s=s.a!==1||!s.h(0,B.x)}}if(s)return null
 if((q?a:b).b+0.3<t.b)return null
 return q?-1:1},
@@ -2018,7 +2018,7 @@ t=p?b:a
 s=p?d:c
 if(!s.a)return q
 r=t.a.c
-if(r!==B.N&&r!==B.O)return q
+if(r!==B.O&&r!==B.P)return q
 if(s.R8===0)return q
 if((p?a:b).b+0.55<t.b)return q
 return p?-1:1},
@@ -2033,7 +2033,7 @@ return q?-1:1},
 iP(a,b,c,d,e){var t,s,r,q=null,p=c.k4
 if(p===d.k4)return q
 t=p?b:a
-s=(p?d:c).a&&t.a.c===B.P
+s=(p?d:c).a&&t.a.c===B.Q
 r=t.a
 if(!s&&r.c!==B.Z)return q
 if(e.b===B.h&&s&&r.a===e.a.e)return q
@@ -2139,7 +2139,7 @@ t=p?d:c
 s=p?a:b
 r=p?b:a
 if(!t.ok)return q
-if(r.a.c!==B.K)return q
+if(r.a.c!==B.L)return q
 if(s.b+0.55<r.b)return q
 return p?-1:1},
 iW(a,b,c,d,e){var t,s,r,q,p,o=null
@@ -2261,14 +2261,14 @@ if(!m&&!l)return null
 return k?-1:1},
 j3(a,b,c,d,e){var t,s=e.L(a.a),r=e.L(b.a)
 if(s==null||r==null)return null
-t=r===B.H
-if(s===B.H===t)return null
+t=r===B.I
+if(s===B.I===t)return null
 return t?1:-1},
 j2(a,b,c,d,e){var t,s=a.a,r=e.L(s),q=e.L(b.a)
 if(r==null||q==null)return null
 if(s.b!==e.a.e)return null
-t=q===B.H
-if(r===B.H===t)return null
+t=q===B.I
+if(r===B.I===t)return null
 return t?1:-1},
 iT(a,b,c,d,e){var t,s,r=d.rx.a,q=c.rx.a,p=B.a.B(r[2],q[2])
 if(p!==0)return p
@@ -2363,7 +2363,7 @@ if(!b.O(r))return!1
 if(!J.U(b.u(0,r),s.b))return!1}return!0},
 fN(a,b,c){var t,s,r
 for(t=new A.a0(a,A.b(a).i("a0<1,2>")).gt(0),s=0;t.k();){r=t.d
-s^=A.aj(r.a,r.b,B.e,B.e,B.e,B.e)}return s},
+s^=A.ak(r.a,r.b,B.e,B.e,B.e,B.e)}return s},
 V(a){switch(a.a){case 11:case 12:case 13:case 14:case 15:case 16:case 17:case 18:case 19:case 20:case 21:case 22:case 23:case 24:case 25:return B.o
 default:return B.b3}},
 aA(a){switch(a.a){case 9:case 10:return!0
@@ -2394,7 +2394,7 @@ case 21:case 22:case 23:return 7}},
 n:function n(a,b){this.a=a
 this.b=b},
 dl(a){var t,s,r,q
-for(t=a.b,s=t===B.h,t=t===B.d,r=0;r<15;++r){q=B.bR[r]
+for(t=a.b,s=t===B.h,t=t===B.d,r=0;r<15;++r){q=B.bS[r]
 if(t&&q.b.A(0,a))return q
 if(s&&q.c.A(0,a))return q}throw A.c(A.e7("No KeySignature found for tonality "+a.j(0)))},
 C:function C(a,b,c){this.a=a
@@ -2412,7 +2412,7 @@ this.b=b},
 i:function i(a,b){this.a=a
 this.b=b},
 hy(a){var t,s
-for(t=0;t<21;++t){s=B.bS[t]
+for(t=0;t<21;++t){s=B.bT[t]
 if(s.c===a)return s}return null},
 x:function x(a,b,c,d,e){var _=this
 _.c=a
@@ -2449,14 +2449,14 @@ break
 case 5:t.$2(4,B.i)
 t.$2(8,B.F)
 break
-case 6:t.$2(2,B.Q)
+case 6:t.$2(2,B.R)
 t.$2(7,B.f)
 break
-case 7:t.$2(5,B.R)
+case 7:t.$2(5,B.S)
 t.$2(7,B.f)
 break
-case 8:t.$2(2,B.Q)
-t.$2(5,B.R)
+case 8:t.$2(2,B.R)
+t.$2(5,B.S)
 t.$2(7,B.f)
 break
 case 9:t.$2(4,B.i)
@@ -2471,11 +2471,11 @@ case 11:t.$2(4,B.i)
 t.$2(7,B.f)
 t.$2(10,B.j)
 break
-case 12:t.$2(2,B.Q)
+case 12:t.$2(2,B.R)
 t.$2(7,B.f)
 t.$2(10,B.j)
 break
-case 13:t.$2(5,B.R)
+case 13:t.$2(5,B.S)
 t.$2(7,B.f)
 t.$2(10,B.j)
 break
@@ -2491,11 +2491,11 @@ case 16:t.$2(4,B.i)
 t.$2(7,B.f)
 t.$2(11,B.G)
 break
-case 17:t.$2(2,B.Q)
+case 17:t.$2(2,B.R)
 t.$2(7,B.f)
 t.$2(11,B.G)
 break
-case 18:t.$2(5,B.R)
+case 18:t.$2(5,B.S)
 t.$2(7,B.f)
 t.$2(11,B.G)
 break
@@ -2532,21 +2532,21 @@ switch((p==null?q.a(p):p).a){case 0:case 11:s.$2(1,B.a7)
 break
 case 1:s.$2(2,B.aJ)
 break
-case 2:s.$2(3,B.ag)
+case 2:s.$2(3,B.ah)
 break
 case 3:s.$2(3,B.aK)
 break
 case 4:s.$2(5,B.aE)
 break
-case 5:s.$2(6,B.ae)
+case 5:s.$2(6,B.af)
 break
 case 6:s.$2(8,B.aF)
 break
 case 7:s.$2(9,B.aG)
 break
-case 8:s.$2(2,B.ah)
+case 8:s.$2(2,B.ai)
 break
-case 9:s.$2(5,B.af)
+case 9:s.$2(5,B.ag)
 break
 case 10:s.$2(9,B.aH)
 break}}return o},
@@ -2559,19 +2559,19 @@ dE(a,b,c,d){var t,s,r,q,p
 if(c!=null)t=B.b.H(b).length===0
 else t=!0
 if(t)return A.bw(a,d)
-s=A.aw(b)
+s=A.ax(b)
 if(0>=s.length)return A.a(s,0)
 r=B.c.P(B.v,s[0].toUpperCase())
 if(r===-1)return A.bw(a,d)
 q=B.v[B.a.m(r+(A.h_(c)-1),7)]
-t=B.a8.u(0,q)
+t=B.a9.u(0,q)
 t.toString
 p=B.a.m(B.a.m(a,12)-t,12)
 if(p>6)p-=12
 if(p<-2||p>2)return A.bw(a,d)
 return q+A.cY(p)},
 dD(a,b){var t,s,r,q,p,o,n,m,l=a.a,k=A.bw(l,b),j=A.er(A.dl(b).a,b.a.d)
-if(new A.h(j,A.b(j).i("h<2>")).h(0,A.aw(k)))return k
+if(new A.h(j,A.b(j).i("h<2>")).h(0,A.ax(k)))return k
 t=A.i2(l)
 for(l=t.length,s=null,r=0;r<t.length;t.length===l||(0,A.Y)(t),++r){q=t[r]
 p=A.j7(a,q,k,b)
@@ -2592,7 +2592,7 @@ er(a,b){var t,s,r,q,p,o,n=B.c.P(B.v,b),m=n===-1?0:n,l=A.en(a),k=u.N,j=J.dV(new A
 for(t=0;t<7;++t)j[t]=B.v[B.a.m(m+t,7)]
 s=A.aH(u.S,k)
 for(k=j.length,r=0;r<k;++r){q=j[r]
-p=B.a8.u(0,q)
+p=B.a9.u(0,q)
 p.toString
 o=l.u(0,q)
 o.toString
@@ -2601,7 +2601,7 @@ jb(a,b,c,d){var t,s,r,q,p,o,n,m,l,k,j,i=A.en(c),h=A.b(b).i("h<2>"),g=new A.d2(A.
 for(h=c<0,t=c>0,s=null,r=0;r<7;++r){q=B.v[r]
 p=i.u(0,q)
 p.toString
-o=B.a8.u(0,q)
+o=B.a9.u(0,q)
 o.toString
 n=B.a.m(a-B.a.m(o+p,12),12)
 if(n>6)n-=12
@@ -2616,7 +2616,7 @@ if(t&&m>0)--k
 if(h&&m<0)--k
 j=new A.cM(l,k)
 if(s==null||k<s.b)s=j}h=s==null?null:s.a
-return h==null?B.bW[B.a.m(a,12)]:h},
+return h==null?B.bX[B.a.m(a,12)]:h},
 cY(a){var t
 A:{t=""
 if(-2===a){t="bb"
@@ -2627,7 +2627,7 @@ break A}if(2===a){t="x"
 break A}break A}return t},
 i2(a){var t,s,r,q,p=B.a.m(a,12),o=A.k([],u.s)
 for(t=0;t<7;++t){s=B.v[t]
-r=B.a8.u(0,s)
+r=B.a9.u(0,s)
 r.toString
 q=B.a.m(p-r,12)
 if(q>6)q-=12
@@ -2637,7 +2637,7 @@ j7(a,b,c,d){var t,s,r,q=b!==c?3:0
 q+=A.eC(b)
 for(t=a.e,t=new A.a0(t,A.b(t).i("a0<1,2>")).gt(0),s=a.a;t.k();){r=t.d
 q+=A.eC(A.dE(B.a.m(s+r.a,12),b,r.b,d))}return q},
-eC(a){var t,s,r,q,p,o,n=A.aw(a)
+eC(a){var t,s,r,q,p,o,n=A.ax(a)
 if(n.length===0)return 1000
 t=B.b.E(n,1)
 for(s=t.split(""),r=s.length,q=0,p=0;p<r;++p){o=s[p]
@@ -2663,37 +2663,37 @@ t=a.d
 if(t.a!==1||!t.h(0,B.p))return!1
 return B.a.m(s-r,12)===2},
 fI(a){var t,s,r,q,p
-if(A.fJ(a))return B.c6
+if(A.fJ(a))return B.c7
 t=a.b
 s=a.a
 if(t===s)return a.d
 r=a.d
 q=A.b(r)
-p=q.i("al<1>")
-return A.e_(new A.al(r,q.i("E(1)").a(new A.cl(B.a.m(t-s,12))),p),p.i("e.E"))},
+p=q.i("am<1>")
+return A.e_(new A.am(r,q.i("E(1)").a(new A.cl(B.a.m(t-s,12))),p),p.i("e.E"))},
 cl:function cl(a){this.a=a},
-fU(a,b,c){var t,s,r,q,p,o,n,m,l,k,j,i,h,g=null,f=b===B.a9?B.bu:B.bv,e=A.fZ(c,f),d=A.aI(a,A.b(a).c)
+fU(a,b,c){var t,s,r,q,p,o,n,m,l,k,j,i,h,g=null,f=b===B.aa?B.bu:B.bv,e=A.fZ(c,f),d=A.aI(a,A.b(a).c)
 B.c.Y(d,new A.cn())
 if(A.aA(c)&&a.h(0,B.D))e+="/9"
 t=a.h(0,B.p)
-s=a.h(0,B.I)
-r=a.h(0,B.J)
-if(A.V(c)===B.o&&A.fQ(f,c))if(r)q=B.J
-else if(s)q=B.I
+s=a.h(0,B.J)
+r=a.h(0,B.K)
+if(A.V(c)===B.o&&A.fQ(f,c))if(r)q=B.K
+else if(s)q=B.J
 else q=t?B.p:g
 else q=g
 if(q!=null){p=A.fS(e,A.dQ(q))
 if(p!==e)e=p
 else q=g}o=A.k([],u._)
 n=A.aA(c)&&B.b.R(e,"/9")
-for(m=d.length,l=q===B.I,k=q===B.J,j=0;j<d.length;d.length===m||(0,A.Y)(d),++j){i=d[j]
+for(m=d.length,l=q===B.J,k=q===B.K,j=0;j<d.length;d.length===m||(0,A.Y)(d),++j){i=d[j]
 if(i===q)continue
 if(n&&i===B.D)continue
-if(k){if(i===B.p||i===B.I)continue}else if(l)if(i===B.p)continue
+if(k){if(i===B.p||i===B.J)continue}else if(l)if(i===B.p)continue
 B.c.l(o,A.fR(i,c))}if(o.length===0)return e
 m=u.Y
 h=A.aI(new A.H(o,u.q.a(new A.co()),m),m.i("I.E"))
-if(A.fT(o,b,c))return e+"("+B.c.I(h,b===B.a9?"":",")+")"
+if(A.fT(o,b,c))return e+"("+B.c.I(h,b===B.aa?"":",")+")"
 return e+B.c.b3(h)},
 fQ(a,b){switch(b.a){case 11:case 12:case 13:case 14:case 15:case 16:case 17:case 18:case 19:case 20:case 21:case 22:case 23:case 24:return!0
 default:return!1}},
@@ -2839,7 +2839,7 @@ t=A.P(t,"x","\ud834\udd2a")
 t=A.P(t,"#","\u266f")
 return A.P(t,"b","\u266d")},
 kr(a){var t,s
-A:{t=new A.aq(B.a0).N(a.a.c)
+A:{t=new A.ar(B.a0).N(a.a.c)
 s=a.b===B.d?"major":"minor"
 s=t+" "+s
 t=s
@@ -2850,7 +2850,7 @@ if(0>=r)return A.a(s,0)
 t=s[0].toUpperCase()
 if(!B.b.h("ABCDEFG",t))return null
 return new A.cS(t,B.b.E(s,1))},
-aq:function aq(a){this.a=a},
+ar:function ar(a){this.a=a},
 cS:function cS(a,b){this.a=a
 this.b=b},
 fa(a){var t
@@ -2861,55 +2861,56 @@ break
 case 2:t="unlikely"
 break
 default:t=null}return t},
-ju(a9,b0,b1){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4=null,a5=A.jB(b0),a6=A.dl(a5),a7=A.kr(a5),a8=A.kj(a9)
-if(a8.length===0)return new A.az(!1,B.S,"",a7,B.ai,B.S,B.bQ)
-t=A.jA(a8)
-s=t.b
-if(s.length===0){s=A.k([],u.s)
+ju(a9,b0,b1){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3=null,a4=A.jB(b0),a5=A.dl(a4),a6=A.kr(a4),a7=A.kj(a9),a8=a7.length
+if(a8===0)return new A.ae(!1,B.H,"",a6,B.a8,B.H,B.bR)
+if(a8>128)return new A.ae(!1,B.H,"",a6,B.a8,B.H,B.bQ)
+t=A.jA(a7)
+a8=t.b
+if(a8.length===0){a8=A.k([],u.s)
+s=t.e
+if(s.length===0)a8.push("Could not parse any notes.")
+else{r=A.O(s)
+a8.push("Not a note: "+new A.H(s,r.i("d(1)").a(A.eF()),r.i("H<1,d>")).I(0,", ")+". Use note names like C, F#, Bb, or MIDI numbers 0-127.")}return new A.ae(!1,B.H,"",a6,B.a8,B.H,a8)}s=A.k([],u.s)
 r=t.e
-if(r.length===0)s.push("Could not parse any notes.")
-else{q=A.O(r)
-s.push("Not a note: "+new A.H(r,q.i("d(1)").a(A.eF()),q.i("H<1,d>")).I(0,", ")+". Use note names like C, F#, Bb, or MIDI numbers 0-127.")}return new A.az(!1,B.S,"",a7,B.ai,B.S,s)}r=A.k([],u.s)
-q=t.e
-if(q.length!==0){p=A.O(q)
-r.push("Ignored: "+new A.H(q,p.i("d(1)").a(A.eF()),p.i("H<1,d>")).I(0,", ")+".")}o=t.a
-n=o.length!==0?B.a.m(B.c.b5(o,new A.d3()),12):B.c.gS(s)
-q=A.eD(s)
-p=B.a.X(1,n)
-m=A.eD(s)
-l=o.length
-s=l!==0?l:s.length
-m=(m&p)>>>0===0?1:0
-k=A.jv(t,a5)
-j=t.c.u(0,n)
-l=j!=null?A.aw(j):A.bw(n,a5)
-i=new A.aq(B.a0).N(l)
-h=A.fE(new A.bH((q|p)>>>0,n,s+m),new A.bB(a5,a6,new A.cD(a6.a<0)),5)
-if(h.length===0)return new A.az(!0,k,i,a7,B.ai,r,B.S)
-g=B.c.gS(h).b
-f=A.k([],u.U)
-for(e=0;e<h.length;){d=h[e]
-if(e===0)c=B.aZ
-else c=g-d.b<=0.2?B.b_:B.b0;++e
-s=d.a
-b=A.dD(s,a5)
-q=s.b
-p=s.a
-a=q!==p?A.dE(q,b,s.e.u(0,B.a.m(q-p,12)),a5):a4
-a0=A.fU(A.fI(s),b1,s.c)
-a1=a==null?a4:B.b.H(a)
-a2=a1==null||a1.length===0?a4:a1
-a3=new A.aq(B.a0)
-q=A.P(a0,"bb","\ud834\udd2b")
-q=A.P(q,"x","\ud834\udd2a")
-q=A.P(q,"#","\u266f")
-a0=A.P(q,"b","\u266d")
-q=a3.N(b)
-p=a2!=null?a3.N(a2):a4
-q+=a0
-q=p==null?q:q+" / "+p
-p=d.b
-B.c.l(f,new A.bF(e,q,A.ja(s,a5),p,p-g,c))}return new A.az(!0,k,i,a7,f,r,B.S)},
+if(r.length!==0){q=A.O(r)
+s.push("Ignored: "+new A.H(r,q.i("d(1)").a(A.eF()),q.i("H<1,d>")).I(0,", ")+".")}p=t.a
+o=p.length!==0?B.a.m(B.c.b5(p,new A.d3()),12):B.c.gS(a8)
+r=A.eD(a8)
+q=B.a.X(1,o)
+n=A.eD(a8)
+m=p.length
+a8=m!==0?m:a8.length
+n=(n&q)>>>0===0?1:0
+l=A.jv(t,a4)
+k=t.c.u(0,o)
+m=k!=null?A.ax(k):A.bw(o,a4)
+j=new A.ar(B.a0).N(m)
+i=A.fE(new A.bH((r|q)>>>0,o,a8+n),new A.bB(a4,a5,new A.cD(a5.a<0)),5)
+if(i.length===0)return new A.ae(!0,l,j,a6,B.a8,s,B.H)
+h=B.c.gS(i).b
+g=A.k([],u.U)
+for(f=0;f<i.length;){e=i[f]
+if(f===0)d=B.aZ
+else d=h-e.b<=0.2?B.b_:B.b0;++f
+a8=e.a
+c=A.dD(a8,a4)
+r=a8.b
+q=a8.a
+b=r!==q?A.dE(r,c,a8.e.u(0,B.a.m(r-q,12)),a4):a3
+a=A.fU(A.fI(a8),b1,a8.c)
+a0=b==null?a3:B.b.H(b)
+a1=a0==null||a0.length===0?a3:a0
+a2=new A.ar(B.a0)
+r=A.P(a,"bb","\ud834\udd2b")
+r=A.P(r,"x","\ud834\udd2a")
+r=A.P(r,"#","\u266f")
+a=A.P(r,"b","\u266d")
+r=a2.N(c)
+q=a1!=null?a2.N(a1):a3
+r+=a
+r=q==null?r:r+" / "+q
+q=e.b
+B.c.l(g,new A.bF(f,r,A.ja(a8,a4),q,q-h,d))}return new A.ae(!0,l,j,a6,g,s,B.H)},
 kj(a){var t=B.b.aE(a,A.e3("[\\s,]+")),s=A.O(t),r=s.i("H<1,d>")
 r=new A.H(t,s.i("d(1)").a(new A.d6()),r).aF(0,r.i("E(I.E)").a(new A.d7()))
 t=A.aI(r,r.$ti.i("e.E"))
@@ -2926,12 +2927,12 @@ o=null}if(o!=null){n=o.toLowerCase()
 m=n==="min"||n==="minor"?B.h:B.d}else{l=t.toLowerCase()
 k=0
 for(;;){if(!(k<4)){m=B.d
-break}A:{j=B.bV[k]
+break}A:{j=B.bW[k]
 if(!B.b.R(l,j))break A
 m=B.b.a4(j,"min")?B.h:B.d
 t=J.f7(t,0,J.bz(t)-j.length)
 break}++k}}s=null
-try{i=A.hy(A.aw(t))
+try{i=A.hy(A.ax(t))
 s=i==null?B.a2:i}catch(h){if(A.dF(h) instanceof A.Q)s=B.a2
 else throw h}return new A.i(s,m)},
 jA(a){var t,s,r,q,p,o,n=u.t,m=A.k([],n),l=A.k([],n),k=A.aH(u.S,u.N),j=A.k([],u.k),i=A.k([],u.s)
@@ -2952,17 +2953,17 @@ jv(a,b){var t,s,r,q,p,o=A.dZ(u.S),n=A.k([],u.s)
 for(t=a.d,s=t.length,r=0;r<t.length;t.length===s||(0,A.Y)(t),++r){q=t[r]
 p=q.a
 if(p==null||o.l(0,p)){p=q.b
-p=p!=null?A.aw(p):A.bw(q.c,b)
-n.push(new A.aq(B.a0).N(p))}}return n},
+p=p!=null?A.ax(p):A.bw(q.c,b)
+n.push(new A.ar(B.a0).N(p))}}return n},
 ja(a,b){var t,s,r,q,p,o,n=A.dD(a,b),m=A.aH(u.S,u.u)
 m.q(0,0,B.n)
 m.ad(0,a.e)
-t=m.$ti.i("ah<1>")
-s=A.aI(new A.ah(m,t),t.i("e.E"))
+t=m.$ti.i("ai<1>")
+s=A.aI(new A.ai(m,t),t.i("e.E"))
 B.c.aD(s)
 t=A.k([],u.s)
 for(r=s.length,q=a.a,p=0;p<s.length;s.length===r||(0,A.Y)(s),++p){o=s[p]
-t.push(new A.aq(B.a0).N(A.dE(B.a.m(q+o,12),n,m.u(0,o),b)))}return B.c.I(t," ")},
+t.push(new A.ar(B.a0).N(A.dE(B.a.m(q+o,12),n,m.u(0,o),b)))}return B.c.I(t," ")},
 eD(a){var t,s,r
 for(t=a.length,s=0,r=0;r<t;++r)s=(s|B.a.X(1,B.a.m(a[r],12)))>>>0
 return s},
@@ -2976,7 +2977,7 @@ _.c=c
 _.d=d
 _.e=e
 _.f=f},
-az:function az(a,b,c,d,e,f,g){var _=this
+ae:function ae(a,b,c,d,e,f,g){var _=this
 _.a=a
 _.b=b
 _.c=c
@@ -3008,7 +3009,7 @@ if(e>=3)return a.$3(b,c,d)
 if(e===2)return a.$2(b,c)
 if(e===1)return a.$1(b)
 return a.$0()},
-aw(a){var t,s,r,q,p,o,n="name",m=B.b.H(a)
+ax(a){var t,s,r,q,p,o,n="name",m=B.b.H(a)
 if(m.length===0)throw A.c(A.bC(a,n,"Empty note name"))
 t=A.P(m,"\ud834\udd2a","x")
 t=A.P(t,"\ud834\udd2b","bb")
@@ -3016,7 +3017,7 @@ t=A.P(t,"\u266f","#")
 s=A.P(t,"\u266d","b")
 if(0>=s.length)return A.a(s,0)
 r=s[0].toUpperCase()
-if(!B.c2.h(0,r))throw A.c(A.bC(a,n,"Invalid note letter"))
+if(!B.c3.h(0,r))throw A.c(A.bC(a,n,"Invalid note letter"))
 q=B.b.E(s,1)
 if(q.length===0)return r
 if(q==="##")q="x"
@@ -3034,7 +3035,7 @@ break A}if(2===o){t="x"
 break A}break A}return r+t},
 aU(a,b){var t=B.a.m(a-b,12)
 return t},
-jC(a){var t,s,r,q,p,o,n,m=A.aw(a)
+jC(a){var t,s,r,q,p,o,n,m=A.ax(a)
 if(0>=m.length)return A.a(m,0)
 t=m[0]
 A:{if("C"===t){s=0
@@ -3079,7 +3080,7 @@ A.hw(h,f)
 A.hs(h,f)
 return new A.cH(h,f)},
 hp(a,b,c){var t,s=B.a.m(b-a.a.e,12)
-switch(c.a){case 0:A:{if(0===s){t=B.H
+switch(c.a){case 0:A:{if(0===s){t=B.I
 break A}if(2===s){t=B.al
 break A}if(4===s){t=B.am
 break A}if(5===s){t=B.an
@@ -3088,7 +3089,7 @@ break A}if(9===s){t=B.ap
 break A}if(11===s){t=B.aq
 break A}t=null
 break A}return t
-case 1:B:{if(0===s){t=B.H
+case 1:B:{if(0===s){t=B.I
 break B}if(2===s){t=B.al
 break B}if(3===s){t=B.am
 break B}if(5===s){t=B.an
@@ -3097,7 +3098,7 @@ break B}if(8===s){t=B.ap
 break B}if(10===s){t=B.aq
 break B}t=null
 break B}return t
-case 2:C:{if(0===s){t=B.H
+case 2:C:{if(0===s){t=B.I
 break C}if(2===s){t=B.al
 break C}if(3===s){t=B.am
 break C}if(5===s){t=B.an
@@ -3111,7 +3112,7 @@ if(r==null)return!0
 t=B.c.P(B.v,a.a.d)
 s=t<0?0:t
 return r===B.v[B.a.m(s+c.a,7)]},
-ht(a){var t,s=A.aw(a),r=s.length
+ht(a){var t,s=A.ax(a),r=s.length
 if(r===0)return null
 if(0>=r)return A.a(s,0)
 t=s[0].toUpperCase()
@@ -3135,50 +3136,50 @@ if(!A.e5(a,q,d))return!1}return!0},
 hm(a,b){var t
 switch(a.a){case 0:switch(b.a){case 0:t=B.a1
 break
-case 1:t=B.L
+case 1:t=B.M
 break
-case 2:t=B.L
+case 2:t=B.M
 break
 case 3:t=B.a1
 break
 case 4:t=B.aO
 break
-case 5:t=B.L
+case 5:t=B.M
 break
 case 6:t=B.ar
 break
 default:t=null}return t
-case 1:switch(b.a){case 0:t=B.L
+case 1:switch(b.a){case 0:t=B.M
 break
 case 1:t=B.ar
 break
 case 2:t=B.a1
 break
-case 3:t=B.L
+case 3:t=B.M
 break
-case 4:t=B.L
+case 4:t=B.M
 break
 case 5:t=B.a1
 break
 case 6:t=B.aO
 break
 default:t=null}return t
-case 2:switch(b.a){case 0:t=B.c5
+case 2:switch(b.a){case 0:t=B.c6
 break
 case 1:t=B.ar
 break
-case 2:t=B.c4
+case 2:t=B.c5
 break
-case 3:t=B.L
+case 3:t=B.M
 break
-case 4:t=B.c3
+case 4:t=B.c4
 break
 case 5:t=B.a1
 break
-case 6:t=B.c7
+case 6:t=B.c8
 break
 default:t=null}return t}},
-hv(a){if(a.b===B.d)return B.bT
+hv(a){if(a.b===B.d)return B.bU
 return B.bP},
 e5(a,b,c){var t,s=B.a.m(b-a.a.e,12)
 switch(c.a){case 0:A:{t=0===s||2===s||4===s||5===s||7===s||9===s||11===s
@@ -3230,11 +3231,11 @@ break A}if(B.y===b){t=a+"7b5"
 break A}if(B.z===b){t=a+"7#5"
 break A}if(B.Y===b){t=a+"#5"
 break A}if(B.a4===b){t=a+"maj7"
-break A}if(B.N===b){t=a+"maj7b5"
-break A}if(B.O===b){t=a+"maj7#5"
+break A}if(B.O===b){t=a+"maj7b5"
+break A}if(B.P===b){t=a+"maj7#5"
 break A}if(B.A===b){t=a+"7"
-break A}if(B.K===b){t=a+"7#5"
-break A}if(B.P===b){t=a+"(maj7)"
+break A}if(B.L===b){t=a+"7#5"
+break A}if(B.Q===b){t=a+"(maj7)"
 break A}if(B.X===b){t=(B.b.R(a,"\xb0")?B.b.C(a,0,a.length-1):a)+"\xf87"
 break A}if(B.E===b){t=a+"7"
 break A}t=a
@@ -3246,11 +3247,11 @@ J.bS.prototype={
 A(a,b){return a===b},
 gv(a){return A.bd(a)},
 j(a){return"Instance of '"+A.c_(a)+"'"},
-gJ(a){return A.at(A.dw(this))}}
+gJ(a){return A.au(A.dw(this))}}
 J.bU.prototype={
 j(a){return String(a)},
 gv(a){return a?519018:218159},
-gJ(a){return A.at(u.y)},
+gJ(a){return A.au(u.y)},
 $ia4:1,
 $iE:1}
 J.b3.prototype={
@@ -3269,7 +3270,7 @@ j(a){var t=a[$.eP()]
 if(t==null)t=a[$.dG()]
 if(t==null)return this.aG(a)
 return"JavaScript function for "+J.bA(t)},
-$iaf:1}
+$iag:1}
 J.j.prototype={
 l(a,b){A.O(a).c.a(b)
 a.$flags&1&&A.d8(a,29)
@@ -3359,12 +3360,12 @@ return 1}return 0}else if(isNaN(a)){if(isNaN(b))return 0
 return 1}else return-1},
 ga0(a){return a===0?1/a<0:a<0},
 K(a,b){var t
-if(b>20)throw A.c(A.ak(b,0,20,"fractionDigits",null))
+if(b>20)throw A.c(A.al(b,0,20,"fractionDigits",null))
 t=a.toFixed(b)
 if(a===0&&this.ga0(a))return"-"+t
 return t},
 b7(a,b){var t,s,r,q,p
-if(b<2||b>36)throw A.c(A.ak(b,2,36,"radix",null))
+if(b<2||b>36)throw A.c(A.al(b,2,36,"radix",null))
 t=a.toString(b)
 s=t.length
 r=s-1
@@ -3401,20 +3402,20 @@ if(a>0)t=this.aV(a,b)
 else{t=b>31?31:b
 t=a>>t>>>0}return t},
 aV(a,b){return b>31?0:a>>>b},
-gJ(a){return A.at(u.H)},
+gJ(a){return A.au(u.H)},
 $ia_:1,
 $iad:1,
 $iJ:1}
 J.b2.prototype={
-gJ(a){return A.at(u.S)},
+gJ(a){return A.au(u.S)},
 $ia4:1,
 $ir:1}
 J.bV.prototype={
-gJ(a){return A.at(u.i)},
+gJ(a){return A.au(u.i)},
 $ia4:1}
 J.a8.prototype={
 ae(a,b,c){var t=b.length
-if(c>t)throw A.c(A.ak(c,0,t,null,null))
+if(c>t)throw A.c(A.al(c,0,t,null,null))
 return new A.cc(b,a,c)},
 au(a,b){return this.ae(a,b,0)},
 R(a,b){var t=b.length,s=a.length
@@ -3474,7 +3475,7 @@ s=s+((s&524287)<<10)&536870911
 s^=s>>6}s=s+((s&67108863)<<3)&536870911
 s^=s>>11
 return s+((s&16383)<<15)&536870911},
-gJ(a){return A.at(u.N)},
+gJ(a){return A.au(u.N)},
 gp(a){return a.length},
 $ia4:1,
 $ia_:1,
@@ -3524,7 +3525,7 @@ $iy:1}
 A.H.prototype={
 gp(a){return J.bz(this.a)},
 G(a,b){return this.b.$1(J.f5(this.a,b))}}
-A.al.prototype={
+A.am.prototype={
 gt(a){return new A.bo(J.da(this.a),this.b,this.$ti.i("bo<1>"))}}
 A.bo.prototype={
 k(){var t,s
@@ -3553,7 +3554,7 @@ this.$ti.i("~(1,2)").a(b)
 t=this.gaS()
 s=this.b
 for(r=t.length,q=0;q<r;++q)b.$2(t[q],s[q])}}
-A.an.prototype={
+A.ao.prototype={
 gn(){var t=this.d
 return t==null?this.$ti.c.a(t):t},
 k(){var t=this,s=t.c
@@ -3565,19 +3566,19 @@ $iy:1}
 A.aB.prototype={
 l(a,b){A.b(this).c.a(b)
 A.h6()}}
-A.ae.prototype={
+A.af.prototype={
 gp(a){return this.b},
 gt(a){var t,s=this,r=s.$keys
 if(r==null){r=Object.keys(s.a)
 s.$keys=r}t=r
-return new A.an(t,t.length,s.$ti.i("an<1>"))},
+return new A.ao(t,t.length,s.$ti.i("ao<1>"))},
 h(a,b){if(typeof b!="string")return!1
 if("__proto__"===b)return!1
 return this.a.hasOwnProperty(b)}}
 A.M.prototype={
 gp(a){return this.a.length},
 gt(a){var t=this.a
-return new A.an(t,t.length,this.$ti.i("an<1>"))},
+return new A.ao(t,t.length,this.$ti.i("ao<1>"))},
 aR(){var t,s,r,q,p=this,o=p.$map
 if(o==null){o=new A.b5(p.$ti.i("b5<1,1>"))
 for(t=p.a,s=t.length,r=0;r<t.length;t.length===s||(0,A.Y)(t),++r){q=t[r]
@@ -3615,7 +3616,7 @@ j(a){return"Throw of null ('"+(this.a===null?"null":"undefined")+"' from JavaScr
 A.a7.prototype={
 j(a){var t=this.constructor,s=t==null?null:t.name
 return"Closure '"+A.eN(s==null?"unknown":s)+"'"},
-$iaf:1,
+$iag:1,
 gbc(){return this},
 $C:"$1",
 $R:1,
@@ -3627,10 +3628,10 @@ A.c1.prototype={
 j(a){var t=this.$static_name
 if(t==null)return"Closure of unknown static method"
 return"Closure '"+A.eN(t)+"'"}}
-A.ay.prototype={
+A.az.prototype={
 A(a,b){if(b==null)return!1
 if(this===b)return!0
-if(!(b instanceof A.ay))return!1
+if(!(b instanceof A.az))return!1
 return this.$_target===b.$_target&&this.a===b.a},
 gv(a){return(A.dC(this.a)^A.bd(this.$_target))>>>0},
 j(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.c_(this.a)+"'")}}
@@ -3753,11 +3754,11 @@ $2(a,b){var t=this.a,s=A.b(t)
 t.q(0,s.c.a(a),s.y[1].a(b))},
 $S(){return A.b(this.a).i("~(1,2)")}}
 A.cy.prototype={}
-A.ah.prototype={
+A.ai.prototype={
 gp(a){return this.a.a},
 gt(a){var t=this.a
-return new A.ag(t,t.r,t.e,this.$ti.i("ag<1>"))}}
-A.ag.prototype={
+return new A.ah(t,t.r,t.e,this.$ti.i("ah<1>"))}}
+A.ah.prototype={
 gn(){return this.d},
 k(){var t,s=this,r=s.a
 if(s.b!==r.r)throw A.c(A.W(r))
@@ -3793,7 +3794,7 @@ k(){var t,s=this,r=s.a
 if(s.b!==r.r)throw A.c(A.W(r))
 t=s.c
 if(t==null){s.d=null
-return!1}else{s.d=new A.ai(t.a,t.b,s.$ti.i("ai<1,2>"))
+return!1}else{s.d=new A.aj(t.a,t.b,s.$ti.i("aj<1,2>"))
 s.c=t.c
 return!0}},
 $iy:1}
@@ -3833,12 +3834,12 @@ A(a,b){var t=this
 if(b==null)return!1
 return b instanceof A.aQ&&t.$s===b.$s&&J.U(t.a,b.a)&&J.U(t.b,b.b)&&J.U(t.c,b.c)},
 gv(a){var t=this
-return A.aj(t.$s,t.a,t.b,t.c,B.e,B.e)}}
+return A.ak(t.$s,t.a,t.b,t.c,B.e,B.e)}}
 A.aR.prototype={
 aa(){return this.a},
 A(a,b){if(b==null)return!1
 return b instanceof A.aR&&this.$s===b.$s&&A.hI(this.a,b.a)},
-gv(a){return A.aj(this.$s,A.hf(this.a),B.e,B.e,B.e,B.e)}}
+gv(a){return A.ak(this.$s,A.hf(this.a),B.e,B.e,B.e,B.e)}}
 A.aF.prototype={
 j(a){return"RegExp/"+this.a+"/"+this.b.flags},
 gan(){var t=this,s=t.c
@@ -3850,7 +3851,7 @@ if(!B.b.h(s,"("))return!1
 t=this.b.unicode?"u":""
 return new RegExp("(?:)|"+s,t).exec("").length>1},
 ae(a,b,c){var t=b.length
-if(c>t)throw A.c(A.ak(c,0,t,null,null))
+if(c>t)throw A.c(A.al(c,0,t,null,null))
 return new A.c6(this,b,c)},
 au(a,b){return this.ae(0,b,0)},
 aN(a,b){var t,s=this.gan()
@@ -3920,8 +3921,8 @@ j(a){return A.K(this.a,null)}}
 A.c8.prototype={
 j(a){return this.a}}
 A.br.prototype={}
-A.ao.prototype={
-gt(a){var t=this,s=new A.ap(t,t.r,A.b(t).i("ap<1>"))
+A.ap.prototype={
+gt(a){var t=this,s=new A.aq(t,t.r,A.b(t).i("aq<1>"))
 s.c=t.e
 return s},
 gp(a){return this.a},
@@ -3964,7 +3965,7 @@ t=a.length
 for(s=0;s<t;++s)if(J.U(a[s].a,b))return s
 return-1}}
 A.ca.prototype={}
-A.ap.prototype={
+A.aq.prototype={
 gn(){var t=this.d
 return t==null?this.$ti.c.a(t):t},
 k(){var t=this,s=t.c,r=t.a
@@ -3977,7 +3978,7 @@ $iy:1}
 A.aJ.prototype={
 T(a,b){var t,s,r,q=this,p=A.b(q)
 p.i("~(1,2)").a(b)
-for(t=new A.ag(q,q.r,q.e,p.i("ag<1>")),p=p.y[1];t.k();){s=t.d
+for(t=new A.ah(q,q.r,q.e,p.i("ah<1>")),p=p.y[1];t.k();){s=t.d
 r=q.u(0,s)
 b.$2(s,r==null?p.a(r):r)}},
 gp(a){return this.a},
@@ -4202,7 +4203,7 @@ if(r.length>78)r=B.b.C(r,0,75)+"..."
 return s+"\n"+r}}
 A.e.prototype={
 b9(a,b){var t=A.b(this)
-return new A.al(this,t.i("E(e.E)").a(b),t.i("al<e.E>"))},
+return new A.am(this,t.i("E(e.E)").a(b),t.i("am<e.E>"))},
 h(a,b){var t
 for(t=this.gt(this);t.k();)if(J.U(t.gn(),b))return!0
 return!1},
@@ -4217,7 +4218,7 @@ A.dq(b,"index")
 t=this.gt(this)
 for(s=b;t.k();){if(s===0)return t.gn();--s}throw A.c(A.dh(b,b-s,this,"index"))},
 j(a){return A.h7(this,"(",")")}}
-A.ai.prototype={
+A.aj.prototype={
 j(a){return"MapEntry("+A.q(this.a)+": "+A.q(this.b)+")"}}
 A.bb.prototype={
 gv(a){return A.o.prototype.gv.call(this,0)},
@@ -4268,7 +4269,7 @@ $3$detail(a,b,c){var t=this.a
 if(t!=null)B.c.l(t,new A.cI(a,b,c))},
 $2(a,b){return this.$3$detail(a,b,null)},
 $S:11}
-A.am.prototype={}
+A.an.prototype={}
 A.cV.prototype={}
 A.aL.prototype={}
 A.ck.prototype={
@@ -4299,12 +4300,12 @@ A.ba.prototype={}
 A.d0.prototype={
 $2(a,b){var t,s,r=!0
 if(b.a){t=a.a
-if(t.c===B.P){r=t.d
+if(t.c===B.Q){r=t.d
 r=r.a!==1||!r.h(0,B.C)}}if(r)return!1
 r=a.a
 s=A.e6(this.a,r,r.f,!0,null,!0)
 r=s==null
-if((r?null:s.a)===B.H){t=(r?null:s.b)===B.aN
+if((r?null:s.a)===B.I){t=(r?null:s.b)===B.aN
 r=t}else r=!1
 return r},
 $S:7}
@@ -4320,7 +4321,7 @@ if(b==null)return!1
 if(s!==b)t=b instanceof A.bB&&s.a.A(0,b.a)&&s.b.a===b.b.a&&s.c.a===b.c.a
 else t=!0
 return t},
-gv(a){return A.aj(this.a,this.b.a,this.c.a,B.e,B.e,B.e)}}
+gv(a){return A.ak(this.a,this.b.a,this.c.a,B.e,B.e,B.e)}}
 A.G.prototype={
 j(a){return"ChordCandidate(score="+A.q(this.b)+", "+this.a.j(0)+")"}}
 A.p.prototype={
@@ -4334,7 +4335,7 @@ if(s!==b)t=b instanceof A.bG&&b.a===s.a&&b.b===s.b&&b.c===s.c&&A.fO(b.d,s.d,u.G)
 else t=!0
 return t},
 gv(a){var t=this
-return A.aj(t.a,t.b,t.c,A.fP(t.d,u.G),A.fN(t.e,u.S,u.u),t.f)}}
+return A.ak(t.a,t.b,t.c,A.fP(t.d,u.G),A.fN(t.e,u.S,u.u),t.f)}}
 A.l.prototype={
 D(){return"ChordQualityToken."+this.b}}
 A.bJ.prototype={
@@ -4346,7 +4347,7 @@ if(b==null)return!1
 if(s!==b)t=b instanceof A.bH&&b.a===s.a&&b.b===s.b&&b.c===s.c
 else t=!0
 return t},
-gv(a){return A.aj(this.a,this.b,this.c,B.e,B.e,B.e)}}
+gv(a){return A.ak(this.a,this.b,this.c,B.e,B.e,B.e)}}
 A.n.prototype={
 D(){return"ChordToneRole."+this.b}}
 A.C.prototype={}
@@ -4461,7 +4462,7 @@ if(b==null)return!1
 if(this!==b)t=b instanceof A.i&&b.a===this.a&&b.b===this.b
 else t=!0
 return t},
-gv(a){return A.aj(this.a,this.b,B.e,B.e,B.e,B.e)},
+gv(a){return A.ak(this.a,this.b,B.e,B.e,B.e,B.e)},
 j(a){var t=this.a.c
 return this.b===B.d?t+" major":t+" minor"}}
 A.x.prototype={
@@ -4509,7 +4510,7 @@ $1(a){return A.dQ(u.G.a(a))},
 $S:6}
 A.bK.prototype={
 D(){return"ChordQualityLabelForm."+this.b}}
-A.aq.prototype={
+A.ar.prototype={
 N(a){var t,s,r=A.hB(a)
 if(r==null)return A.d9(a)
 t=A.d9(r.b)
@@ -4556,7 +4557,7 @@ D(){return"CandidateClass."+this.b}}
 A.bF.prototype={
 a1(){var t=this
 return A.dn(["rank",t.a,"symbol",t.b,"notes",t.c,"score",A.eI(B.u.K(t.d,2)),"deltaBest",A.eI(B.u.K(t.e,2)),"class",A.fa(t.f)],u.N,u.X)}}
-A.az.prototype={
+A.ae.prototype={
 a1(){var t,s,r,q=this,p=u.N,o=u.X,n=A.dn(["notes",q.b,"bass",q.c,"key",q.d],p,o),m=A.k([],u.d)
 for(t=q.e,s=t.length,r=0;r<t.length;t.length===s||(0,A.Y)(t),++r)m.push(t[r].a1())
 return A.dn(["ok",q.a,"input",n,"candidates",m,"warnings",q.f,"errors",q.r],p,o)}}
@@ -4578,7 +4579,7 @@ $S:13}
 A.d4.prototype={
 $3(a,b,c){A.T(a)
 A.T(b)
-return B.aX.aY(A.ju(a,b,A.T(c)==="symbolic"?B.a9:B.b2).a1(),null)},
+return B.aX.aY(A.ju(a,b,A.T(c)==="symbolic"?B.aa:B.b2).a1(),null)},
 $S:14};(function aliases(){var t=J.a9.prototype
 t.aG=t.j
 t=A.e.prototype
@@ -4629,7 +4630,7 @@ r(A,"k0",5,null,["$5"],["iO"],0,0)
 r(A,"jE",5,null,["$5"],["i0"],0,0)
 s(A,"eF","j5",10)})();(function inheritance(){var t=hunkHelpers.inherit,s=hunkHelpers.inheritMany
 t(A.o,null)
-s(A.o,[A.dj,J.bS,A.bg,J.aY,A.w,A.cJ,A.e,A.b9,A.bo,A.X,A.b0,A.an,A.a3,A.cK,A.cE,A.a7,A.aJ,A.cy,A.ag,A.b8,A.b7,A.aF,A.cb,A.c7,A.c2,A.cd,A.S,A.c9,A.ce,A.ca,A.ap,A.bN,A.bP,A.cQ,A.cN,A.bZ,A.bi,A.cO,A.cs,A.ai,A.bb,A.aM,A.aO,A.Z,A.cI,A.am,A.cV,A.aL,A.b_,A.ba,A.bB,A.G,A.bG,A.bH,A.C,A.cD,A.cH,A.i,A.m,A.cM,A.cU,A.dg,A.aq,A.cS,A.bF,A.az,A.cC])
+s(A.o,[A.dj,J.bS,A.bg,J.aY,A.w,A.cJ,A.e,A.b9,A.bo,A.X,A.b0,A.ao,A.a3,A.cK,A.cE,A.a7,A.aJ,A.cy,A.ah,A.b8,A.b7,A.aF,A.cb,A.c7,A.c2,A.cd,A.S,A.c9,A.ce,A.ca,A.aq,A.bN,A.bP,A.cQ,A.cN,A.bZ,A.bi,A.cO,A.cs,A.aj,A.bb,A.aM,A.aO,A.Z,A.cI,A.an,A.cV,A.aL,A.b_,A.ba,A.bB,A.G,A.bG,A.bH,A.C,A.cD,A.cH,A.i,A.m,A.cM,A.cU,A.dg,A.ar,A.cS,A.bF,A.ae,A.cC])
 s(J.bS,[J.bU,J.b3,J.aG,J.aD,J.a8])
 s(J.aG,[J.a9,J.j])
 s(J.a9,[J.cG,J.a6,J.b4])
@@ -4637,23 +4638,23 @@ t(J.bT,A.bg)
 t(J.cu,J.j)
 s(J.aD,[J.b2,J.bV])
 s(A.w,[A.bY,A.bm,A.bW,A.c5,A.c0,A.c8,A.b6,A.bD,A.Q,A.bn,A.bj,A.bO])
-s(A.e,[A.b1,A.al,A.c6,A.cc])
-s(A.b1,[A.I,A.ah,A.h,A.a0])
+s(A.e,[A.b1,A.am,A.c6,A.cc])
+s(A.b1,[A.I,A.ai,A.h,A.a0])
 s(A.I,[A.bk,A.H])
 s(A.X,[A.aQ,A.aR])
 t(A.aS,A.aQ)
 t(A.bp,A.aR)
 t(A.aC,A.b0)
 s(A.a3,[A.aB,A.bq])
-s(A.aB,[A.ae,A.M])
+s(A.aB,[A.af,A.M])
 t(A.bc,A.bm)
 s(A.a7,[A.bL,A.bM,A.c3,A.cg,A.cj,A.ch,A.ci,A.d_,A.cr,A.d2,A.cl,A.co,A.d6,A.d7,A.d4])
-s(A.c3,[A.c1,A.ay])
+s(A.c3,[A.c1,A.az])
 t(A.R,A.aJ)
 s(A.bM,[A.cv,A.cA,A.cR,A.ck,A.cZ,A.d0,A.d1,A.cp,A.cq,A.cn,A.d3])
 t(A.b5,A.R)
 t(A.br,A.c8)
-t(A.ao,A.bq)
+t(A.ap,A.bq)
 t(A.bX,A.b6)
 t(A.cw,A.bN)
 t(A.cx,A.bP)
@@ -4661,11 +4662,11 @@ t(A.cP,A.cQ)
 s(A.Q,[A.be,A.bR])
 s(A.cN,[A.p,A.l,A.bJ,A.n,A.a2,A.aN,A.c4,A.x,A.bI,A.cB,A.bK,A.aZ])
 t(A.d5,A.bL)})()
-var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{r:"int",ad:"double",J:"num",d:"String",E:"bool",bb:"Null",aa:"List",o:"Object",a1:"Map",aE:"JSObject"},mangledNames:{},types:["r?(G,G,Z,Z,i)","~(o?,o?)","E(p)","G(am)","r(r,r)","r(p,p)","d(p)","E(G,Z)","~(r,n)","E(d)","d(d)","~(d,ad{detail:d?})","E(r)","d()","d(d,d,d)","r(@,@)","@(@)"],arrayRti:Symbol("$ti"),rttc:{"3;midi,name,pc":(a,b,c)=>d=>d instanceof A.aS&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"4;addCount,alterationCount,naturalCount,totalCount":a=>b=>b instanceof A.bp&&A.jz(a,b.a)}}
-A.hP(v.typeUniverse,JSON.parse('{"b4":"a9","cG":"a9","a6":"a9","bU":{"E":[],"a4":[]},"b3":{"a4":[]},"aG":{"aE":[]},"a9":{"aE":[]},"j":{"aa":["1"],"aE":[],"e":["1"]},"bT":{"bg":[]},"cu":{"j":["1"],"aa":["1"],"aE":[],"e":["1"]},"aY":{"y":["1"]},"aD":{"ad":[],"J":[],"a_":["J"]},"b2":{"ad":[],"r":[],"J":[],"a_":["J"],"a4":[]},"bV":{"ad":[],"J":[],"a_":["J"],"a4":[]},"a8":{"d":[],"a_":["d"],"cF":[],"a4":[]},"bY":{"w":[]},"b1":{"e":["1"]},"I":{"e":["1"]},"bk":{"I":["1"],"e":["1"],"I.E":"1","e.E":"1"},"b9":{"y":["1"]},"H":{"I":["2"],"e":["2"],"I.E":"2","e.E":"2"},"al":{"e":["1"],"e.E":"1"},"bo":{"y":["1"]},"aS":{"aQ":[],"X":[]},"bp":{"aR":[],"X":[]},"b0":{"a1":["1","2"]},"aC":{"b0":["1","2"],"a1":["1","2"]},"an":{"y":["1"]},"aB":{"a3":["1"],"bh":["1"],"e":["1"]},"ae":{"aB":["1"],"a3":["1"],"bh":["1"],"e":["1"]},"M":{"aB":["1"],"a3":["1"],"bh":["1"],"e":["1"]},"bc":{"w":[]},"bW":{"w":[]},"c5":{"w":[]},"a7":{"af":[]},"bL":{"af":[]},"bM":{"af":[]},"c3":{"af":[]},"c1":{"af":[]},"ay":{"af":[]},"c0":{"w":[]},"R":{"aJ":["1","2"],"dm":["1","2"],"a1":["1","2"]},"ah":{"e":["1"],"e.E":"1"},"ag":{"y":["1"]},"h":{"e":["1"],"e.E":"1"},"b8":{"y":["1"]},"a0":{"e":["ai<1,2>"],"e.E":"ai<1,2>"},"b7":{"y":["ai<1,2>"]},"b5":{"R":["1","2"],"aJ":["1","2"],"dm":["1","2"],"a1":["1","2"]},"aQ":{"X":[]},"aR":{"X":[]},"aF":{"hj":[],"cF":[]},"cb":{"bf":[],"aK":[]},"c6":{"e":["bf"],"e.E":"bf"},"c7":{"y":["bf"]},"c2":{"aK":[]},"cc":{"e":["aK"],"e.E":"aK"},"cd":{"y":["aK"]},"c8":{"w":[]},"br":{"w":[]},"ao":{"a3":["1"],"bh":["1"],"e":["1"]},"ap":{"y":["1"]},"aJ":{"a1":["1","2"]},"a3":{"bh":["1"],"e":["1"]},"bq":{"a3":["1"],"bh":["1"],"e":["1"]},"b6":{"w":[]},"bX":{"w":[]},"ad":{"J":[],"a_":["J"]},"r":{"J":[],"a_":["J"]},"aa":{"e":["1"]},"J":{"a_":["J"]},"bf":{"aK":[]},"d":{"a_":["d"],"cF":[]},"bD":{"w":[]},"bm":{"w":[]},"Q":{"w":[]},"be":{"w":[]},"bR":{"w":[]},"bn":{"w":[]},"bj":{"w":[]},"bO":{"w":[]},"bZ":{"w":[]},"bi":{"w":[]},"aM":{"y":["r"]},"aO":{"hx":[]}}'))
+var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{r:"int",ad:"double",J:"num",d:"String",E:"bool",bb:"Null",aa:"List",o:"Object",a1:"Map",aE:"JSObject"},mangledNames:{},types:["r?(G,G,Z,Z,i)","~(o?,o?)","E(p)","G(an)","r(r,r)","r(p,p)","d(p)","E(G,Z)","~(r,n)","E(d)","d(d)","~(d,ad{detail:d?})","E(r)","d()","d(d,d,d)","r(@,@)","@(@)"],arrayRti:Symbol("$ti"),rttc:{"3;midi,name,pc":(a,b,c)=>d=>d instanceof A.aS&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"4;addCount,alterationCount,naturalCount,totalCount":a=>b=>b instanceof A.bp&&A.jz(a,b.a)}}
+A.hP(v.typeUniverse,JSON.parse('{"b4":"a9","cG":"a9","a6":"a9","bU":{"E":[],"a4":[]},"b3":{"a4":[]},"aG":{"aE":[]},"a9":{"aE":[]},"j":{"aa":["1"],"aE":[],"e":["1"]},"bT":{"bg":[]},"cu":{"j":["1"],"aa":["1"],"aE":[],"e":["1"]},"aY":{"y":["1"]},"aD":{"ad":[],"J":[],"a_":["J"]},"b2":{"ad":[],"r":[],"J":[],"a_":["J"],"a4":[]},"bV":{"ad":[],"J":[],"a_":["J"],"a4":[]},"a8":{"d":[],"a_":["d"],"cF":[],"a4":[]},"bY":{"w":[]},"b1":{"e":["1"]},"I":{"e":["1"]},"bk":{"I":["1"],"e":["1"],"I.E":"1","e.E":"1"},"b9":{"y":["1"]},"H":{"I":["2"],"e":["2"],"I.E":"2","e.E":"2"},"am":{"e":["1"],"e.E":"1"},"bo":{"y":["1"]},"aS":{"aQ":[],"X":[]},"bp":{"aR":[],"X":[]},"b0":{"a1":["1","2"]},"aC":{"b0":["1","2"],"a1":["1","2"]},"ao":{"y":["1"]},"aB":{"a3":["1"],"bh":["1"],"e":["1"]},"af":{"aB":["1"],"a3":["1"],"bh":["1"],"e":["1"]},"M":{"aB":["1"],"a3":["1"],"bh":["1"],"e":["1"]},"bc":{"w":[]},"bW":{"w":[]},"c5":{"w":[]},"a7":{"ag":[]},"bL":{"ag":[]},"bM":{"ag":[]},"c3":{"ag":[]},"c1":{"ag":[]},"az":{"ag":[]},"c0":{"w":[]},"R":{"aJ":["1","2"],"dm":["1","2"],"a1":["1","2"]},"ai":{"e":["1"],"e.E":"1"},"ah":{"y":["1"]},"h":{"e":["1"],"e.E":"1"},"b8":{"y":["1"]},"a0":{"e":["aj<1,2>"],"e.E":"aj<1,2>"},"b7":{"y":["aj<1,2>"]},"b5":{"R":["1","2"],"aJ":["1","2"],"dm":["1","2"],"a1":["1","2"]},"aQ":{"X":[]},"aR":{"X":[]},"aF":{"hj":[],"cF":[]},"cb":{"bf":[],"aK":[]},"c6":{"e":["bf"],"e.E":"bf"},"c7":{"y":["bf"]},"c2":{"aK":[]},"cc":{"e":["aK"],"e.E":"aK"},"cd":{"y":["aK"]},"c8":{"w":[]},"br":{"w":[]},"ap":{"a3":["1"],"bh":["1"],"e":["1"]},"aq":{"y":["1"]},"aJ":{"a1":["1","2"]},"a3":{"bh":["1"],"e":["1"]},"bq":{"a3":["1"],"bh":["1"],"e":["1"]},"b6":{"w":[]},"bX":{"w":[]},"ad":{"J":[],"a_":["J"]},"r":{"J":[],"a_":["J"]},"aa":{"e":["1"]},"J":{"a_":["J"]},"bf":{"aK":[]},"d":{"a_":["d"],"cF":[]},"bD":{"w":[]},"bm":{"w":[]},"Q":{"w":[]},"be":{"w":[]},"bR":{"w":[]},"bn":{"w":[]},"bj":{"w":[]},"bO":{"w":[]},"bZ":{"w":[]},"bi":{"w":[]},"aM":{"y":["r"]},"aO":{"hx":[]}}'))
 A.hO(v.typeUniverse,JSON.parse('{"b1":1,"bq":1,"bN":2,"bP":2}'))
 var u=(function rtii(){var t=A.F
-return{G:t("p"),u:t("n"),V:t("a_<@>"),I:t("aC<d,r>"),C:t("w"),Z:t("af"),h:t("M<l>"),W:t("e<@>"),B:t("j<G>"),_:t("j<p>"),U:t("j<bF>"),d:t("j<a1<d,o?>>"),k:t("j<+midi,name,pc(r?,d?,r)>"),f:t("j<aN>"),s:t("j<d>"),r:t("j<am>"),b:t("j<@>"),t:t("j<r>"),T:t("b3"),m:t("aE"),L:t("b4"),v:t("aa<E>"),j:t("aa<@>"),J:t("a1<@,@>"),Y:t("H<p,d>"),P:t("bb"),K:t("o"),M:t("kw"),F:t("+()"),e:t("bf"),N:t("d"),q:t("d(p)"),R:t("a4"),A:t("a6"),o:t("am"),y:t("E"),i:t("ad"),S:t("r"),O:t("dT<bb>?"),z:t("aE?"),X:t("o?"),w:t("d?"),g:t("ca?"),c:t("E?"),x:t("ad?"),D:t("r?"),n:t("J?"),H:t("J")}})();(function constants(){var t=hunkHelpers.makeConstList
+return{G:t("p"),u:t("n"),V:t("a_<@>"),I:t("aC<d,r>"),C:t("w"),Z:t("ag"),h:t("M<l>"),W:t("e<@>"),B:t("j<G>"),_:t("j<p>"),U:t("j<bF>"),d:t("j<a1<d,o?>>"),k:t("j<+midi,name,pc(r?,d?,r)>"),f:t("j<aN>"),s:t("j<d>"),r:t("j<an>"),b:t("j<@>"),t:t("j<r>"),T:t("b3"),m:t("aE"),L:t("b4"),v:t("aa<E>"),j:t("aa<@>"),J:t("a1<@,@>"),Y:t("H<p,d>"),P:t("bb"),K:t("o"),M:t("kw"),F:t("+()"),e:t("bf"),N:t("d"),q:t("d(p)"),R:t("a4"),A:t("a6"),o:t("an"),y:t("E"),i:t("ad"),S:t("r"),O:t("dT<bb>?"),z:t("aE?"),X:t("o?"),w:t("d?"),g:t("ca?"),c:t("E?"),x:t("ad?"),D:t("r?"),n:t("J?"),H:t("J")}})();(function constants(){var t=hunkHelpers.makeConstList
 B.bx=J.bS.prototype
 B.c=J.j.prototype
 B.a=J.b2.prototype
@@ -4686,15 +4687,15 @@ B.w=new A.p(0,"flat9")
 B.p=new A.p(1,"nine")
 B.T=new A.p(10,"add13")
 B.b1=new A.p(11,"addFlat9")
-B.M=new A.p(2,"sharp9")
+B.N=new A.p(2,"sharp9")
 B.U=new A.p(3,"addSharp9")
-B.I=new A.p(4,"eleven")
+B.J=new A.p(4,"eleven")
 B.q=new A.p(5,"sharp11")
 B.C=new A.p(6,"flat13")
-B.J=new A.p(7,"thirteen")
+B.K=new A.p(7,"thirteen")
 B.D=new A.p(8,"add9")
 B.x=new A.p(9,"add11")
-B.a9=new A.bI(0,"symbolic")
+B.aa=new A.bI(0,"symbolic")
 B.b2=new A.bI(1,"textual")
 B.b3=new A.bJ(0,"triad")
 B.o=new A.bJ(1,"seventh")
@@ -4709,29 +4710,29 @@ B.W=new A.l(13,"dominant7sus4")
 B.y=new A.l(14,"dominant7Flat5")
 B.z=new A.l(15,"dominant7Sharp5")
 B.a4=new A.l(16,"major7")
-B.aa=new A.l(17,"major7sus2")
+B.ab=new A.l(17,"major7sus2")
 B.a5=new A.l(18,"major7sus4")
-B.N=new A.l(19,"major7Flat5")
+B.O=new A.l(19,"major7Flat5")
 B.r=new A.l(2,"minor")
-B.O=new A.l(20,"major7Sharp5")
+B.P=new A.l(20,"major7Sharp5")
 B.A=new A.l(21,"minor7")
-B.K=new A.l(22,"minor7Sharp5")
-B.P=new A.l(23,"minorMajor7")
+B.L=new A.l(22,"minor7Sharp5")
+B.Q=new A.l(23,"minorMajor7")
 B.X=new A.l(24,"halfDiminished7")
 B.E=new A.l(25,"diminished7")
 B.Y=new A.l(3,"minorSharp5")
 B.Z=new A.l(4,"diminished")
 B.a_=new A.l(5,"augmented")
-B.ab=new A.l(6,"sus2")
-B.ac=new A.l(7,"sus4")
-B.ad=new A.l(8,"sus2sus4")
+B.ac=new A.l(6,"sus2")
+B.ad=new A.l(7,"sus4")
+B.ae=new A.l(8,"sus2sus4")
 B.t=new A.l(9,"major6")
 B.n=new A.n(0,"root")
-B.Q=new A.n(1,"sus2")
-B.R=new A.n(10,"sus4")
+B.R=new A.n(1,"sus2")
+B.S=new A.n(10,"sus4")
 B.aE=new A.n(11,"eleven")
-B.ae=new A.n(12,"sharp11")
-B.af=new A.n(13,"add11")
+B.af=new A.n(12,"sharp11")
+B.ag=new A.n(13,"add11")
 B.B=new A.n(14,"flat5")
 B.f=new A.n(15,"perfect5")
 B.F=new A.n(16,"sharp5")
@@ -4744,8 +4745,8 @@ B.aI=new A.n(21,"dim7")
 B.j=new A.n(22,"flat7")
 B.G=new A.n(23,"major7")
 B.aJ=new A.n(3,"nine")
-B.ag=new A.n(4,"sharp9")
-B.ah=new A.n(5,"add9")
+B.ah=new A.n(4,"sharp9")
+B.ai=new A.n(5,"add9")
 B.bw=new A.n(6,"addSharp9")
 B.k=new A.n(7,"minor3")
 B.aK=new A.n(8,"splitMinor3")
@@ -4754,96 +4755,97 @@ B.bz=new A.cx(null)
 B.ak=new A.aN(1,"naturalMinor")
 B.aN=new A.aN(2,"harmonicMinor")
 B.bP=t([B.ak,B.aN],u.f)
-B.bQ=t(["Type some notes, e.g. C E G or 60 64 67."],u.s)
+B.bQ=t(["Too many notes. Enter no more than 128 note names or MIDI numbers."],u.s)
+B.bR=t(["Type some notes, e.g. C E G or 60 64 67."],u.s)
 B.aL=t(["B","E","A","D","G","C","F"],u.s)
 B.aQ=new A.x("Cb","C",11,0,"cFlat")
 B.d=new A.c4(0,"major")
-B.ca=new A.i(B.aQ,B.d)
+B.cb=new A.i(B.aQ,B.d)
 B.av=new A.x("Ab","A",8,15,"aFlat")
 B.h=new A.c4(1,"minor")
-B.cy=new A.i(B.av,B.h)
-B.bL=new A.C(-7,B.ca,B.cy)
+B.cz=new A.i(B.av,B.h)
+B.bL=new A.C(-7,B.cb,B.cz)
 B.aU=new A.x("Gb","G",6,12,"gFlat")
-B.c9=new A.i(B.aU,B.d)
+B.ca=new A.i(B.aU,B.d)
 B.az=new A.x("Eb","E",3,6,"eFlat")
-B.cv=new A.i(B.az,B.h)
-B.bO=new A.C(-6,B.c9,B.cv)
+B.cw=new A.i(B.az,B.h)
+B.bO=new A.C(-6,B.ca,B.cw)
 B.aV=new A.x("Db","D",1,3,"dFlat")
-B.ch=new A.i(B.aV,B.d)
+B.ci=new A.i(B.aV,B.d)
 B.au=new A.x("Bb","B",10,18,"bFlat")
-B.c8=new A.i(B.au,B.h)
-B.bK=new A.C(-5,B.ch,B.c8)
-B.cx=new A.i(B.av,B.d)
+B.c9=new A.i(B.au,B.h)
+B.bK=new A.C(-5,B.ci,B.c9)
+B.cy=new A.i(B.av,B.d)
 B.at=new A.x("F","F",5,10,"f")
-B.cd=new A.i(B.at,B.h)
-B.bN=new A.C(-4,B.cx,B.cd)
-B.cl=new A.i(B.az,B.d)
+B.ce=new A.i(B.at,B.h)
+B.bN=new A.C(-4,B.cy,B.ce)
+B.cm=new A.i(B.az,B.d)
 B.a2=new A.x("C","C",0,1,"c")
-B.cA=new A.i(B.a2,B.h)
-B.bE=new A.C(-3,B.cl,B.cA)
-B.cj=new A.i(B.au,B.d)
+B.cB=new A.i(B.a2,B.h)
+B.bE=new A.C(-3,B.cm,B.cB)
+B.ck=new A.i(B.au,B.d)
 B.aC=new A.x("G","G",7,13,"g")
-B.cs=new A.i(B.aC,B.h)
-B.bI=new A.C(-2,B.cj,B.cs)
-B.cn=new A.i(B.at,B.d)
+B.ct=new A.i(B.aC,B.h)
+B.bI=new A.C(-2,B.ck,B.ct)
+B.co=new A.i(B.at,B.d)
 B.ax=new A.x("D","D",2,4,"d")
-B.cp=new A.i(B.ax,B.h)
-B.bC=new A.C(-1,B.cn,B.cp)
+B.cq=new A.i(B.ax,B.h)
+B.bC=new A.C(-1,B.co,B.cq)
 B.aP=new A.i(B.a2,B.d)
 B.aw=new A.x("A","A",9,16,"a")
-B.cg=new A.i(B.aw,B.h)
-B.bB=new A.C(0,B.aP,B.cg)
-B.cw=new A.i(B.aC,B.d)
+B.ch=new A.i(B.aw,B.h)
+B.bB=new A.C(0,B.aP,B.ch)
+B.cx=new A.i(B.aC,B.d)
 B.ay=new A.x("E","E",4,7,"e")
-B.cb=new A.i(B.ay,B.h)
-B.bJ=new A.C(1,B.cw,B.cb)
-B.cr=new A.i(B.ax,B.d)
+B.cc=new A.i(B.ay,B.h)
+B.bJ=new A.C(1,B.cx,B.cc)
+B.cs=new A.i(B.ax,B.d)
 B.aB=new A.x("B","B",11,19,"b")
-B.ck=new A.i(B.aB,B.h)
-B.bF=new A.C(2,B.cr,B.ck)
-B.ct=new A.i(B.aw,B.d)
+B.cl=new A.i(B.aB,B.h)
+B.bF=new A.C(2,B.cs,B.cl)
+B.cu=new A.i(B.aw,B.d)
 B.aA=new A.x("F#","F",6,11,"fSharp")
-B.ci=new A.i(B.aA,B.h)
-B.bG=new A.C(3,B.ct,B.ci)
-B.cz=new A.i(B.ay,B.d)
+B.cj=new A.i(B.aA,B.h)
+B.bG=new A.C(3,B.cu,B.cj)
+B.cA=new A.i(B.ay,B.d)
 B.as=new A.x("C#","C",1,2,"cSharp")
-B.co=new A.i(B.as,B.h)
-B.bM=new A.C(4,B.cz,B.co)
-B.cu=new A.i(B.aB,B.d)
+B.cp=new A.i(B.as,B.h)
+B.bM=new A.C(4,B.cA,B.cp)
+B.cv=new A.i(B.aB,B.d)
 B.aT=new A.x("G#","G",8,14,"gSharp")
-B.cq=new A.i(B.aT,B.h)
-B.bH=new A.C(5,B.cu,B.cq)
-B.cm=new A.i(B.aA,B.d)
+B.cr=new A.i(B.aT,B.h)
+B.bH=new A.C(5,B.cv,B.cr)
+B.cn=new A.i(B.aA,B.d)
 B.aR=new A.x("D#","D",3,5,"dSharp")
-B.cf=new A.i(B.aR,B.h)
-B.bA=new A.C(6,B.cm,B.cf)
-B.cc=new A.i(B.as,B.d)
+B.cg=new A.i(B.aR,B.h)
+B.bA=new A.C(6,B.cn,B.cg)
+B.cd=new A.i(B.as,B.d)
 B.aS=new A.x("A#","A",10,17,"aSharp")
-B.ce=new A.i(B.aS,B.h)
-B.bD=new A.C(7,B.cc,B.ce)
-B.bR=t([B.bL,B.bO,B.bK,B.bN,B.bE,B.bI,B.bC,B.bB,B.bJ,B.bF,B.bG,B.bM,B.bH,B.bA,B.bD],A.F("j<C>"))
+B.cf=new A.i(B.aS,B.h)
+B.bD=new A.C(7,B.cd,B.cf)
+B.bS=t([B.bL,B.bO,B.bK,B.bN,B.bE,B.bI,B.bC,B.bB,B.bJ,B.bF,B.bG,B.bM,B.bH,B.bA,B.bD],A.F("j<C>"))
 B.aM=t(["F","C","G","D","A","E","B"],u.s)
-B.cD=new A.x("E#","E",5,8,"eSharp")
-B.cC=new A.x("Fb","F",4,9,"fFlat")
-B.cB=new A.x("B#","B",0,20,"bSharp")
-B.bS=t([B.aQ,B.a2,B.as,B.aV,B.ax,B.aR,B.az,B.ay,B.cD,B.cC,B.at,B.aA,B.aU,B.aC,B.aT,B.av,B.aw,B.aS,B.au,B.aB,B.cB],A.F("j<x>"))
+B.cE=new A.x("E#","E",5,8,"eSharp")
+B.cD=new A.x("Fb","F",4,9,"fFlat")
+B.cC=new A.x("B#","B",0,20,"bSharp")
+B.bT=t([B.aQ,B.a2,B.as,B.aV,B.ax,B.aR,B.az,B.ay,B.cE,B.cD,B.at,B.aA,B.aU,B.aC,B.aT,B.av,B.aw,B.aS,B.au,B.aB,B.cC],A.F("j<x>"))
 B.aj=new A.aN(0,"major")
-B.bT=t([B.aj],u.f)
-B.ai=t([],u.U)
-B.S=t([],u.s)
-B.bU=t([],u.r)
-B.bV=t(["minor","major","min","maj"],u.s)
+B.bU=t([B.aj],u.f)
+B.a8=t([],u.U)
+B.H=t([],u.s)
+B.bV=t([],u.r)
+B.bW=t(["minor","major","min","maj"],u.s)
 B.v=t(["C","D","E","F","G","A","B"],u.s)
-B.bW=t(["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"],u.s)
+B.bX=t(["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"],u.s)
 B.b4=new A.m(B.l,145,128)
 B.bf=new A.m(B.aD,81,0)
 B.bm=new A.m(B.r,137,128)
 B.bn=new A.m(B.Y,265,0)
 B.bo=new A.m(B.Z,73,0)
 B.bp=new A.m(B.a_,273,0)
-B.bq=new A.m(B.ab,133,0)
-B.br=new A.m(B.ac,161,0)
-B.bs=new A.m(B.ad,165,0)
+B.bq=new A.m(B.ac,133,0)
+B.br=new A.m(B.ad,161,0)
+B.bs=new A.m(B.ae,165,0)
 B.bt=new A.m(B.t,657,128)
 B.b5=new A.m(B.V,649,128)
 B.b6=new A.m(B.m,1169,128)
@@ -4852,41 +4854,41 @@ B.b8=new A.m(B.W,1185,128)
 B.b9=new A.m(B.y,1105,0)
 B.ba=new A.m(B.z,1297,0)
 B.bb=new A.m(B.a4,2193,128)
-B.bc=new A.m(B.aa,2181,128)
+B.bc=new A.m(B.ab,2181,128)
 B.bd=new A.m(B.a5,2209,128)
-B.be=new A.m(B.N,2129,0)
-B.bg=new A.m(B.O,2321,0)
+B.be=new A.m(B.O,2129,0)
+B.bg=new A.m(B.P,2321,0)
 B.bh=new A.m(B.A,1161,128)
-B.bi=new A.m(B.K,1289,0)
-B.bj=new A.m(B.P,2185,128)
+B.bi=new A.m(B.L,1289,0)
+B.bj=new A.m(B.Q,2185,128)
 B.bk=new A.m(B.X,1097,0)
 B.bl=new A.m(B.E,585,0)
-B.bX=t([B.b4,B.bf,B.bm,B.bn,B.bo,B.bp,B.bq,B.br,B.bs,B.bt,B.b5,B.b6,B.b7,B.b8,B.b9,B.ba,B.bb,B.bc,B.bd,B.be,B.bg,B.bh,B.bi,B.bj,B.bk,B.bl],A.F("j<m>"))
-B.bZ={C:0,D:1,E:2,F:3,G:4,A:5,B:6}
-B.a8=new A.aC(B.bZ,[0,2,4,5,7,9,11],u.I)
-B.c0={major:0,dominant7:1,minor:2,minor7:3,major7:4,"dominant7|nine":5,diminished:6,major6:7,halfDiminished7:8,"dominant7|flat9":9,minor6:10,"dominant7|nine,eleven,thirteen":11,diminished7:12,dominant7Sharp5:13,"minor7|nine":14,augmented:15,dominant7sus4:16,"major7|nine":17,sus4:18,"major6|add9":19,"dominant7|sharp9":20,"dominant7sus4|nine":21,dominant7Flat5:22,"minor7|nine,eleven":23,sus2:24,minorMajor7:25,"dominant7|nine,sharp11":26,major7sus4:27,"dominant7Sharp5|flat9":28,"dominant7Sharp5|sharp9":29,"dominant7|flat9,add11,add13":30,"dominant7Sharp5|nine":31,"dominant7|sharp11":32,minorSharp5:33,"dominant7Flat5|flat9":34,"major|add9":35,"dominant7sus4|nine,eleven,thirteen":36,"dominant7|nine,eleven":37,"major7|nine,sharp11":38,"dominant7|nine,sharp11,thirteen":39,"dominant7Flat5|nine":40,"major7sus4|nine":41,"major7|nine,eleven,thirteen":42,"dominant7|sharp9,sharp11,flat13":43,"minor6|add9":44,minor7Sharp5:45,"dominant7Flat5|flat9,flat13":46,major7Sharp5:47,"dominant7Flat5|nine,eleven,thirteen":48,"dominant7sus4|flat9":49,"dominant7|flat9,nine,eleven,thirteen":50,"dominant7|flat13":51,"dominant7Flat5|nine,thirteen":52,"dominant7Flat5|sharp9":53,"dominant7|flat9,sharp11":54,"minor|add9":55,"major7|sharp11":56,"minor7|nine,eleven,thirteen":57,"dominant7|flat9,sharp11,add13":58,"major|add11":59,"dominant7sus4|sharp9":60,"minor|addFlat9":61,"major7sus4|add13":62,"dominant7|sharp9,flat13":63,"major7|nine,sharp11,thirteen":64,"dominant7|sharp9,add11,add13":65,"dominant7Sharp5|sharp9,sharp11":66,"major7Sharp5|nine":67,"dominant7|nine,eleven,sharp11,thirteen":68,"major7sus4|nine,eleven,thirteen":69,"minor7|add11":70,major7Flat5:71,"major|sharp11":72,"dominant7|flat9,flat13,add11":73,"minor|addSharp9":74,"dominant7|flat9,sharp9,sharp11,flat13":75,"dominant7Flat5|flat9,add11,add13":76,"dominant7|sharp9,sharp11,add13":77,"dominant7|flat9,flat13":78,"dominant7|nine,eleven,flat13":79,"major|addFlat9":80,"major7|sharp9":81,"dominant7Flat5|flat9,add13":82,"minor|add11":83,"dominant7Sharp5|sharp11":84,"major7sus4|flat9":85,"minor7|flat9":86,"dominant7Sharp5|nine,eleven,thirteen":87,"dominant7|sharp9,sharp11":88,"minorMajor7|nine":89,"minorMajor7|nine,eleven,thirteen":90,"minorMajor7|nine,sharp11":91,"dominant7Sharp5|flat9,add11,add13":92,"dominant7|add11":93,"halfDiminished7|nine":94,"major6|sharp11,add9":95,"major|sharp9":96,"dominant7Sharp5|nine,sharp11":97,"dominant7sus4|flat9,add11,add13":98,"halfDiminished7|nine,eleven":99,"major|add9,add11":100,"minor|addFlat9,add9":101,"minor|sharp11":102,"sus4|addFlat9":103,"minor6|flat9":104,"dominant7Sharp5|add11":105,"dominant7Sharp5|nine,thirteen":106,"dominant7|sharp11,flat13":107,"major7Flat5|nine":108,"sus4|add9":109,"augmented|add9":110,"diminished|add11":111,"diminished|addFlat9":112,"dominant7Sharp5|flat9,sharp11":113,"dominant7|nine,flat13":114,"halfDiminished7|flat9":115,"major7Sharp5|sharp9":116,"major7|add11":117,"major7|sharp9,sharp11":118}
-B.bY=new A.aC(B.c0,[377568,235374,126463,116677,40596,29941,24716,23897,14746,11213,10366,8947,8083,7470,5800,4760,4179,3440,2958,2943,2710,2530,2426,2193,1423,1365,1285,1127,1098,900,896,750,563,531,509,498,459,388,346,314,292,277,274,263,236,207,135,135,107,103,102,85,65,57,56,55,53,50,43,43,39,35,33,30,29,28,27,27,26,25,25,24,21,20,18,17,16,16,15,15,15,13,12,12,10,9,9,8,8,8,8,8,6,6,5,5,5,4,4,4,4,4,4,4,3,2,2,2,2,2,1,1,1,1,1,1,1,1,1],u.I)
+B.bY=t([B.b4,B.bf,B.bm,B.bn,B.bo,B.bp,B.bq,B.br,B.bs,B.bt,B.b5,B.b6,B.b7,B.b8,B.b9,B.ba,B.bb,B.bc,B.bd,B.be,B.bg,B.bh,B.bi,B.bj,B.bk,B.bl],A.F("j<m>"))
+B.c_={C:0,D:1,E:2,F:3,G:4,A:5,B:6}
+B.a9=new A.aC(B.c_,[0,2,4,5,7,9,11],u.I)
+B.c1={major:0,dominant7:1,minor:2,minor7:3,major7:4,"dominant7|nine":5,diminished:6,major6:7,halfDiminished7:8,"dominant7|flat9":9,minor6:10,"dominant7|nine,eleven,thirteen":11,diminished7:12,dominant7Sharp5:13,"minor7|nine":14,augmented:15,dominant7sus4:16,"major7|nine":17,sus4:18,"major6|add9":19,"dominant7|sharp9":20,"dominant7sus4|nine":21,dominant7Flat5:22,"minor7|nine,eleven":23,sus2:24,minorMajor7:25,"dominant7|nine,sharp11":26,major7sus4:27,"dominant7Sharp5|flat9":28,"dominant7Sharp5|sharp9":29,"dominant7|flat9,add11,add13":30,"dominant7Sharp5|nine":31,"dominant7|sharp11":32,minorSharp5:33,"dominant7Flat5|flat9":34,"major|add9":35,"dominant7sus4|nine,eleven,thirteen":36,"dominant7|nine,eleven":37,"major7|nine,sharp11":38,"dominant7|nine,sharp11,thirteen":39,"dominant7Flat5|nine":40,"major7sus4|nine":41,"major7|nine,eleven,thirteen":42,"dominant7|sharp9,sharp11,flat13":43,"minor6|add9":44,minor7Sharp5:45,"dominant7Flat5|flat9,flat13":46,major7Sharp5:47,"dominant7Flat5|nine,eleven,thirteen":48,"dominant7sus4|flat9":49,"dominant7|flat9,nine,eleven,thirteen":50,"dominant7|flat13":51,"dominant7Flat5|nine,thirteen":52,"dominant7Flat5|sharp9":53,"dominant7|flat9,sharp11":54,"minor|add9":55,"major7|sharp11":56,"minor7|nine,eleven,thirteen":57,"dominant7|flat9,sharp11,add13":58,"major|add11":59,"dominant7sus4|sharp9":60,"minor|addFlat9":61,"major7sus4|add13":62,"dominant7|sharp9,flat13":63,"major7|nine,sharp11,thirteen":64,"dominant7|sharp9,add11,add13":65,"dominant7Sharp5|sharp9,sharp11":66,"major7Sharp5|nine":67,"dominant7|nine,eleven,sharp11,thirteen":68,"major7sus4|nine,eleven,thirteen":69,"minor7|add11":70,major7Flat5:71,"major|sharp11":72,"dominant7|flat9,flat13,add11":73,"minor|addSharp9":74,"dominant7|flat9,sharp9,sharp11,flat13":75,"dominant7Flat5|flat9,add11,add13":76,"dominant7|sharp9,sharp11,add13":77,"dominant7|flat9,flat13":78,"dominant7|nine,eleven,flat13":79,"major|addFlat9":80,"major7|sharp9":81,"dominant7Flat5|flat9,add13":82,"minor|add11":83,"dominant7Sharp5|sharp11":84,"major7sus4|flat9":85,"minor7|flat9":86,"dominant7Sharp5|nine,eleven,thirteen":87,"dominant7|sharp9,sharp11":88,"minorMajor7|nine":89,"minorMajor7|nine,eleven,thirteen":90,"minorMajor7|nine,sharp11":91,"dominant7Sharp5|flat9,add11,add13":92,"dominant7|add11":93,"halfDiminished7|nine":94,"major6|sharp11,add9":95,"major|sharp9":96,"dominant7Sharp5|nine,sharp11":97,"dominant7sus4|flat9,add11,add13":98,"halfDiminished7|nine,eleven":99,"major|add9,add11":100,"minor|addFlat9,add9":101,"minor|sharp11":102,"sus4|addFlat9":103,"minor6|flat9":104,"dominant7Sharp5|add11":105,"dominant7Sharp5|nine,thirteen":106,"dominant7|sharp11,flat13":107,"major7Flat5|nine":108,"sus4|add9":109,"augmented|add9":110,"diminished|add11":111,"diminished|addFlat9":112,"dominant7Sharp5|flat9,sharp11":113,"dominant7|nine,flat13":114,"halfDiminished7|flat9":115,"major7Sharp5|sharp9":116,"major7|add11":117,"major7|sharp9,sharp11":118}
+B.bZ=new A.aC(B.c1,[377568,235374,126463,116677,40596,29941,24716,23897,14746,11213,10366,8947,8083,7470,5800,4760,4179,3440,2958,2943,2710,2530,2426,2193,1423,1365,1285,1127,1098,900,896,750,563,531,509,498,459,388,346,314,292,277,274,263,236,207,135,135,107,103,102,85,65,57,56,55,53,50,43,43,39,35,33,30,29,28,27,27,26,25,25,24,21,20,18,17,16,16,15,15,15,13,12,12,10,9,9,8,8,8,8,8,6,6,5,5,5,4,4,4,4,4,4,4,3,2,2,2,2,2,1,1,1,1,1,1,1,1,1],u.I)
 B.a0=new A.cB(0,"international")
-B.H=new A.a2(0,"one")
+B.I=new A.a2(0,"one")
 B.al=new A.a2(1,"two")
 B.am=new A.a2(2,"three")
 B.an=new A.a2(3,"four")
 B.ao=new A.a2(4,"five")
 B.ap=new A.a2(5,"six")
 B.aq=new A.a2(6,"seven")
-B.c1={A:0,B:1,C:2,D:3,E:4,F:5,G:6}
-B.c2=new A.ae(B.c1,7,A.F("ae<d>"))
+B.c2={A:0,B:1,C:2,D:3,E:4,F:5,G:6}
+B.c3=new A.af(B.c2,7,A.F("af<d>"))
 B.a1=new A.M([B.l,B.a4],u.h)
-B.c3=new A.M([B.l,B.m,B.z],u.h)
-B.c4=new A.M([B.a_,B.O],u.h)
-B.c5=new A.M([B.r,B.P],u.h)
-B.L=new A.M([B.r,B.A],u.h)
-B.c_={}
-B.c6=new A.ae(B.c_,0,A.F("ae<p>"))
-B.c7=new A.M([B.Z,B.E],u.h)
+B.c4=new A.M([B.l,B.m,B.z],u.h)
+B.c5=new A.M([B.a_,B.P],u.h)
+B.c6=new A.M([B.r,B.Q],u.h)
+B.M=new A.M([B.r,B.A],u.h)
+B.c0={}
+B.c7=new A.af(B.c0,0,A.F("af<p>"))
+B.c8=new A.M([B.Z,B.E],u.h)
 B.ar=new A.M([B.Z,B.X],u.h)
 B.aO=new A.M([B.l,B.m],u.h)
-B.cE=A.ks("o")})();(function staticFields(){$.L=A.k([],A.F("j<o>"))
+B.cF=A.ks("o")})();(function staticFields(){$.L=A.k([],A.F("j<o>"))
 $.e0=null
 $.dL=null
 $.dK=null
@@ -4908,13 +4910,13 @@ t($,"kD","eW",()=>A.a5(A.e9(null)))
 t($,"kC","eV",()=>A.a5(function(){try{null.$method$}catch(s){return s.message}}()))
 t($,"kH","f_",()=>A.a5(A.e9(void 0)))
 t($,"kG","eZ",()=>A.a5(function(){try{(void 0).$method$}catch(s){return s.message}}()))
-t($,"kI","aW",()=>A.dC(B.cE))
+t($,"kI","aW",()=>A.dC(B.cF))
 t($,"kt","eO",()=>A.hc(u.S,A.F("aa<G>")))
-t($,"kL","dH",()=>A.k([A.v(A.u(B.l),3080,!1),A.v(A.u(B.aD),3208,!1),A.v(A.u(B.r),3088,!1),A.v(A.u(B.Y),3216,!1),A.v(A.u(B.Z),144,!1),A.v(A.u(B.a_),136,!1),A.v(A.u(B.ab),3096,!1),A.v(A.u(B.ac),3096,!1),A.v(A.u(B.ad),0,!0),A.v(A.u(B.t),3080,!1),A.v(A.u(B.V),3088,!1),A.v(A.u(B.m),2056,!1),A.v(A.u(B.a3),2104,!1),A.v(A.u(B.W),2072,!1),A.v(A.u(B.y),2184,!1),A.v(A.u(B.z),2184,!1),A.v(A.u(B.a4),1032,!1),A.v(A.u(B.aa),1080,!1),A.v(A.u(B.a5),1052,!1),A.v(A.u(B.N),1160,!1),A.v(A.u(B.O),1160,!1),A.v(A.u(B.A),2064,!1),A.v(A.u(B.K),2192,!1),A.v(A.u(B.P),1040,!1),A.v(A.u(B.X),2192,!1),A.v(A.u(B.E),3216,!1)],A.F("j<b_>")))
+t($,"kL","dH",()=>A.k([A.v(A.u(B.l),3080,!1),A.v(A.u(B.aD),3208,!1),A.v(A.u(B.r),3088,!1),A.v(A.u(B.Y),3216,!1),A.v(A.u(B.Z),144,!1),A.v(A.u(B.a_),136,!1),A.v(A.u(B.ac),3096,!1),A.v(A.u(B.ad),3096,!1),A.v(A.u(B.ae),0,!0),A.v(A.u(B.t),3080,!1),A.v(A.u(B.V),3088,!1),A.v(A.u(B.m),2056,!1),A.v(A.u(B.a3),2104,!1),A.v(A.u(B.W),2072,!1),A.v(A.u(B.y),2184,!1),A.v(A.u(B.z),2184,!1),A.v(A.u(B.a4),1032,!1),A.v(A.u(B.ab),1080,!1),A.v(A.u(B.a5),1052,!1),A.v(A.u(B.O),1160,!1),A.v(A.u(B.P),1160,!1),A.v(A.u(B.A),2064,!1),A.v(A.u(B.L),2192,!1),A.v(A.u(B.Q),1040,!1),A.v(A.u(B.X),2192,!1),A.v(A.u(B.E),3216,!1)],A.F("j<b_>")))
 t($,"kM","f2",()=>A.k([A.f("prefer complete dominant flat-nine over colored diminished7",A.jJ()),A.f("prefer flat-nine-bass dominant over remote reinterpretation",A.k1()),A.f("prefer complete altered dominant inversion over altered major7",A.jI()),A.f("prefer complete dominant sharp-nine over sixth flat-nine",A.jK()),A.f("prefer conventional inversion in split-nine tritone dominant ambiguity",A.jU()),A.f("prefer altered dominant7 over dim7 slash",A.jH()),A.f("prefer conventional altered seventh over add11 slash",A.jS()),A.f("prefer complete minor sharp11 over altered maj7sus4",A.jO()),A.f("prefer close root-position dominant7 over non-dominant slash",A.jX()),A.f("prefer ninth-bass seventh chord over altered slash",A.k6()),A.f("prefer minor7 eleventh-bass slash over minor7 sharp-five slash",A.k4()),A.f("prefer root-position altered-fifth dominant over slash",A.k8()),A.f("prefer root-position add-chord over sus slash",A.k7()),A.f("prefer complete triad over structurally deficient reading",A.jQ()),A.f("prefer root-position minor-eleventh shell over sus slash",A.kb()),A.f("prefer complete major six-nine over inverted minor-seven sharp-five",A.jN()),A.f("prefer simple triad add-tone over seventh-family unusual quality",A.ke())],A.F("j<ba>")))
 t($,"kN","f3",()=>A.k([A.f("prefer root-position 6th over inverted 7th",A.jF()),A.f("prefer complete triad over incomplete inverted 6th",A.jR()),A.f("prefer upper-structure dominant7 slash",A.kh()),A.f("prefer root-position dominant sus over slash",A.k9()),A.f("prefer root-position extended dominant over altered-fifth slash",A.ka()),A.f("prefer complete major inversion over minor sharp-five",A.jL()),A.f("prefer complete major inversion over seventh-family color-bass slash",A.jM()),A.f("prefer root-position diminished7",A.jW()),A.f("prefer dominant7 over dim7 slash",A.jY()),A.f("prefer dominant7 shell slash over non-dominant seventh-family slash",A.jZ()),A.f("prefer voicing that names every tone",A.k2()),A.f("prefer harmonic-minor tonic over split-third inversion",A.k3()),A.f("prefer fewer altered/tension colors",A.k_()),A.f("prefer diatonic chords",A.jV()),A.f("prefer root-position relative minor7 over major6 slash",A.kc()),A.f("prefer tonic chord",A.kg()),A.f("prefer I chord when bass is tonic",A.kf()),A.f("prefer complete triad add-tone over seventh-family add-tone",A.jP()),A.f("prefer natural extensions over adds, then fewer total",A.k5()),A.f("prefer root position",A.kd()),A.f("prefer common naming preference",A.jh()),A.f("prefer more conventional inversion",A.jT()),A.f("prefer 7th chords over triads",A.jG()),A.f("prefer fewer extensions",A.k0()),A.f("avoid suspended chords",A.jE())],A.F("j<ba>")))
 t($,"kK","f1",()=>{var s,r,q=A.aH(A.F("l"),A.F("m"))
-for(s=0;s<26;++s){r=B.bX[s]
+for(s=0;s<26;++s){r=B.bY[s]
 q.q(0,r.a,r)}return q})
 t($,"kx","eQ",()=>{var s,r,q,p=A.aH(A.F("l"),A.F("b_"))
 for(s=$.dH(),r=0;r<26;++r){q=s[r]

--- a/docs/site/js/try.js
+++ b/docs/site/js/try.js
@@ -184,8 +184,7 @@
 
   function buildQuery() {
     var params = new URLSearchParams();
-    var notes = state.canonicalNotes || els.notes.value.trim();
-    if (notes) params.set("notes", notes);
+    if (state.canonicalNotes) params.set("notes", state.canonicalNotes);
     if (currentKey() !== "C:" + DEFAULT_MODE) params.set("key", currentKey());
     if (state.notation !== DEFAULT_NOTATION)
       params.set("notation", state.notation);

--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -81,6 +81,7 @@
                 type="text"
                 autocomplete="off"
                 autocapitalize="off"
+                maxlength="512"
                 spellcheck="false"
                 placeholder="C E G Bb D"
                 aria-describedby="notes-hint"

--- a/test/chord_id_engine_test.dart
+++ b/test/chord_id_engine_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../tool/src/chord_id_engine.dart';
+
+void main() {
+  group('identifyChord input limits', () {
+    test('accepts up to 128 note tokens', () {
+      final notes = List<String>.filled(maxChordIdNoteTokens, 'C').join(' ');
+
+      final result = identifyChord(notes);
+
+      expect(result.ok, isTrue);
+    });
+
+    test('rejects more than 128 note tokens', () {
+      final notes = List<String>.filled(
+        maxChordIdNoteTokens + 1,
+        'C',
+      ).join(' ');
+
+      final result = identifyChord(notes);
+
+      expect(result.ok, isFalse);
+      expect(
+        result.errors,
+        contains(
+          'Too many notes. Enter no more than 128 note names or MIDI numbers.',
+        ),
+      );
+    });
+  });
+}

--- a/tool/src/chord_id_engine.dart
+++ b/tool/src/chord_id_engine.dart
@@ -14,6 +14,9 @@ import 'package:whatchord/features/theory/presentation/models/chord_symbol.dart'
 import 'package:whatchord/features/theory/presentation/services/chord_symbol_builder.dart';
 import 'package:whatchord/features/theory/presentation/services/note_display_formatter.dart';
 
+/// Maximum number of note tokens accepted by a single identification request.
+const maxChordIdNoteTokens = 128;
+
 /// How a candidate relates to the top pick.
 enum CandidateClass {
   /// The engine's chosen interpretation (rank 1).
@@ -127,6 +130,19 @@ ChordIdResult identifyChord(
       candidates: const [],
       warnings: const [],
       errors: const ['Type some notes, e.g. C E G or 60 64 67.'],
+    );
+  }
+  if (tokens.length > maxChordIdNoteTokens) {
+    return ChordIdResult(
+      ok: false,
+      notes: const [],
+      bass: '',
+      key: keyLabel,
+      candidates: const [],
+      warnings: const [],
+      errors: const [
+        'Too many notes. Enter no more than 128 note names or MIDI numbers.',
+      ],
     );
   }
 


### PR DESCRIPTION
Limit chord identification requests to 128 note tokens, cap web input length, and keep invalid note text out of shared URLs.