### PR TITLE
Add a tone ledger to the Why This Chord scoring view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 - The guided tour's final step now points its callout arrows at both the search
   button and the MIDI status icon, so you can see where to look up notes by name
   or connect a device.
+- The "Why This Chord?" scoring view now opens with a tone ledger that lays out
+  the chord's template notes by degree and shows which you played, which were
+  missing, and any extra or conflicting tones, so the score that follows is
+  easier to read. Each ranked chord also has an Explore button that opens it in
+  the chord builder and returns you to the same view.
 
 ### Added
 

--- a/lib/features/home/widgets/chord_ranking_details_sheet.dart
+++ b/lib/features/home/widgets/chord_ranking_details_sheet.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:whatchord/core/core.dart';
+import 'package:whatchord/features/chords/chords.dart';
 import 'package:whatchord/features/theory/theory.dart';
 
 import 'adaptive_side_sheet.dart';
@@ -549,18 +552,61 @@ class _CandidateScoreBack extends StatelessWidget {
   final RankingDecision? decision;
   final ChordCandidate winner;
 
+  void _openExplore(BuildContext context) {
+    // Push over the open sheet without dismissing it, so returning from Explore
+    // reveals the same "Why This Chord?" view (flipped cards and scroll intact).
+    unawaited(
+      Navigator.of(
+        context,
+      ).push(ExploreChordPage.route(seedIdentity: row.candidate.identity)),
+    );
+  }
+
+  int _maskFor(String label) {
+    for (final reason in row.scoreReasons) {
+      if (reason.label == label) return reason.intervals ?? 0;
+    }
+    return 0;
+  }
+
+  /// Builds (degree, note) pairs for the tones in [mask], ascending by interval.
+  /// Each tone is labeled individually so the degree and note name stay paired.
+  List<_ToneEntry> _tonesFor(int mask) {
+    final identity = row.candidate.identity;
+    final entries = <_ToneEntry>[];
+    for (var interval = 0; interval < 12; interval++) {
+      if ((mask & (1 << interval)) == 0) continue;
+      final pitchClass = (identity.rootPc + interval) % 12;
+      final pc = {pitchClass};
+      final degree = theoryTokenDisplayLabel(
+        ChordMemberDegreeFormatter.formatDegrees(
+          identity: identity,
+          pitchClasses: pc,
+        ).first,
+      );
+      final note = noteDisplayLabel(
+        ChordMemberSpeller.spellMembers(
+          identity: identity,
+          pitchClasses: pc,
+          tonality: tonality,
+        ).first,
+        noteNameSystem: noteNameSystem,
+      );
+      entries.add(
+        _ToneEntry(
+          degree: degree,
+          note: note,
+          isBass: pitchClass == identity.bassPc,
+        ),
+      );
+    }
+    return entries;
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
-    final members = ChordMemberSpeller.spellMembers(
-      identity: row.candidate.identity,
-      pitchClasses: ChordPresentationBuilder.chordMemberPitchClassesFromMask(
-        rootPc: row.candidate.identity.rootPc,
-        presentIntervalsMask: row.candidate.identity.presentIntervalsMask,
-      ).toSet(),
-      tonality: tonality,
-    ).map((name) => noteDisplayLabel(name, noteNameSystem: noteNameSystem));
     final scoringReasons = row.scoreReasons.where(
       (reason) => reason.label != 'normalize' && reason.delta != 0,
     );
@@ -585,11 +631,15 @@ class _CandidateScoreBack extends StatelessWidget {
             ),
           ],
         ),
-        const SizedBox(height: 8),
-        Text('Members', style: theme.textTheme.labelMedium),
-        const SizedBox(height: 2),
-        Text(members.join('  '), style: theme.textTheme.bodyMedium),
         const SizedBox(height: 10),
+        _TemplateLedger(
+          chordTones: _tonesFor(
+            _maskFor('required tones') | _maskFor('optional tones'),
+          ),
+          missing: _tonesFor(_maskFor('missing required')),
+          alsoPlayed: _tonesFor(_maskFor('penalty tones') | _maskFor('extras')),
+        ),
+        const Divider(height: 16),
         for (final reason in scoringReasons)
           _ScoreRow(
             label: _scoreReasonLabel(reason.label),
@@ -614,7 +664,168 @@ class _CandidateScoreBack extends StatelessWidget {
             ),
           ),
         ],
+        const SizedBox(height: 4),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton.icon(
+            onPressed: () => _openExplore(context),
+            icon: const Icon(Icons.explore_outlined, size: 18),
+            label: const Text('Explore'),
+            style: TextButton.styleFrom(
+              visualDensity: VisualDensity.compact,
+              foregroundColor: cs.primary,
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            ),
+          ),
+        ),
       ],
+    );
+  }
+}
+
+class _ToneEntry {
+  const _ToneEntry({
+    required this.degree,
+    required this.note,
+    this.isBass = false,
+  });
+
+  final String degree;
+  final String note;
+  final bool isBass;
+}
+
+/// Shows the candidate's template tones grouped as played chord tones, missing
+/// required tones, and any extra/conflicting tones that were played anyway.
+class _TemplateLedger extends StatelessWidget {
+  const _TemplateLedger({
+    required this.chordTones,
+    required this.missing,
+    required this.alsoPlayed,
+  });
+
+  final List<_ToneEntry> chordTones;
+  final List<_ToneEntry> missing;
+  final List<_ToneEntry> alsoPlayed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _ToneGroup(label: 'Chord tones', tones: chordTones),
+        if (missing.isNotEmpty)
+          _ToneGroup(label: 'Missing', tones: missing, muted: true),
+        if (alsoPlayed.isNotEmpty)
+          _ToneGroup(label: 'Also played', tones: alsoPlayed),
+      ],
+    );
+  }
+}
+
+class _ToneGroup extends StatelessWidget {
+  const _ToneGroup({
+    required this.label,
+    required this.tones,
+    this.muted = false,
+  });
+
+  final String label;
+  final List<_ToneEntry> tones;
+  final bool muted;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: cs.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.only(left: 8),
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 6,
+              children: [
+                for (final tone in tones) _ToneChip(tone: tone, muted: muted),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ToneChip extends StatelessWidget {
+  const _ToneChip({required this.tone, this.muted = false});
+
+  final _ToneEntry tone;
+  final bool muted;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final isBass = tone.isBass;
+    final foreground = isBass
+        ? cs.onPrimaryContainer
+        : muted
+        ? cs.onSurfaceVariant
+        : cs.onSurface;
+    final fill = isBass
+        ? cs.primaryContainer
+        : muted
+        ? cs.surface
+        : cs.surfaceContainer;
+
+    final chip = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: fill,
+        borderRadius: BorderRadius.circular(7),
+        border: Border.all(
+          color: isBass ? cs.primary : cs.outlineVariant.withValues(alpha: 0.6),
+          width: 1.5,
+        ),
+      ),
+      child: Text.rich(
+        TextSpan(
+          children: [
+            TextSpan(
+              text: tone.degree,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: foreground.withValues(alpha: 0.7),
+              ),
+            ),
+            const TextSpan(text: '  '),
+            TextSpan(
+              text: tone.note,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: foreground,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (!isBass) return chip;
+
+    return Semantics(
+      label: '${tone.note}, ${tone.degree}, bass note',
+      child: ExcludeSemantics(child: chip),
     );
   }
 }
@@ -634,11 +845,10 @@ class _ScoreRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final style = emphasized
-        ? Theme.of(
-            context,
-          ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700)
-        : Theme.of(context).textTheme.bodyMedium;
+        ? theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w700)
+        : theme.textTheme.bodyMedium;
     final valueLabel =
         '${signed && value > 0 ? '+' : ''}${value.toStringAsFixed(2)}';
 
@@ -647,6 +857,7 @@ class _ScoreRow extends StatelessWidget {
       child: Row(
         children: [
           Expanded(child: Text(label, style: style)),
+          const SizedBox(width: 8),
           Text(valueLabel, style: style),
         ],
       ),

--- a/lib/features/theory/domain/analysis/chord_analyzer.dart
+++ b/lib/features/theory/domain/analysis/chord_analyzer.dart
@@ -20,7 +20,12 @@ class ScoreReason {
   final double delta;
   final String? detail;
 
-  const ScoreReason(this.label, this.delta, {this.detail});
+  /// Root-relative interval mask for the notes in this category, when the
+  /// reason describes a tone set (required, optional, penalty, extras,
+  /// missing). Null for contextual modifiers that have no note set.
+  final int? intervals;
+
+  const ScoreReason(this.label, this.delta, {this.detail, this.intervals});
 
   @override
   String toString() {
@@ -267,8 +272,10 @@ abstract final class ChordAnalyzer {
     required AnalysisContext context,
     List<ScoreReason>? reasons,
   }) {
-    void add(String label, double delta, {String? detail}) {
-      reasons?.add(ScoreReason(label, delta, detail: detail));
+    void add(String label, double delta, {String? detail, int? intervals}) {
+      reasons?.add(
+        ScoreReason(label, delta, detail: detail, intervals: intervals),
+      );
     }
 
     if ((relMask & 0x1) == 0) return null;
@@ -341,23 +348,48 @@ abstract final class ChordAnalyzer {
 
     final reqDelta = reqCount * _reqWeight;
     raw += reqDelta;
-    add('required tones', reqDelta, detail: 'count=$reqCount');
+    add(
+      'required tones',
+      reqDelta,
+      detail: 'count=$reqCount',
+      intervals: presentRequiredMask,
+    );
 
     final missDelta = -missCount * _missWeight;
     raw += missDelta;
-    add('missing required', missDelta, detail: 'count=$missCount');
+    add(
+      'missing required',
+      missDelta,
+      detail: 'count=$missCount',
+      intervals: missingRequiredMask,
+    );
 
     final optDelta = optCount * _optWeight;
     raw += optDelta;
-    add('optional tones', optDelta, detail: 'count=$optCount');
+    add(
+      'optional tones',
+      optDelta,
+      detail: 'count=$optCount',
+      intervals: presentOptionalMask,
+    );
 
     final penDelta = -penCount * _penWeight;
     raw += penDelta;
-    add('penalty tones', penDelta, detail: 'count=$penCount');
+    add(
+      'penalty tones',
+      penDelta,
+      detail: 'count=$penCount',
+      intervals: presentPenaltyMask,
+    );
 
     final extraDelta = -extraCount * _extraWeight;
     raw += extraDelta;
-    add('extras', extraDelta, detail: 'count=$extraCount');
+    add(
+      'extras',
+      extraDelta,
+      detail: 'count=$extraCount',
+      intervals: extrasMask,
+    );
 
     // Bass scoring priority (reflects common voicing practices):
     // base tone > color/extension tone on 7th chord > add tone on triad > not in template


### PR DESCRIPTION
Open each scoring breakdown with the chord's template tones grouped into played chord tones, missing required tones, and extra or conflicting tones, each labeled by degree and note with glyph accidentals. Mark the bass tone with a filled, ringed chip and ghost the missing tones so the score that follows is easier to trace.

Surface the per-category interval masks the analyzer already computes so the ledger can spell each group's notes, at no cost to the live analysis path. Keep the score in the card's top-right to match the front-face fit label, and add an Explore button that opens the chord in the builder without dismissing the sheet, so returning lands on the same view.