### PR TITLE
Harden website response headers

### DIFF
--- a/docs/site/_headers
+++ b/docs/site/_headers
@@ -1,0 +1,5 @@
+/*
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; style-src 'self'; upgrade-insecure-requests
+  Permissions-Policy: camera=(), geolocation=(), microphone=()
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Content-Type-Options: nosniff

--- a/docs/site/articles/choco-chord-coverage.html
+++ b/docs/site/articles/choco-chord-coverage.html
@@ -407,11 +407,7 @@
 
           <div class="article-related">
             <h4>Also on this site</h4>
-            <a
-              class="article-card"
-              href="chord-naming.html"
-              style="margin-top: 0"
-            >
+            <a class="article-card article-card-first" href="chord-naming.html">
               <div class="article-tag">For musicians</div>
               <h3>Why Chord Naming Is Harder Than It Looks</h3>
               <p>
@@ -422,9 +418,8 @@
               <span class="read-more">Read the article →</span>
             </a>
             <a
-              class="article-card"
+              class="article-card article-card-following"
               href="under-the-hood.html"
-              style="margin-top: 20px"
             >
               <div class="article-tag">Technical deep-dive</div>
               <h3>Under the Hood: Building a Real-Time Chord Recognizer</h3>
@@ -486,30 +481,11 @@
           >
           with your Gmail address and we'll add you to the tester pool.
         </p>
-        <button
-          class="btn btn-primary"
-          onclick="document.getElementById('android-dialog').close()"
-        >
+        <button class="btn btn-primary" data-close-android-dialog>
           Got it
         </button>
       </div>
     </dialog>
-    <script>
-      (function () {
-        function openAndroidDialog(e) {
-          e.preventDefault();
-          document.getElementById("android-dialog").showModal();
-        }
-        document.querySelectorAll("[data-android-beta]").forEach(function (el) {
-          el.addEventListener("click", openAndroidDialog);
-        });
-        if (/android/i.test(navigator.userAgent)) {
-          document.querySelectorAll(".btn-get-app").forEach(function (el) {
-            el.href = "#";
-            el.addEventListener("click", openAndroidDialog);
-          });
-        }
-      })();
-    </script>
+    <script src="../js/site.js"></script>
   </body>
 </html>

--- a/docs/site/articles/chord-naming.html
+++ b/docs/site/articles/chord-naming.html
@@ -373,7 +373,7 @@
               Free for iOS and Android. No subscription, no ads, no internet
               required.
             </p>
-            <div class="store-badges" style="margin-bottom: 16px">
+            <div class="store-badges store-badges-spaced">
               <a
                 href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
               >
@@ -400,9 +400,8 @@
           <div class="article-related">
             <h4>Also on this site</h4>
             <a
-              class="article-card"
+              class="article-card article-card-first"
               href="under-the-hood.html"
-              style="margin-top: 0"
             >
               <div class="article-tag">Technical deep-dive</div>
               <h3>Under the Hood: Building a Real-Time Chord Recognizer</h3>
@@ -413,9 +412,8 @@
               <span class="read-more">Read the article →</span>
             </a>
             <a
-              class="article-card"
+              class="article-card article-card-following"
               href="choco-chord-coverage.html"
-              style="margin-top: 20px"
             >
               <div class="article-tag">Chord data</div>
               <h3>What We Learned From 1 Million Chord Annotations</h3>
@@ -477,30 +475,11 @@
           >
           with your Gmail address and we'll add you to the tester pool.
         </p>
-        <button
-          class="btn btn-primary"
-          onclick="document.getElementById('android-dialog').close()"
-        >
+        <button class="btn btn-primary" data-close-android-dialog>
           Got it
         </button>
       </div>
     </dialog>
-    <script>
-      (function () {
-        function openAndroidDialog(e) {
-          e.preventDefault();
-          document.getElementById("android-dialog").showModal();
-        }
-        document.querySelectorAll("[data-android-beta]").forEach(function (el) {
-          el.addEventListener("click", openAndroidDialog);
-        });
-        if (/android/i.test(navigator.userAgent)) {
-          document.querySelectorAll(".btn-get-app").forEach(function (el) {
-            el.href = "#";
-            el.addEventListener("click", openAndroidDialog);
-          });
-        }
-      })();
-    </script>
+    <script src="../js/site.js"></script>
   </body>
 </html>

--- a/docs/site/articles/under-the-hood.html
+++ b/docs/site/articles/under-the-hood.html
@@ -1026,7 +1026,7 @@ pcs: B♭ C E F♯  |  bass: F♯ (pc 6)  |  key: C major
               Free for iOS and Android. No subscription, no ads, all analysis
               on-device.
             </p>
-            <div class="store-badges" style="margin-bottom: 16px">
+            <div class="store-badges store-badges-spaced">
               <a
                 href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
               >
@@ -1061,11 +1061,7 @@ pcs: B♭ C E F♯  |  bass: F♯ (pc 6)  |  key: C major
 
           <div class="article-related">
             <h4>Also on this site</h4>
-            <a
-              class="article-card"
-              href="chord-naming.html"
-              style="margin-top: 0"
-            >
+            <a class="article-card article-card-first" href="chord-naming.html">
               <div class="article-tag">For musicians</div>
               <h3>Why Chord Naming Is Harder Than It Looks</h3>
               <p>
@@ -1076,9 +1072,8 @@ pcs: B♭ C E F♯  |  bass: F♯ (pc 6)  |  key: C major
               <span class="read-more">Read the article →</span>
             </a>
             <a
-              class="article-card"
+              class="article-card article-card-following"
               href="choco-chord-coverage.html"
-              style="margin-top: 20px"
             >
               <div class="article-tag">Chord data</div>
               <h3>What We Learned From 1 Million Chord Annotations</h3>
@@ -1140,30 +1135,11 @@ pcs: B♭ C E F♯  |  bass: F♯ (pc 6)  |  key: C major
           >
           with your Gmail address and we'll add you to the tester pool.
         </p>
-        <button
-          class="btn btn-primary"
-          onclick="document.getElementById('android-dialog').close()"
-        >
+        <button class="btn btn-primary" data-close-android-dialog>
           Got it
         </button>
       </div>
     </dialog>
-    <script>
-      (function () {
-        function openAndroidDialog(e) {
-          e.preventDefault();
-          document.getElementById("android-dialog").showModal();
-        }
-        document.querySelectorAll("[data-android-beta]").forEach(function (el) {
-          el.addEventListener("click", openAndroidDialog);
-        });
-        if (/android/i.test(navigator.userAgent)) {
-          document.querySelectorAll(".btn-get-app").forEach(function (el) {
-            el.href = "#";
-            el.addEventListener("click", openAndroidDialog);
-          });
-        }
-      })();
-    </script>
+    <script src="../js/site.js"></script>
   </body>
 </html>

--- a/docs/site/css/style.css
+++ b/docs/site/css/style.css
@@ -241,6 +241,10 @@ img {
   margin-bottom: 0;
 }
 
+.store-badges-spaced {
+  margin-bottom: 16px;
+}
+
 .store-badge {
   height: 60px;
   width: auto;
@@ -1091,6 +1095,14 @@ footer {
   text-transform: uppercase;
   color: var(--text-2);
   margin-bottom: 20px;
+}
+
+.article-related .article-card-first {
+  margin-top: 0;
+}
+
+.article-related .article-card-following {
+  margin-top: 20px;
 }
 
 /* ─── Pipeline diagram ───────────────────────────────────────── */

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -415,100 +415,11 @@
           >
           with your Gmail address and we'll add you to the tester pool.
         </p>
-        <button
-          class="btn btn-primary"
-          onclick="document.getElementById('android-dialog').close()"
-        >
+        <button class="btn btn-primary" data-close-android-dialog>
           Got it
         </button>
       </div>
     </dialog>
-    <script>
-      (function () {
-        function openAndroidDialog(e) {
-          e.preventDefault();
-          document.getElementById("android-dialog").showModal();
-        }
-        document.querySelectorAll("[data-android-beta]").forEach(function (el) {
-          el.addEventListener("click", openAndroidDialog);
-        });
-        if (/android/i.test(navigator.userAgent)) {
-          document.querySelectorAll(".btn-get-app").forEach(function (el) {
-            el.href = "#";
-            el.addEventListener("click", openAndroidDialog);
-          });
-        }
-
-        if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-          return;
-        }
-
-        document.querySelectorAll("[data-motion-media]").forEach(function (el) {
-          var video = el.querySelector("[data-motion-video]");
-          var toggle = el.querySelector("[data-motion-toggle]");
-          if (!video) return;
-
-          function setPaused(isPaused) {
-            el.classList.toggle("is-video-paused", isPaused);
-            if (toggle) {
-              toggle.setAttribute(
-                "aria-label",
-                isPaused ? "Play animation" : "Pause animation",
-              );
-            }
-          }
-
-          function activateVideoControl() {
-            el.classList.add("is-video-active");
-            setPaused(video.paused);
-            if (toggle) {
-              toggle.hidden = false;
-            }
-          }
-
-          function activateVideo() {
-            var play = video.play();
-            if (play && typeof play.then === "function") {
-              play
-                .then(function () {
-                  activateVideoControl();
-                })
-                .catch(function () {});
-              return;
-            }
-
-            activateVideoControl();
-          }
-
-          if (toggle) {
-            toggle.addEventListener("click", function () {
-              if (video.paused) {
-                var play = video.play();
-                if (play && typeof play.then === "function") {
-                  play
-                    .then(function () {
-                      activateVideoControl();
-                    })
-                    .catch(function () {});
-                  return;
-                }
-
-                activateVideoControl();
-                return;
-              }
-
-              video.pause();
-              setPaused(true);
-            });
-          }
-
-          if (video.readyState >= 3) {
-            activateVideo();
-          } else {
-            video.addEventListener("canplay", activateVideo, { once: true });
-          }
-        });
-      })();
-    </script>
+    <script src="js/site.js"></script>
   </body>
 </html>

--- a/docs/site/js/site.js
+++ b/docs/site/js/site.js
@@ -1,0 +1,89 @@
+// Shared behavior for the static site.
+(function () {
+  "use strict";
+
+  var androidDialog = document.getElementById("android-dialog");
+  if (androidDialog) {
+    function openAndroidDialog(event) {
+      event.preventDefault();
+      androidDialog.showModal();
+    }
+
+    document
+      .querySelectorAll("[data-android-beta]")
+      .forEach(function (element) {
+        element.addEventListener("click", openAndroidDialog);
+      });
+
+    document
+      .querySelectorAll("[data-close-android-dialog]")
+      .forEach(function (element) {
+        element.addEventListener("click", function () {
+          androidDialog.close();
+        });
+      });
+
+    if (/android/i.test(navigator.userAgent)) {
+      document.querySelectorAll(".btn-get-app").forEach(function (element) {
+        element.href = "#";
+        element.addEventListener("click", openAndroidDialog);
+      });
+    }
+  }
+
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    return;
+  }
+
+  document.querySelectorAll("[data-motion-media]").forEach(function (element) {
+    var video = element.querySelector("[data-motion-video]");
+    var toggle = element.querySelector("[data-motion-toggle]");
+    if (!video) return;
+
+    function setPaused(isPaused) {
+      element.classList.toggle("is-video-paused", isPaused);
+      if (toggle) {
+        toggle.setAttribute(
+          "aria-label",
+          isPaused ? "Play animation" : "Pause animation",
+        );
+      }
+    }
+
+    function activateVideoControl() {
+      element.classList.add("is-video-active");
+      setPaused(video.paused);
+      if (toggle) {
+        toggle.hidden = false;
+      }
+    }
+
+    function activateVideo() {
+      var play = video.play();
+      if (play && typeof play.then === "function") {
+        play.then(activateVideoControl).catch(function () {});
+        return;
+      }
+
+      activateVideoControl();
+    }
+
+    if (toggle) {
+      toggle.addEventListener("click", function () {
+        if (video.paused) {
+          activateVideo();
+          return;
+        }
+
+        video.pause();
+        setPaused(true);
+      });
+    }
+
+    if (video.readyState >= 3) {
+      activateVideo();
+    } else {
+      video.addEventListener("canplay", activateVideo, { once: true });
+    }
+  });
+})();

--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -15,10 +15,7 @@
     />
     <meta property="og:image" content="images/theme_modes.webp" />
     <meta property="og:type" content="website" />
-    <meta
-      property="og:url"
-      content="https://whatchord.earthmanmuons.com/try"
-    />
+    <meta property="og:url" content="https://whatchord.earthmanmuons.com/try" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Try WhatChord - Identify a Chord" />
     <meta
@@ -195,7 +192,7 @@
               for iOS and Android. No subscription, no ads, no internet
               required.
             </p>
-            <div class="store-badges" style="margin-bottom: 16px">
+            <div class="store-badges store-badges-spaced">
               <a
                 href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
               >
@@ -263,22 +260,14 @@
           >
           with your Gmail address and we'll add you to the tester pool.
         </p>
-        <button
-          class="btn btn-primary"
-          onclick="document.getElementById('android-dialog').close()"
-        >
+        <button class="btn btn-primary" data-close-android-dialog>
           Got it
         </button>
       </div>
     </dialog>
 
-    <script>
-      window.whatchordOnReady = function () {
-        window.whatchordReady = true;
-        window.dispatchEvent(new Event("whatchord-ready"));
-      };
-    </script>
-    <script src="js/chord-id.js" onload="whatchordOnReady()"></script>
+    <script src="js/chord-id.js"></script>
     <script src="js/try.js"></script>
+    <script src="js/site.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Add a strict Content Security Policy and related browser security headers for the Cloudflare-hosted site.

Move inline scripts, event handlers, and styles into shared assets so the policy can avoid unsafe-inline while preserving existing behavior.

Note that Cloudflare Pages already adds nosniff to static assets by default. Including it in \_headers makes the intended policy explicit and ensures Worker-generated responses receive it too.