### PR TITLE
Drop safe-area inset from footer padding

### DIFF
--- a/docs/site/css/style.css
+++ b/docs/site/css/style.css
@@ -863,7 +863,7 @@ dialog::backdrop {
 footer {
   border-top: 1px solid var(--border-mid);
   background: var(--bg-raised);
-  padding: 36px 0 calc(36px + env(safe-area-inset-bottom));
+  padding: 36px 0;
 }
 
 .footer-inner {


### PR DESCRIPTION
The footer's bottom padding added env(safe-area-inset-bottom) on top of the base 36px, which made it look bottom-heavy on iPad while staying even on desktop. The footer is a normal in-flow element with ample spacing, so it does not need to clear the home indicator. Use a flat 36px top and bottom for even spacing across devices.