### PR TITLE
Reject lone accidental glyphs as note names

### DIFF
--- a/docs/site/js/chord-id.js
+++ b/docs/site/js/chord-id.js
@@ -3009,30 +3009,30 @@ if(e>=3)return a.$3(b,c,d)
 if(e===2)return a.$2(b,c)
 if(e===1)return a.$1(b)
 return a.$0()},
-ax(a){var t,s,r,q,p,o,n="name",m=B.b.H(a)
-if(m.length===0)throw A.c(A.bC(a,n,"Empty note name"))
-t=A.P(m,"\ud834\udd2a","x")
-t=A.P(t,"\ud834\udd2b","bb")
-t=A.P(t,"\u266f","#")
-s=A.P(t,"\u266d","b")
-if(0>=s.length)return A.a(s,0)
-r=s[0].toUpperCase()
-if(!B.c3.h(0,r))throw A.c(A.bC(a,n,"Invalid note letter"))
-q=B.b.E(s,1)
-if(q.length===0)return r
-if(q==="##")q="x"
-for(t=new A.aM(q);t.k();){p=A.z(t.d)
-if(p!=="b"&&p!=="#"&&p!=="x")throw A.c(A.bC(a,n,'Invalid accidental character: "'+p+'"'))}if(B.b.h(q,"x")){if(q!=="x")throw A.c(A.bC(a,n,'Invalid accidental sequence: "'+q+'"'))
-return r+"x"}for(t=new A.aM(q),o=0;t.k();){p=A.z(t.d)
-if(p==="#")++o
-if(p==="b")--o}if(o<-2||o>2)throw A.c(A.bC(a,n,'Accidentals beyond double-flat/double-sharp not supported: "'+q+'"'))
-A:{t=""
-if(-2===o){t="bb"
-break A}if(-1===o){t="b"
-break A}if(0===o)break A
-if(1===o){t="#"
-break A}if(2===o){t="x"
-break A}break A}return r+t},
+ax(a){var t,s,r,q,p="name",o=B.b.H(a),n=o.length
+if(n===0)throw A.c(A.bC(a,p,"Empty note name"))
+if(0>=n)return A.a(o,0)
+t=o[0].toUpperCase()
+if(!B.c3.h(0,t))throw A.c(A.bC(a,p,"Invalid note letter"))
+n=B.b.E(o,1)
+n=A.P(n,"\ud834\udd2a","x")
+n=A.P(n,"\ud834\udd2b","bb")
+n=A.P(n,"\u266f","#")
+s=A.P(n,"\u266d","b")
+if(s.length===0)return t
+if(s==="##")s="x"
+for(n=new A.aM(s);n.k();){r=A.z(n.d)
+if(r!=="b"&&r!=="#"&&r!=="x")throw A.c(A.bC(a,p,'Invalid accidental character: "'+r+'"'))}if(B.b.h(s,"x")){if(s!=="x")throw A.c(A.bC(a,p,'Invalid accidental sequence: "'+s+'"'))
+return t+"x"}for(n=new A.aM(s),q=0;n.k();){r=A.z(n.d)
+if(r==="#")++q
+if(r==="b")--q}if(q<-2||q>2)throw A.c(A.bC(a,p,'Accidentals beyond double-flat/double-sharp not supported: "'+s+'"'))
+A:{n=""
+if(-2===q){n="bb"
+break A}if(-1===q){n="b"
+break A}if(0===q)break A
+if(1===q){n="#"
+break A}if(2===q){n="x"
+break A}break A}return t+n},
 aU(a,b){var t=B.a.m(a-b,12)
 return t},
 jC(a){var t,s,r,q,p,o,n,m=A.ax(a)

--- a/lib/features/theory/domain/services/pitch_class.dart
+++ b/lib/features/theory/domain/services/pitch_class.dart
@@ -23,23 +23,25 @@ String normalizeNoteNameToAscii(String name) {
     throw ArgumentError.value(name, 'name', 'Empty note name');
   }
 
-  // 1) Normalize glyph accidentals to ASCII tokens.
-  // Do double-accidentals first to avoid partial replacement issues.
-  final t = s
-      .replaceAll('𝄪', 'x') // double sharp
-      .replaceAll('𝄫', 'bb') // double flat
-      .replaceAll('♯', '#')
-      .replaceAll('♭', 'b');
-
-  // 2) Uppercase the note letter.
-  final letter = t[0].toUpperCase();
+  // 1) The note letter must come first, before any accidental. Validate it
+  // against the raw input: the flat glyphs (♭, 𝄫) normalize to an ASCII "b",
+  // which would otherwise be mistaken for the note letter B.
+  final letter = s[0].toUpperCase();
   const validLetters = {'A', 'B', 'C', 'D', 'E', 'F', 'G'};
   if (!validLetters.contains(letter)) {
     throw ArgumentError.value(name, 'name', 'Invalid note letter');
   }
 
-  // 3) Pull accidental region and canonicalize "##" -> "x".
-  var rest = t.substring(1);
+  // 2) Normalize glyph accidentals in the remainder to ASCII tokens.
+  // Do double-accidentals first to avoid partial replacement issues.
+  var rest = s
+      .substring(1)
+      .replaceAll('𝄪', 'x') // double sharp
+      .replaceAll('𝄫', 'bb') // double flat
+      .replaceAll('♯', '#')
+      .replaceAll('♭', 'b');
+
+  // 3) Canonicalize "##" -> "x".
 
   if (rest.isEmpty) return letter;
 

--- a/test/pitch_class_test.dart
+++ b/test/pitch_class_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:whatchord/features/theory/theory.dart';
+
+void main() {
+  group('normalizeNoteNameToAscii', () {
+    test('canonicalizes ASCII and Unicode accidentals', () {
+      expect(normalizeNoteNameToAscii(' f♯ '), 'F#');
+      expect(normalizeNoteNameToAscii('b♭'), 'Bb');
+      expect(normalizeNoteNameToAscii('G𝄪'), 'Gx');
+      expect(normalizeNoteNameToAscii('A𝄫'), 'Abb');
+      expect(normalizeNoteNameToAscii('C##'), 'Cx');
+    });
+
+    test('rejects a lone accidental with no note letter', () {
+      // The flat glyphs normalize to an ASCII "b"; guard against mistaking
+      // them for the note letter B.
+      for (final glyph in const ['𝄫', '♭', '♯', '𝄪', '#', 'x']) {
+        expect(
+          () => normalizeNoteNameToAscii(glyph),
+          throwsArgumentError,
+          reason: 'lone "$glyph" is not a note name',
+        );
+      }
+    });
+  });
+
+  group('pitchClassFromNoteName', () {
+    test('resolves double accidentals', () {
+      expect(pitchClassFromNoteName('C𝄫'), 10); // C double-flat = Bb
+      expect(pitchClassFromNoteName('G𝄪'), 9); // G double-sharp = A
+      expect(pitchClassFromNoteName('Abb'), 7); // A double-flat = G
+    });
+
+    test('rejects a lone double-flat glyph', () {
+      expect(() => pitchClassFromNoteName('𝄫'), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
normalizeNoteNameToAscii() substituted accidental glyphs to ASCII before extracting the note letter, so a lone double-flat "𝄫" became "bb" and was read as B-flat (and a lone "♭" as B). Validate the note letter against the raw first character first, then normalize glyphs in the remainder, so any name starting with an accidental is rejected. This makes all lone accidentals behave consistently while leaving valid spellings, including double accidentals, unchanged.