### PR TITLE
Allow data: URIs for images in CSP

### DIFF
--- a/docs/site/_headers
+++ b/docs/site/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self'; media-src 'self'; object-src 'none'; script-src 'self'; style-src 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; media-src 'self'; object-src 'none'; script-src 'self'; style-src 'self'; upgrade-insecure-requests
   Permissions-Policy: camera=(), geolocation=(), microphone=()
   Referrer-Policy: strict-origin-when-cross-origin
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
The Try page's key dropdown uses an inline SVG caret encoded as a data: URI background image. The Content-Security-Policy img-src directive was set to 'self', which governs CSS url() images and blocked the caret over HTTP(S). It rendered locally only because file:// pages have no CSP applied.