### PR TITLE
Prevent unexpected Worker-routed paths

### DIFF
--- a/docs/site/worker/index.js
+++ b/docs/site/worker/index.js
@@ -21,6 +21,10 @@ export default {
       );
     }
 
+    if (url.pathname !== "/try") {
+      return new Response("Not Found", { status: 404 });
+    }
+
     // Always start from the real static asset so non-meta content is untouched.
     const asset = await env.ASSETS.fetch(
       new Request(new URL("/try.html", url.origin), request),
@@ -74,7 +78,8 @@ function buildMeta(result, url) {
   const key = result.input.key;
 
   const title = notes + " → " + top;
-  const description = "Identified by WhatChord. Bass " + bass + ", key " + key + ".";
+  const description =
+    "Identified by WhatChord. Bass " + bass + ", key " + key + ".";
 
   return {
     title,


### PR DESCRIPTION
Unresolved requests should reply the relevant missing-resource 404 Not Found status rather than sending all unkwn requests to the worker (which defaults to our try page).