### PR TITLE
Improve Explore Chords alignment with the analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 - Made flat-thirteenth colors available on triad-like chords in Explore Chords
   and preserved them when opening analyzed chords.
+- Added flat-ninth color choices for minor and suspended-fourth chords in
+  Explore Chords.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog][1], and this project adheres to
   and preserved them when opening analyzed chords.
 - Added flat-ninth color choices for minor and suspended-fourth chords in
   Explore Chords.
+- Prevented contradictory natural- and flat-thirteenth selections in Explore
+  Chords.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Made flat-thirteenth colors available on triad-like chords in Explore Chords
+  and preserved them when opening analyzed chords.
+
 ### Changed
 
 - The guided tour's final step now points its callout arrows at both the search

--- a/lib/features/chords/services/explore_chord_options.dart
+++ b/lib/features/chords/services/explore_chord_options.dart
@@ -252,4 +252,5 @@ const _triadLikeAlterationChoiceOrder = [
   ChordExtension.addFlat9,
   ChordExtension.addSharp9,
   ChordExtension.sharp11,
+  ChordExtension.flat13,
 ];

--- a/lib/features/chords/services/explore_extension_rules.dart
+++ b/lib/features/chords/services/explore_extension_rules.dart
@@ -400,6 +400,7 @@ const _triadLikeExtensionsByQuality = <ChordQualityToken, Set<ChordExtension>>{
   ChordQualityToken.minor: {
     ChordExtension.add9,
     ChordExtension.add11,
+    ChordExtension.addFlat9,
     ChordExtension.sharp11,
     ChordExtension.flat13,
   },
@@ -429,6 +430,7 @@ const _triadLikeExtensionsByQuality = <ChordQualityToken, Set<ChordExtension>>{
   ChordQualityToken.sus4: {
     ChordExtension.add9,
     ChordExtension.add13,
+    ChordExtension.addFlat9,
     ChordExtension.flat13,
   },
   ChordQualityToken.sus2sus4: {ChordExtension.add13, ChordExtension.flat13},

--- a/lib/features/chords/services/explore_extension_rules.dart
+++ b/lib/features/chords/services/explore_extension_rules.dart
@@ -220,6 +220,12 @@ void removeTriadLikeConflicts(
     case ChordExtension.sharp11:
       extensions.remove(ChordExtension.add11);
       break;
+    case ChordExtension.add13:
+      extensions.remove(ChordExtension.flat13);
+      break;
+    case ChordExtension.flat13:
+      extensions.remove(ChordExtension.add13);
+      break;
     default:
       break;
   }
@@ -440,14 +446,12 @@ const _triadLikeExtensionsByQuality = <ChordQualityToken, Set<ChordExtension>>{
     ChordExtension.flat9,
     ChordExtension.addSharp9,
     ChordExtension.sharp11,
-    ChordExtension.flat13,
   },
   ChordQualityToken.minor6: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.flat9,
     ChordExtension.sharp11,
-    ChordExtension.flat13,
   },
 };
 

--- a/lib/features/chords/services/explore_extension_rules.dart
+++ b/lib/features/chords/services/explore_extension_rules.dart
@@ -106,7 +106,11 @@ Set<ChordExtension> normalizeExtensionsForQuality({
         }
         break;
       case ChordExtension.flat13:
-        addSeventhAlteration(extension);
+        if (quality.isSeventhFamily) {
+          addSeventhAlteration(extension);
+        } else {
+          addTriadLikeExtension(extension);
+        }
         break;
       case ChordExtension.flat9:
       case ChordExtension.addFlat9:
@@ -335,6 +339,7 @@ Set<ChordExtension> triadLikeAlterations(ChordQualityToken quality) {
     if (available.contains(ChordExtension.addFlat9)) ChordExtension.addFlat9,
     if (available.contains(ChordExtension.addSharp9)) ChordExtension.addSharp9,
     if (available.contains(ChordExtension.sharp11)) ChordExtension.sharp11,
+    if (available.contains(ChordExtension.flat13)) ChordExtension.flat13,
   };
 }
 
@@ -390,11 +395,13 @@ const _triadLikeExtensionsByQuality = <ChordQualityToken, Set<ChordExtension>>{
     ChordExtension.addFlat9,
     ChordExtension.addSharp9,
     ChordExtension.sharp11,
+    ChordExtension.flat13,
   },
   ChordQualityToken.minor: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.sharp11,
+    ChordExtension.flat13,
   },
   ChordQualityToken.minorSharp5: {
     ChordExtension.add9,
@@ -402,7 +409,11 @@ const _triadLikeExtensionsByQuality = <ChordQualityToken, Set<ChordExtension>>{
     ChordExtension.add13,
     ChordExtension.sharp11,
   },
-  ChordQualityToken.diminished: {ChordExtension.add9, ChordExtension.add11},
+  ChordQualityToken.diminished: {
+    ChordExtension.add9,
+    ChordExtension.add11,
+    ChordExtension.flat13,
+  },
   ChordQualityToken.augmented: {
     ChordExtension.add9,
     ChordExtension.add11,
@@ -410,20 +421,31 @@ const _triadLikeExtensionsByQuality = <ChordQualityToken, Set<ChordExtension>>{
     ChordExtension.addSharp9,
     ChordExtension.sharp11,
   },
-  ChordQualityToken.sus2: {ChordExtension.add11, ChordExtension.add13},
-  ChordQualityToken.sus4: {ChordExtension.add9, ChordExtension.add13},
+  ChordQualityToken.sus2: {
+    ChordExtension.add11,
+    ChordExtension.add13,
+    ChordExtension.flat13,
+  },
+  ChordQualityToken.sus4: {
+    ChordExtension.add9,
+    ChordExtension.add13,
+    ChordExtension.flat13,
+  },
+  ChordQualityToken.sus2sus4: {ChordExtension.add13, ChordExtension.flat13},
   ChordQualityToken.major6: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.flat9,
     ChordExtension.addSharp9,
     ChordExtension.sharp11,
+    ChordExtension.flat13,
   },
   ChordQualityToken.minor6: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.flat9,
     ChordExtension.sharp11,
+    ChordExtension.flat13,
   },
 };
 

--- a/test/explore_chord_options_test.dart
+++ b/test/explore_chord_options_test.dart
@@ -185,6 +185,7 @@ void main() {
           ChordExtension.add11,
         ]);
         expect(groups[1].choices.map((choice) => choice.extension), [
+          ChordExtension.addFlat9,
           ChordExtension.sharp11,
           ChordExtension.flat13,
         ]);
@@ -357,6 +358,7 @@ void main() {
         ChordQualityToken.minor: [
           ChordExtension.add9,
           ChordExtension.add11,
+          ChordExtension.addFlat9,
           ChordExtension.sharp11,
           ChordExtension.flat13,
         ],
@@ -386,6 +388,7 @@ void main() {
         ChordQualityToken.sus4: [
           ChordExtension.add9,
           ChordExtension.add13,
+          ChordExtension.addFlat9,
           ChordExtension.flat13,
         ],
         ChordQualityToken.sus2sus4: [
@@ -808,7 +811,7 @@ void main() {
       expect(sus4, {ChordExtension.add9, ChordExtension.add13});
     });
 
-    test('drops unsupported alterations for non-seventh qualities', () {
+    test('preserves supported alterations for non-seventh qualities', () {
       final normalized = normalizeExtensionsForQuality(
         quality: ChordQualityToken.minor,
         extensions: const {
@@ -819,7 +822,11 @@ void main() {
         },
       );
 
-      expect(normalized, {ChordExtension.sharp11, ChordExtension.flat13});
+      expect(normalized, {
+        ChordExtension.addFlat9,
+        ChordExtension.sharp11,
+        ChordExtension.flat13,
+      });
     });
 
     test('drops seventh-family extensions that duplicate core chord tones', () {

--- a/test/explore_chord_options_test.dart
+++ b/test/explore_chord_options_test.dart
@@ -229,7 +229,6 @@ void main() {
         ChordExtension.flat9,
         ChordExtension.addSharp9,
         ChordExtension.sharp11,
-        ChordExtension.flat13,
       ]);
     });
 
@@ -401,14 +400,12 @@ void main() {
           ChordExtension.flat9,
           ChordExtension.addSharp9,
           ChordExtension.sharp11,
-          ChordExtension.flat13,
         ],
         ChordQualityToken.minor6: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.flat9,
           ChordExtension.sharp11,
-          ChordExtension.flat13,
         ],
       };
 
@@ -960,6 +957,34 @@ void main() {
       );
 
       expect(withAdd11, {ChordExtension.add11});
+    });
+
+    test('replaces natural and flat thirteenth choices for sus qualities', () {
+      final groups = buildExploreExtensionControlGroups(ChordQualityToken.sus4);
+      final addToneGroup = groups[0];
+      final colorGroup = groups[1];
+
+      final withFlat13 = selectExploreExtensionChoice(
+        quality: ChordQualityToken.sus4,
+        currentExtensions: const {ChordExtension.add13},
+        group: colorGroup,
+        choice: colorGroup.choices.firstWhere(
+          (choice) => choice.extension == ChordExtension.flat13,
+        ),
+      );
+
+      expect(withFlat13, {ChordExtension.flat13});
+
+      final withAdd13 = selectExploreExtensionChoice(
+        quality: ChordQualityToken.sus4,
+        currentExtensions: withFlat13,
+        group: addToneGroup,
+        choice: addToneGroup.choices.firstWhere(
+          (choice) => choice.extension == ChordExtension.add13,
+        ),
+      );
+
+      expect(withAdd13, {ChordExtension.add13});
     });
 
     test('toggles triad-like extension choices within their groups', () {

--- a/test/explore_chord_options_test.dart
+++ b/test/explore_chord_options_test.dart
@@ -153,11 +153,13 @@ void main() {
           ChordExtension.addFlat9,
           ChordExtension.addSharp9,
           ChordExtension.sharp11,
+          ChordExtension.flat13,
         ]);
         expect(groups[1].choices.map((choice) => choice.label), [
           '♭9',
           '♯9',
           '♯11',
+          '♭13',
         ]);
       },
     );
@@ -184,6 +186,7 @@ void main() {
         ]);
         expect(groups[1].choices.map((choice) => choice.extension), [
           ChordExtension.sharp11,
+          ChordExtension.flat13,
         ]);
       },
     );
@@ -225,6 +228,7 @@ void main() {
         ChordExtension.flat9,
         ChordExtension.addSharp9,
         ChordExtension.sharp11,
+        ChordExtension.flat13,
       ]);
     });
 
@@ -348,11 +352,13 @@ void main() {
           ChordExtension.addFlat9,
           ChordExtension.addSharp9,
           ChordExtension.sharp11,
+          ChordExtension.flat13,
         ],
         ChordQualityToken.minor: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.sharp11,
+          ChordExtension.flat13,
         ],
         ChordQualityToken.minorSharp5: [
           ChordExtension.add9,
@@ -363,6 +369,7 @@ void main() {
         ChordQualityToken.diminished: [
           ChordExtension.add9,
           ChordExtension.add11,
+          ChordExtension.flat13,
         ],
         ChordQualityToken.augmented: [
           ChordExtension.add9,
@@ -371,20 +378,34 @@ void main() {
           ChordExtension.addSharp9,
           ChordExtension.sharp11,
         ],
-        ChordQualityToken.sus2: [ChordExtension.add11, ChordExtension.add13],
-        ChordQualityToken.sus4: [ChordExtension.add9, ChordExtension.add13],
+        ChordQualityToken.sus2: [
+          ChordExtension.add11,
+          ChordExtension.add13,
+          ChordExtension.flat13,
+        ],
+        ChordQualityToken.sus4: [
+          ChordExtension.add9,
+          ChordExtension.add13,
+          ChordExtension.flat13,
+        ],
+        ChordQualityToken.sus2sus4: [
+          ChordExtension.add13,
+          ChordExtension.flat13,
+        ],
         ChordQualityToken.major6: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.flat9,
           ChordExtension.addSharp9,
           ChordExtension.sharp11,
+          ChordExtension.flat13,
         ],
         ChordQualityToken.minor6: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.flat9,
           ChordExtension.sharp11,
+          ChordExtension.flat13,
         ],
       };
 
@@ -599,6 +620,28 @@ void main() {
       expect(identity.extensions, {ChordExtension.sharp11});
     });
 
+    test('keeps a minor flat thirteenth when normalizing a page seed', () {
+      final normalized = normalizeExtensionsForQuality(
+        quality: ChordQualityToken.minor,
+        extensions: const {ChordExtension.flat13},
+      );
+      final identity = buildExploreChordIdentity(
+        ExploreChordState(
+          rootPc: 9,
+          bassPc: 2,
+          quality: ChordQualityToken.minor,
+          extensions: normalized,
+        ),
+      );
+
+      expect(identity.rootPc, 9);
+      // Explore currently limits bass choices to chord members, so the foreign
+      // D bass from Amb13/D normalizes to the A root independently of flat13.
+      expect(identity.bassPc, 9);
+      expect(identity.quality, ChordQualityToken.minor);
+      expect(identity.extensions, {ChordExtension.flat13});
+    });
+
     test(
       'promotes seventh-family add ninth while preserving skipped add tones',
       () {
@@ -776,7 +819,7 @@ void main() {
         },
       );
 
-      expect(normalized, {ChordExtension.sharp11});
+      expect(normalized, {ChordExtension.sharp11, ChordExtension.flat13});
     });
 
     test('drops seventh-family extensions that duplicate core chord tones', () {

--- a/tool/chord_debug.dart
+++ b/tool/chord_debug.dart
@@ -40,7 +40,8 @@ Options:
                          Default: textual.
   -f, --format=FORMAT    Output format. Valid: text, json. Default: text.
       --json             Alias for --format=json.
-  -v, --verbose          Include input and ChordIdentity diagnostics.
+  -v, --verbose          Include input, ChordIdentity, and played/missing/extra
+                         tone-bucket diagnostics.
   -c, --compact          Use a condensed, single-line-per-candidate output.
 ''';
 
@@ -246,6 +247,13 @@ void main(List<String> args) {
       stdout.writeln('     members: $members');
     }
 
+    // Played/missing/extra tone buckets, mirroring the app's tone ledger.
+    if (verbose) {
+      stdout.writeln(
+        '     tones: ${_formatToneBuckets(id, r.scoreReasons, context: context)}',
+      );
+    }
+
     // Reasons: tokenized & compact.
     final tokens = _reasonTokens(
       r.scoreReasons,
@@ -337,6 +345,79 @@ String _formatChordMembersByRole(
   }
 
   return parts.join('  ');
+}
+
+/// Formats the played, missing, and extra tone buckets for a candidate,
+/// mirroring the app's "Why This Chord?" tone ledger.
+///
+/// Output example:
+///   chord=[1:C 3:E 5:G*]  missing=[7:B]  also=[#9:D#]
+///
+/// Buckets reuse the per-category interval masks the analyzer records on each
+/// ScoreReason. The bass tone is marked with a trailing `*`.
+String _formatToneBuckets(
+  ChordIdentity id,
+  List<ScoreReason> reasons, {
+  required AnalysisContext context,
+}) {
+  final chordMask =
+      _maskForReason(reasons, 'required tones') |
+      _maskForReason(reasons, 'optional tones');
+  final missingMask = _maskForReason(reasons, 'missing required');
+  final alsoMask =
+      _maskForReason(reasons, 'penalty tones') |
+      _maskForReason(reasons, 'extras');
+
+  final segments = <String>[
+    'chord=[${_formatTones(id, chordMask, context: context)}]',
+  ];
+
+  final missing = _formatTones(id, missingMask, context: context);
+  if (missing.isNotEmpty) segments.add('missing=[$missing]');
+
+  final also = _formatTones(id, alsoMask, context: context);
+  if (also.isNotEmpty) segments.add('also=[$also]');
+
+  return segments.join('  ');
+}
+
+/// Returns the root-relative interval mask the analyzer recorded for [label],
+/// or 0 when that reason carries no tone set.
+int _maskForReason(List<ScoreReason> reasons, String label) {
+  for (final reason in reasons) {
+    if (reason.label == label) return reason.intervals ?? 0;
+  }
+  return 0;
+}
+
+/// Formats the tones in [mask] as `degree:note` tokens, ascending by interval,
+/// marking the bass tone with a trailing `*`.
+String _formatTones(
+  ChordIdentity id,
+  int mask, {
+  required AnalysisContext context,
+}) {
+  final parts = <String>[];
+  for (var interval = 0; interval < 12; interval++) {
+    if ((mask & (1 << interval)) == 0) continue;
+    final pc = {(id.rootPc + interval) % 12};
+    final degree = theoryTokenDisplayLabel(
+      ChordMemberDegreeFormatter.formatDegrees(
+        identity: id,
+        pitchClasses: pc,
+      ).first,
+    );
+    final note = _displayNoteLabel(
+      ChordMemberSpeller.spellMembers(
+        identity: id,
+        pitchClasses: pc,
+        tonality: context.tonality,
+      ).first,
+    );
+    final bassMark = pc.first == id.bassPc ? '*' : '';
+    parts.add('$degree:$note$bassMark');
+  }
+  return parts.join(' ');
 }
 
 void _writeJsonOutput({


### PR DESCRIPTION
...while keeping the interface focused on conventional, useful chord construction.

- Added flat-thirteenth support for applicable triad-like chords, allowing analyzed colors such as Amb13 to seed correctly into Explore.
- Added evidence-backed added-flat-ninth options for minor and suspended-fourth chords.
- Kept uncommon or ambiguous analyzer-generated combinations excluded when they lacked strong theoretical or corpus justification.
- Made natural and flat thirteenths mutually exclusive.
- Removed flat-thirteenth options from sixth chords, which already contain the natural sixth/13th.
- Preserved conventional altered-seventh flexibility, including multiple ninth alterations.
- Confirmed that foreign slash basses intentionally normalize to chord-member basses in Explore.

An exhaustive analyzer-to-Explore audit was performed during development. It confirmed that a full round-trip contract would be inappropriate because the analyzer deliberately generates low-ranked structural interpretations that Explore should canonicalize or exclude. Focused tests now cover the supported extension options, normalization, conflict handling, and representative seed behavior.