### PR TITLE
Fix back-forward cache restoration bug

### DIFF
--- a/docs/site/js/try.js
+++ b/docs/site/js/try.js
@@ -375,6 +375,17 @@
     window.addEventListener("whatchord-ready", start, { once: true });
   }
 
+  // Browsers may restore rendered results from the back-forward cache without
+  // restoring an autocomplete-off input. Reapply the URL-backed state so the
+  // form and results cannot disagree.
+  window.addEventListener("pageshow", function (event) {
+    if (!event.persisted) return;
+    var params = new URLSearchParams(location.search);
+    els.notes.value = params.get("notes") || "";
+    syncClear();
+    run();
+  });
+
   // Android beta dialog (mirrors index.html behavior on this standalone page).
   function openAndroidDialog(e) {
     e.preventDefault();

--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -22,6 +22,7 @@
       name="twitter:description"
       content="Type notes, get the chord name and close alternatives. The same on-device engine that powers the WhatChord app, running in your browser."
     />
+    <link rel="canonical" href="https://whatchord.earthmanmuons.com/try" />
     <link rel="icon" type="image/webp" href="images/whatchord_logo.webp" />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/try.css" />


### PR DESCRIPTION
It was possible to navigate back to a page and have an empty text box despite the chord analysis showing properly and a legit URL encoded.