### PR TITLE
Add chord deep links and home-screen sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added a Share button on the home screen that creates a link to the current
+  chord. Recipients who have WhatChord open it directly in the app, seeded into
+  the manual lookup pad with the same key; everyone else lands on the matching
+  page of the website.
+- Added support for opening whatchord.earthmanmuons.com/try links in the app,
+  including shared links and links from the Try page on the website.
+
 ### Fixed
 
 - Identify a raised eleventh on major, major-sixth, and major-seventh chords as

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,16 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- App Links: open verified https://whatchord.earthmanmuons.com/try
+                 links directly in the app. Verified via /.well-known/assetlinks.json. -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https"
+                    android:host="whatchord.earthmanmuons.com"
+                    android:pathPrefix="/try"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/docs/site/.well-known/apple-app-site-association
+++ b/docs/site/.well-known/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["6ZR326Y3XC.com.earthmanmuons.whatchord"],
+        "components": [
+          {
+            "/": "/try",
+            "comment": "Open shared chord links in the app"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/site/.well-known/assetlinks.json
+++ b/docs/site/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.earthmanmuons.whatchord",
+      "sha256_cert_fingerprints": [
+        "E8:21:56:94:BA:A2:E0:A3:48:E6:97:49:3E:8B:A9:92:94:93:5E:46:DD:17:03:2C:3C:67:F3:63:9F:A1:3E:F8"
+      ]
+    }
+  }
+]

--- a/docs/site/_headers
+++ b/docs/site/_headers
@@ -1,3 +1,7 @@
+# Apple requires this association file served as JSON, with no extension.
+/.well-known/apple-app-site-association
+  Content-Type: application/json
+
 /*
   Content-Security-Policy: default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; media-src 'self'; object-src 'none'; script-src 'self'; style-src 'self'; upgrade-insecure-requests
   Cross-Origin-Opener-Policy: same-origin

--- a/docs/site/css/try.css
+++ b/docs/site/css/try.css
@@ -360,13 +360,23 @@ select.try-select:focus {
   margin-bottom: 0;
 }
 
-#copy-link {
+.try-results-actions {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+#copy-link,
+#open-app {
   flex-shrink: 0;
   gap: 7px;
   font-size: 0.82rem;
 }
 
-#copy-link svg {
+#copy-link svg,
+#open-app svg {
   width: 14px;
   height: 14px;
   fill: currentcolor;

--- a/docs/site/js/try.js
+++ b/docs/site/js/try.js
@@ -66,6 +66,9 @@
   var DEFAULT_MODE = "maj";
   var DEFAULT_NOTATION = "textual";
   var MAX_NOTES_CHARACTERS = 512;
+  var SITE_HOST = "whatchord.earthmanmuons.com";
+  var ANDROID_PACKAGE = "com.earthmanmuons.whatchord";
+  var IS_ANDROID = /android/i.test(navigator.userAgent);
   // Matches the static <title> in try.html; restored when there is no result
   // to show. The Worker overrides the served title for seeded links, so we
   // cannot read this back from document.title at boot.
@@ -84,6 +87,7 @@
     rankingFeedback: document.getElementById("ranking-feedback"),
     copyLink: document.getElementById("copy-link"),
     copyLabel: document.querySelector("#copy-link .copy-label"),
+    openApp: document.getElementById("open-app"),
   };
 
   var state = {
@@ -200,6 +204,29 @@
   function syncUrl() {
     var path = location.protocol === "file:" ? location.pathname : "/try";
     history.replaceState(null, "", path + buildQuery());
+  }
+
+  // Android has no native smart banner, so offer an explicit deep link. The
+  // intent URL opens the app when installed and falls back to this page when
+  // not. Shown only on Android, and only when there is a chord to open.
+  function updateOpenAppLink() {
+    if (!IS_ANDROID || !state.canonicalNotes) {
+      els.openApp.hidden = true;
+      return;
+    }
+    var query = buildQuery();
+    var httpsUrl = "https://" + SITE_HOST + "/try" + query;
+    els.openApp.href =
+      "intent://" +
+      SITE_HOST +
+      "/try" +
+      query +
+      "#Intent;scheme=https;package=" +
+      ANDROID_PACKAGE +
+      ";S.browser_fallback_url=" +
+      encodeURIComponent(httpsUrl) +
+      ";end";
+    els.openApp.hidden = false;
   }
 
   // Keeps the tab title in step with the current result, same format the
@@ -386,6 +413,7 @@
       els.candidates.innerHTML = "";
       els.resultsHead.hidden = true;
       els.rankingFeedback.hidden = true;
+      updateOpenAppLink();
       setStatus("");
       return;
     }
@@ -397,6 +425,7 @@
     syncUrl();
     syncTitle(result);
     render(result);
+    updateOpenAppLink();
   }
 
   function toAsciiNote(note) {

--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -2,7 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <!-- Native iOS banner offering to open a shared chord in the app. The
+         Worker injects app-argument on seeded links so OPEN deep-links to the
+         exact chord; see worker/index.js. -->
+    <meta name="apple-itunes-app" content="app-id=6758409779" />
     <title>Try It - Identify a Chord | WhatChord</title>
     <meta
       name="description"
@@ -117,9 +124,8 @@
               </button>
             </div>
             <div class="try-hint" id="notes-hint">
-              Separate with spaces, commas, or hyphens. Names like C, F#, Bb,
-              or MIDI numbers like 60.<br />The first note is treated as the
-              bass.
+              Separate with spaces, commas, or hyphens. Names like C, F#, Bb, or
+              MIDI numbers like 60.<br />The first note is treated as the bass.
             </div>
 
             <div class="try-controls">
@@ -184,14 +190,32 @@
               </div>
               <div class="try-results-head" id="results-head" hidden>
                 <div class="try-echo" id="echo"></div>
-                <button class="btn btn-primary" id="copy-link" type="button">
-                  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                    <path
-                      d="M3.9 12a3.1 3.1 0 0 1 3.1-3.1h4V7H7a5 5 0 0 0 0 10h4v-1.9H7A3.1 3.1 0 0 1 3.9 12zm4.1 1h8v-2H8v2zm9-6h-4v1.9h4a3.1 3.1 0 0 1 0 6.2h-4V17h4a5 5 0 0 0 0-10z"
-                    />
-                  </svg>
-                  <span class="copy-label">Copy link</span>
-                </button>
+                <div class="try-results-actions">
+                  <a class="btn btn-ghost" id="open-app" hidden>
+                    <svg
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M14 3v2h3.6l-9.8 9.8 1.4 1.4L19 6.4V10h2V3h-7zM5 5h6V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6h-2v6H5V5z"
+                      />
+                    </svg>
+                    <span>Open in app</span>
+                  </a>
+                  <button class="btn btn-primary" id="copy-link" type="button">
+                    <svg
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M3.9 12a3.1 3.1 0 0 1 3.1-3.1h4V7H7a5 5 0 0 0 0 10h4v-1.9H7A3.1 3.1 0 0 1 3.9 12zm4.1 1h8v-2H8v2zm9-6h-4v1.9h4a3.1 3.1 0 0 1 0 6.2h-4V17h4a5 5 0 0 0 0-10z"
+                      />
+                    </svg>
+                    <span class="copy-label">Copy link</span>
+                  </button>
+                </div>
               </div>
               <div id="candidates"></div>
               <p class="try-feedback" id="ranking-feedback" hidden>

--- a/docs/site/worker/index.js
+++ b/docs/site/worker/index.js
@@ -11,6 +11,7 @@ import "../js/chord-id.js";
 const DEFAULT_MODE = "maj";
 const DEFAULT_NOTATION = "textual";
 const MAX_NOTES_CHARACTERS = 512;
+const IOS_APP_ID = "6758409779";
 const VALID_KEYS = new Set([
   "C:maj",
   "C#:maj",
@@ -135,7 +136,15 @@ function rewriteMeta(html, meta) {
   out = replaceMeta(out, "property", "og:description", meta.description);
   out = replaceMeta(out, "property", "og:url", meta.shareUrl);
   out = replaceMeta(out, "name", "twitter:title", meta.title);
-  return replaceMeta(out, "name", "twitter:description", meta.description);
+  out = replaceMeta(out, "name", "twitter:description", meta.description);
+  // Point the Smart App Banner's OPEN button at this exact chord, so tapping it
+  // deep-links into the app instead of cold-launching to the home screen.
+  return replaceMeta(
+    out,
+    "name",
+    "apple-itunes-app",
+    "app-id=" + IOS_APP_ID + ", app-argument=" + meta.shareUrl,
+  );
 }
 
 function replaceMeta(html, attribute, key, content) {

--- a/docs/whatsnew/unreleased/whatsnew-en-US
+++ b/docs/whatsnew/unreleased/whatsnew-en-US
@@ -1,0 +1,4 @@
+- Share a chord straight from the home screen. The link opens the exact chord
+  in WhatChord, or on the website for anyone who does not have the app yet.
+- Tap a shared link or a link from the website's Try page to drop the notes and
+  key right into the manual lookup pad.

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -481,6 +481,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -678,6 +679,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -711,6 +713,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:whatchord.earthmanmuons.com</string>
+	</array>
+</dict>
+</plist>

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:whatchord/features/demo/demo.dart';
 import 'package:whatchord/features/input/input.dart';
+import 'package:whatchord/features/links/links.dart';
 import 'package:whatchord/features/lookup/lookup.dart';
 import 'package:whatchord/features/midi/midi.dart';
 import 'package:whatchord/features/onboarding/onboarding.dart';
@@ -246,6 +247,7 @@ class _HomeTopBar extends ConsumerWidget {
                     },
                   ),
                 ),
+              const _ShareButton(),
               const SizedBox(width: 4),
               MidiStatusIcon(
                 onPressed: onOpenMidiSettings,
@@ -276,6 +278,39 @@ class _HomeTopBar extends ConsumerWidget {
         ),
       ),
     );
+  }
+}
+
+/// Shares a website link to the current voicing via the native share sheet.
+/// Disabled when nothing is sounding, so there is nothing to link to.
+class _ShareButton extends ConsumerWidget {
+  const _ShareButton();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final link = ref.watch(shareLinkProvider);
+
+    return IconButton(
+      constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
+      icon: const Icon(Icons.ios_share),
+      tooltip: 'Share chord',
+      onPressed: link == null ? null : () => _share(context, link),
+    );
+  }
+
+  void _share(BuildContext context, Uri link) {
+    // Anchor the iPad popover to the button.
+    final box = context.findRenderObject() as RenderBox?;
+    final overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox?;
+    Rect? origin;
+    if (box != null && overlay != null) {
+      origin = Rect.fromPoints(
+        box.localToGlobal(Offset.zero, ancestor: overlay),
+        box.localToGlobal(box.size.bottomRight(Offset.zero), ancestor: overlay),
+      );
+    }
+    unawaited(shareChordLink(link, sharePositionOrigin: origin));
   }
 }
 

--- a/lib/features/links/links.dart
+++ b/lib/features/links/links.dart
@@ -1,0 +1,7 @@
+export 'models/chord_link.dart';
+
+export 'providers/deep_link_provider.dart';
+export 'providers/share_link_provider.dart';
+
+export 'services/deep_link_service.dart';
+export 'services/share_chord_link.dart';

--- a/lib/features/links/models/chord_link.dart
+++ b/lib/features/links/models/chord_link.dart
@@ -1,0 +1,117 @@
+import 'package:meta/meta.dart';
+
+import 'package:whatchord/features/theory/theory.dart';
+
+/// Canonical website link grammar, shared by link building and deep-link
+/// parsing so the two can never drift.
+///
+/// Shape: `https://whatchord.earthmanmuons.com/try?notes=<n>&key=<Root>:<maj|min>`
+/// where `notes` is space-separated note names (C, F#, Bb) or MIDI numbers, and
+/// the first note is the bass. This matches the /try web page. Notation style is
+/// intentionally not carried; the app applies its own.
+class ChordLink {
+  const ChordLink._();
+
+  static const host = 'whatchord.earthmanmuons.com';
+  static const path = '/try';
+
+  /// Mirrors the web page cap; oversized links are ignored rather than parsed.
+  static const _maxNotesCharacters = 512;
+
+  static final _separator = RegExp(r'[\s,\-]+');
+
+  /// Builds a shareable link for [orderedNotes] (ascending MIDI numbers, first
+  /// entry is the bass) in [tonality]. Returns null when there are no notes.
+  static Uri? build({
+    required List<int> orderedNotes,
+    required Tonality tonality,
+  }) {
+    if (orderedNotes.isEmpty) return null;
+    return Uri.https(host, path, {
+      'notes': orderedNotes.join(' '),
+      'key': _formatKey(tonality),
+    });
+  }
+
+  /// Parses an incoming link, or returns null when [uri] is not a recognized
+  /// `/try` link or carries no usable notes.
+  static ChordLinkSeed? parse(Uri uri) {
+    if (!_isTryLink(uri)) return null;
+
+    final rawNotes = uri.queryParameters['notes'];
+    if (rawNotes == null || rawNotes.length > _maxNotesCharacters) return null;
+
+    final pitchClasses = _parseNotes(rawNotes);
+    if (pitchClasses.isEmpty) return null;
+
+    return ChordLinkSeed(
+      pitchClasses: pitchClasses,
+      tonality: _parseKey(uri.queryParameters['key']),
+    );
+  }
+
+  static bool _isTryLink(Uri uri) {
+    if (uri.host.toLowerCase() != host) return false;
+    return uri.path == path || uri.path == '$path/';
+  }
+
+  static String _formatKey(Tonality tonality) =>
+      '${tonality.tonic.label}:${tonality.isMajor ? 'maj' : 'min'}';
+
+  /// Parses ordered pitch classes (first is the bass) from a `notes` value,
+  /// accepting MIDI numbers and note names and skipping unrecognized tokens.
+  static List<int> _parseNotes(String raw) {
+    final result = <int>[];
+    for (final token in raw.split(_separator)) {
+      if (token.isEmpty) continue;
+      final pc = _parseToken(token);
+      if (pc != null) result.add(pc);
+    }
+    return result;
+  }
+
+  static int? _parseToken(String token) {
+    final midi = int.tryParse(token);
+    if (midi != null) return midi % 12 + (midi < 0 ? 12 : 0);
+
+    final label =
+        token[0].toUpperCase() +
+        token
+            .substring(1)
+            .toLowerCase()
+            .replaceAll('♯', '#') // sharp glyph
+            .replaceAll('♭', 'b'); // flat glyph
+    return Tonic.tryFromLabel(label)?.pitchClass;
+  }
+
+  static Tonality? _parseKey(String? key) {
+    if (key == null) return null;
+    final parts = key.split(':');
+    if (parts.length != 2) return null;
+
+    final tonic = Tonic.tryFromLabel(parts[0].trim());
+    if (tonic == null) return null;
+
+    final mode = switch (parts[1].toLowerCase()) {
+      'maj' => TonalityMode.major,
+      'min' => TonalityMode.minor,
+      _ => null,
+    };
+    if (mode == null) return null;
+
+    return Tonality(tonic, mode);
+  }
+}
+
+/// The app state a [ChordLink] seeds: an ordered lookup selection and, when the
+/// link names one, the tonality to apply.
+@immutable
+class ChordLinkSeed {
+  const ChordLinkSeed({required this.pitchClasses, this.tonality});
+
+  /// Entered pitch classes in order; the first entry is the bass.
+  final List<int> pitchClasses;
+
+  /// Tonality to apply, or null to leave the current selection unchanged.
+  final Tonality? tonality;
+}

--- a/lib/features/links/providers/deep_link_provider.dart
+++ b/lib/features/links/providers/deep_link_provider.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:whatchord/features/lookup/lookup.dart';
+import 'package:whatchord/features/theory/theory.dart';
+
+import '../models/chord_link.dart';
+import '../services/deep_link_service.dart';
+
+final deepLinkServiceProvider = Provider<DeepLinkService>(
+  (ref) => DeepLinkService(),
+);
+
+/// App-lifecycle hook: applies incoming `/try` deep links by seeding the lookup
+/// pad and tonality. Watched once near the app root; handles both the
+/// cold-start link and warm links delivered while running.
+final appDeepLinkProvider = Provider<void>((ref) {
+  final service = ref.watch(deepLinkServiceProvider);
+
+  void handle(Uri uri) {
+    final seed = ChordLink.parse(uri);
+    if (seed == null) return;
+
+    if (seed.tonality != null) {
+      unawaited(
+        ref.read(selectedTonalityProvider.notifier).setTonality(seed.tonality!),
+      );
+    }
+
+    // Open the pad and replace any prior selection with the linked notes.
+    final lookup = ref.read(lookupModeProvider.notifier);
+    lookup.enter();
+    lookup.clear();
+    for (final pc in seed.pitchClasses) {
+      lookup.addNote(pc);
+    }
+  }
+
+  unawaited(
+    service.getInitialLink().then((uri) {
+      if (uri != null) handle(uri);
+    }),
+  );
+
+  final sub = service.uriLinkStream.listen(handle);
+  ref.onDispose(sub.cancel);
+});

--- a/lib/features/links/providers/share_link_provider.dart
+++ b/lib/features/links/providers/share_link_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:whatchord/features/input/input.dart';
+import 'package:whatchord/features/theory/theory.dart';
+
+import '../models/chord_link.dart';
+
+/// A shareable website link for the current voicing and tonality, or null when
+/// nothing is sounding (so the share affordance can disable itself).
+final shareLinkProvider = Provider<Uri?>((ref) {
+  final notes = ref.watch(soundingNoteNumbersSortedProvider);
+  if (notes.isEmpty) return null;
+
+  return ChordLink.build(
+    orderedNotes: notes.toList(),
+    tonality: ref.watch(selectedTonalityProvider),
+  );
+});

--- a/lib/features/links/services/deep_link_service.dart
+++ b/lib/features/links/services/deep_link_service.dart
@@ -1,0 +1,15 @@
+import 'package:app_links/app_links.dart';
+
+/// Thin wrapper over [AppLinks] so deep-link handling can be unit tested and the
+/// rest of the app depends on a small surface rather than the plugin directly.
+class DeepLinkService {
+  DeepLinkService([AppLinks? appLinks]) : _appLinks = appLinks ?? AppLinks();
+
+  final AppLinks _appLinks;
+
+  /// The link that cold-launched the app, if any.
+  Future<Uri?> getInitialLink() => _appLinks.getInitialLink();
+
+  /// Links delivered while the app is already running.
+  Stream<Uri> get uriLinkStream => _appLinks.uriLinkStream;
+}

--- a/lib/features/links/services/share_chord_link.dart
+++ b/lib/features/links/services/share_chord_link.dart
@@ -1,0 +1,13 @@
+import 'dart:ui';
+
+import 'package:share_plus/share_plus.dart';
+
+/// Opens the native share sheet for a chord [link].
+///
+/// [sharePositionOrigin] is the source rect the sheet should anchor to; it is
+/// required for the popover presentation on iPad.
+Future<void> shareChordLink(Uri link, {Rect? sharePositionOrigin}) async {
+  await SharePlus.instance.share(
+    ShareParams(uri: link, sharePositionOrigin: sharePositionOrigin),
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:whatchord/core/core.dart';
 import 'package:whatchord/features/audio/audio.dart';
 import 'package:whatchord/features/home/home.dart';
+import 'package:whatchord/features/links/links.dart';
 import 'package:whatchord/features/midi/midi.dart';
 
 Future<void> main() async {
@@ -30,6 +31,7 @@ class MyApp extends ConsumerWidget {
     ref.watch(appResumeWakeupProvider);
     ref.watch(appMidiLifecycleProvider);
     ref.watch(appAudioMonitorLifecycleProvider);
+    ref.watch(appDeepLinkProvider);
 
     final themeMode = ref.watch(appThemeModeProvider);
     final palette = ref.watch(appPaletteProvider);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.11"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "4ec328cd9fd51fd0e7eb8870a9612c1fde0f091901932238c4f4e60b5f7f1315"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.2"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "78a18580eecac98108d1eef52a7db668bc317714f5205e616973363326efe333"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -129,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   collection:
     dependency: "direct main"
     description:
@@ -153,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -217,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -327,6 +383,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: "4ff85b2a16724029dd9e5bbb5a94b6918f9973f74ba571c949d2002801879cf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   http:
     dependency: transitive
     description:
@@ -383,6 +455,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   json_annotation:
     dependency: transitive
     description:
@@ -487,6 +575,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.1"
   package_config:
     dependency: transitive
     description:
@@ -527,6 +623,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -647,6 +767,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   riverpod:
     dependency: transitive
     description:
@@ -671,6 +799,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -956,6 +1100,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.5"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_graphics:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
 
+  app_links: ^7.1.2
   auto_size_text: ^3.0.0
   collection: ^1.19.1
   dart_melty_soundfont: ^2.0.0
@@ -25,6 +26,7 @@ dependencies:
   meta: ^1.17.0
   package_info_plus: ^9.0.0
   permission_handler: ^12.0.1
+  share_plus: ^12.0.2
   shared_preferences: ^2.5.4
   url_launcher: ^6.3.2
   wakelock_plus: ^1.4.0

--- a/test/chord_link_test.dart
+++ b/test/chord_link_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:whatchord/features/links/links.dart';
+import 'package:whatchord/features/theory/theory.dart';
+
+void main() {
+  group('ChordLink.build', () {
+    test('emits MIDI notes and key in the canonical grammar', () {
+      final uri = ChordLink.build(
+        orderedNotes: const [48, 52, 55],
+        tonality: const Tonality(Tonic.c, TonalityMode.major),
+      );
+
+      expect(uri, isNotNull);
+      expect(uri!.host, ChordLink.host);
+      expect(uri.path, ChordLink.path);
+      expect(uri.queryParameters['notes'], '48 52 55');
+      expect(uri.queryParameters['key'], 'C:maj');
+    });
+
+    test('formats a minor key with flat tonic', () {
+      final uri = ChordLink.build(
+        orderedNotes: const [60],
+        tonality: const Tonality(Tonic.bFlat, TonalityMode.minor),
+      );
+
+      expect(uri!.queryParameters['key'], 'Bb:min');
+    });
+
+    test('returns null with no notes', () {
+      expect(
+        ChordLink.build(
+          orderedNotes: const [],
+          tonality: const Tonality(Tonic.c, TonalityMode.major),
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('ChordLink.parse', () {
+    ChordLinkSeed? parse(String url) => ChordLink.parse(Uri.parse(url));
+
+    test('round-trips a link built by build', () {
+      final uri = ChordLink.build(
+        orderedNotes: const [48, 52, 55],
+        tonality: const Tonality(Tonic.d, TonalityMode.minor),
+      )!;
+
+      final seed = ChordLink.parse(uri)!;
+      expect(seed.pitchClasses, [0, 4, 7]);
+      expect(seed.tonality, const Tonality(Tonic.d, TonalityMode.minor));
+    });
+
+    test('parses note names and treats the first as the bass', () {
+      final seed = parse(
+        'https://${ChordLink.host}/try?notes=E+G+C&key=C:maj',
+      )!;
+      expect(seed.pitchClasses, [4, 7, 0]);
+    });
+
+    test('accepts commas, hyphens, glyphs, and mixed case', () {
+      final seed = parse(
+        'https://${ChordLink.host}/try?notes=c,e-g%20b%E2%99%AD',
+      )!;
+      expect(seed.pitchClasses, [0, 4, 7, 10]);
+    });
+
+    test('skips unrecognized tokens but keeps the rest', () {
+      final seed = parse('https://${ChordLink.host}/try?notes=C+zz+G')!;
+      expect(seed.pitchClasses, [0, 7]);
+    });
+
+    test('leaves tonality null when key is absent or invalid', () {
+      expect(parse('https://${ChordLink.host}/try?notes=C')!.tonality, isNull);
+      expect(
+        parse('https://${ChordLink.host}/try?notes=C&key=H:maj')!.tonality,
+        isNull,
+      );
+    });
+
+    test('rejects non-try links and other hosts', () {
+      expect(parse('https://${ChordLink.host}/chords?notes=C'), isNull);
+      expect(parse('https://example.com/try?notes=C'), isNull);
+    });
+
+    test('rejects empty or oversized note lists', () {
+      expect(parse('https://${ChordLink.host}/try?notes='), isNull);
+      final huge = List.filled(300, 'C').join(' ');
+      expect(parse('https://${ChordLink.host}/try?notes=$huge'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Connect the website and the app with a shared link grammar built on Universal Links (iOS) and App Links (Android), so a single https link opens the played chord directly in the app or falls back to the website when the app is not installed.

App:

- New links feature with one canonical /try URL grammar shared by link building and deep-link parsing, so the two cannot drift. The parser accepts note names and MIDI numbers (first note is the bass), skips unrecognized tokens, caps input length, and ignores notation style.
- appDeepLinkProvider handles cold-start and warm links, seeding the lookup pad and tonality. Add a Share button to the home top bar that builds a link from the current voicing and key, disabled when nothing is sounding.

iOS:

- Add the associated-domains entitlement and wire it into all three Runner build configs. Add the Smart App Banner meta to the Try page.

Android:

- Add an autoVerify https App Links intent filter for /try.

Website:

- Serve apple-app-site-association and assetlinks.json under /.well-known, with the AASA returned as JSON. Inject app-argument in the Worker so the banner OPEN button deep-links to the exact chord, and add an Android-only "Open in app" intent link to the results head.