### PR TITLE
Reconcile try.html input on every pageshow, not just persisted

### DIFF
--- a/docs/site/js/try.js
+++ b/docs/site/js/try.js
@@ -375,20 +375,20 @@
     window.addEventListener("whatchord-ready", start, { once: true });
   }
 
-  // Browsers may restore rendered results from the back-forward cache without
-  // restoring an autocomplete-off input. WebKit additionally re-blanks such an
-  // input during its own form-restoration pass, which runs *after* pageshow, so
-  // a synchronous reseed alone gets clobbered. Reapply the URL-backed value both
-  // now and on the next tick; the guard makes whichever pass is redundant a
-  // no-op, so the form and results cannot disagree.
-  window.addEventListener("pageshow", function (event) {
-    if (!event.persisted) return;
+  // Safety net for back-forward cache restores that bring back rendered results
+  // but not the input value. (The input avoids autocomplete="off", which WebKit
+  // clears on page-cache restore, so the value normally survives on its own.)
+  // We cannot gate on event.persisted, which Safari reports unreliably here, so
+  // on every pageshow reconcile the input against the URL when they disagree,
+  // syncing now and on the next tick. The guard keeps it a no-op when the value
+  // is already correct, which is the common case.
+  window.addEventListener("pageshow", function () {
     var notes = new URLSearchParams(location.search).get("notes") || "";
     var reseed = function () {
       if (els.notes.value === notes) return;
       els.notes.value = notes;
       syncClear();
-      run();
+      if (window.whatchordReady) run();
     };
     reseed();
     setTimeout(reseed, 0);

--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -77,7 +77,7 @@
               <input
                 id="notes-input"
                 type="text"
-                autocomplete="off"
+                autocorrect="off"
                 autocapitalize="off"
                 maxlength="512"
                 spellcheck="false"


### PR DESCRIPTION
Safari reports event.persisted unreliably on bfcache restores, so the previous guard short-circuited the reseed there and left the notes input blank while the restored results stayed on screen. Drop the guard and reconcile the input against the URL whenever they disagree, guarding the engine call and repeating on the next tick to outlast WebKit's own form restoration.