### PR TITLE
Reward complete Lydian dominant flat-thirteen stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The format is based on [Keep a Changelog][1], and this project adheres to
   spellings.
 - Improved altered sharp-five dominant identification, preferring labels such as
   C7#5(b9,#11) over natural-eleventh sharp-five spellings.
+- Improved Lydian-dominant flat-thirteen identification, favoring complete
+  9#11b13 dominant stacks such as F#9(#11,b13) over remote altered-fifth
+  spellings.
 - Improved identification of doubled-note voicings, preventing incomplete
   fifthless sixth chords from outranking complete inverted minor or diminished
   chords.

--- a/docs/site/articles/under-the-hood.html
+++ b/docs/site/articles/under-the-hood.html
@@ -583,7 +583,8 @@
                 <td class="pos mono">+2.1</td>
                 <td>
                   Applied when root-position dominant has 9, ♯11, and 13 all
-                  present
+                  present; also applied to complete 9♯11♭13 dominant stacks with
+                  a real fifth, including slash-bass voicings
                 </td>
               </tr>
               <tr>

--- a/docs/site/js/chord-id.js
+++ b/docs/site/js/chord-id.js
@@ -1533,7 +1533,7 @@ fB(a){var t,s,r,q=a.c
 if(q!==B.A&&q!==B.v)return!1
 t=a.e
 s=new A.d(t,A.a(t).i("d<2>"))
-r=s.h(0,B.x)||s.h(0,B.w)
+r=s.h(0,B.y)||s.h(0,B.w)
 return s.h(0,B.l)&&s.h(0,B.h)&&r&&s.h(0,B.i)},
 fG(a){var t,s
 if(a.c!==B.B)return!1
@@ -1571,7 +1571,7 @@ t=a.e
 s=new A.d(t,A.a(t).i("d<2>"))
 return s.h(0,B.l)&&s.h(0,B.h)&&s.h(0,B.d)},
 fO(a,b){if(b===B.r&&a===B.I)return!0
-return a===B.t||a===B.H||a===B.O||a===B.o||a===B.y},
+return a===B.t||a===B.H||a===B.O||a===B.o||a===B.x},
 fJ(a,b){var t
 if(!A.aC(a.c))return!1
 if(b)return!1
@@ -1603,7 +1603,7 @@ q=new A.d(t,A.a(t).i("d<2>"))
 return q.h(0,B.l)&&q.h(0,B.n)&&q.h(0,B.d)&&q.h(0,B.i)},
 fA(a,b){if(!b)return!1
 if(a.c!==B.aa)return!1
-return a.d.h(0,B.y)},
+return a.d.h(0,B.x)},
 fL(a,b){var t,s,r,q
 if(!b)return!1
 t=a.c
@@ -1616,7 +1616,7 @@ fN(a,b){var t,s,r=a.c
 if(r===B.aj||r===B.ak)return!0
 if(A.S(r)===B.u&&!b){t=a.e
 s=new A.d(t,A.a(t).i("d<2>"))
-if(!(s.h(0,B.d)||s.h(0,B.x)||s.h(0,B.w)))return!0}return!1},
+if(!(s.h(0,B.d)||s.h(0,B.y)||s.h(0,B.w)))return!0}return!1},
 fK(a,b,c){var t
 if(b)return!1
 t=a.c
@@ -1631,12 +1631,12 @@ r=A.fz(a.e.p(0,A.aw(s,t)))
 for(t=a.d,t=A.aP(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){q=t.d
 if(q==null)q=s.a(q)
 if(q===r)continue
-if(q===B.t||q===B.H||q===B.o||q===B.y)return!0}return!1},
+if(q===B.t||q===B.H||q===B.o||q===B.x)return!0}return!1},
 fz(a){var t
 A:{if(B.T===a){t=B.t
 break A}if(B.Z===a){t=B.H
 break A}if(B.Y===a){t=B.o
-break A}if(B.am===a){t=B.y
+break A}if(B.am===a){t=B.x
 break A}if(B.ao===a){t=B.k
 break A}if(B.ab===a){t=B.q
 break A}if(B.ad===a){t=B.p
@@ -1649,7 +1649,7 @@ break A}t=null
 break A}return t},
 fx(a){var t=a.e.p(0,A.aw(a.b,a.a))
 if(t==null)return!1
-return!(t===B.l||t===B.h||t===B.n||t===B.d||t===B.x||t===B.w||t===B.S||t===B.i||t===B.D||t===B.ae)},
+return!(t===B.l||t===B.h||t===B.n||t===B.d||t===B.y||t===B.w||t===B.S||t===B.i||t===B.D||t===B.ae)},
 dl(a){var t=A.aw(a.b,a.a)
 if(t===0)return 0
 if(t===3||t===4)return 1
@@ -1750,7 +1750,7 @@ if((g&2)!==0)d.l(0,e||A.aC(f)?B.t:B.b3)
 if((g&8)!==0){if(!e)c=!(f===B.r||f===B.C||f===B.a4)
 else c=!0
 d.l(0,c?B.H:B.O)}if((g&64)!==0)d.l(0,B.o)
-if((g&256)!==0)d.l(0,B.y)
+if((g&256)!==0)d.l(0,B.x)
 b=(g&14)!==0
 if((g&4)!==0)d.l(0,e?B.k:B.z)
 if((g&32)!==0)d.l(0,e&&b?B.q:B.I)
@@ -1786,7 +1786,7 @@ break A}if(A.dZ(d,f)){a8-=a9
 B:{if(c){c="dim7 softened"
 break B}if(A.S(f)!==B.u&&!A.aC(f)){c="triad softened"
 break B}c=b5
-break B}b6.$3$detail("alterations penalty",-a9,c)}b0=A.fQ(b7,d,f)
+break B}b6.$3$detail("alterations penalty",-a9,c)}b0=A.fQ(b7,d,f,c0)
 if(b0!==0){a8+=b0
 b6.$2("dominant stack",b0)}b1=A.fS(b7,d,f,c0)
 if(b1!==0){a8+=b1
@@ -1798,7 +1798,7 @@ b4=a8/b3
 if(b9!=null)b6.$3$detail("normalize",0,"raw="+B.E.N(a8,2)+" denom="+B.E.N(b3,2)+" => "+B.E.N(b4,2))
 return new A.cY(b4,d)},
 dZ(a,b){var t=!0
-if(!a.h(0,B.t))if(!a.h(0,B.H))t=a.h(0,B.o)&&!A.e2(b)||a.h(0,B.y)
+if(!a.h(0,B.t))if(!a.h(0,B.H))t=a.h(0,B.o)&&!A.e2(b)||a.h(0,B.x)
 return t},
 fU(a,b,c){var t=c.a
 if(A.h_(a,b)&&A.fX(t,b))return 8
@@ -1821,16 +1821,20 @@ case 7:case 13:case 18:return a===5
 default:return!1}},
 fT(a,b){if(!(b===B.A||b===B.V))return!1
 return a.h(0,B.p)||a.h(0,B.a8)},
-fQ(a,b,c){if(c!==B.m)return 0
-if(a!==0)return 0
+fQ(a,b,c,d){var t,s
+if(c!==B.m)return 0
 if(!b.h(0,B.k))return 0
 if(!b.h(0,B.o))return 0
-if(!b.h(0,B.p))return 0.8
+t=b.h(0,B.p)
+s=b.h(0,B.x)
+if(!t&&!s)return a===0?0.8:0
+if(t&&!s)return a===0?2.1:0
+if(s&&(d&128)===0)return 0
 return 2.1},
 fS(a,b,c,d){if(a!==0)return 0
 if(c!==B.a1&&c!==B.m)return 0
 if(!b.h(0,B.k))return 0
-if(b.h(0,B.y))return 0
+if(b.h(0,B.x))return 0
 if(!(b.h(0,B.o)||b.h(0,B.p)))return 0
 if((d&128)!==0)return 0
 return 2.4},
@@ -1970,7 +1974,7 @@ t=t.a===2&&t.h(0,B.t)&&t.h(0,B.k)}else t=!1
 return t},
 eU(a){var t
 if(a.c===B.m){t=a.d
-t=t.a===2&&t.h(0,B.o)&&t.h(0,B.y)}else t=!1
+t=t.a===2&&t.h(0,B.o)&&t.h(0,B.x)}else t=!1
 return t},
 jq(a,b,c,d,e){var t,s,r,q,p=c.w
 if(p===d.w)return null
@@ -2089,7 +2093,7 @@ if(p===A.eS(b.a))return q
 t=(p?b:a).a
 s=!1
 if(t.c===B.A){r=t.d
-if(r.a===2)s=(r.h(0,B.k)||r.h(0,B.t))&&r.h(0,B.y)}if(!s)return q
+if(r.a===2)s=(r.h(0,B.k)||r.h(0,B.t))&&r.h(0,B.x)}if(!s)return q
 s=(p?a:b).a
 if(s.a!==t.a)return q
 if((s.f&128)!==0)return q
@@ -2478,7 +2482,7 @@ A:{if(B.l===a){t=1
 break A}if(B.Q===a){t=2
 break A}if(B.n===a||B.ap===a||B.h===a){t=3
 break A}if(B.R===a){t=4
-break A}if(B.x===a||B.d===a||B.w===a){t=5
+break A}if(B.y===a||B.d===a||B.w===a){t=5
 break A}if(B.S===a){t=6
 break A}if(B.ae===a||B.i===a||B.D===a){t=7
 break A}if(B.T===a||B.ao===a||B.Z===a||B.af===a||B.aM===a){t=9
@@ -2536,7 +2540,7 @@ switch(b.a){case 0:t.$2(4,B.h)
 t.$2(7,B.d)
 break
 case 1:t.$2(4,B.h)
-t.$2(6,B.x)
+t.$2(6,B.y)
 break
 case 2:t.$2(3,B.n)
 t.$2(7,B.d)
@@ -2545,7 +2549,7 @@ case 3:t.$2(3,B.n)
 t.$2(8,B.w)
 break
 case 4:t.$2(3,B.n)
-t.$2(6,B.x)
+t.$2(6,B.y)
 break
 case 5:t.$2(4,B.h)
 t.$2(8,B.w)
@@ -2581,7 +2585,7 @@ t.$2(7,B.d)
 t.$2(10,B.i)
 break
 case 14:t.$2(4,B.h)
-t.$2(6,B.x)
+t.$2(6,B.y)
 t.$2(10,B.i)
 break
 case 15:t.$2(4,B.h)
@@ -2601,7 +2605,7 @@ t.$2(7,B.d)
 t.$2(11,B.D)
 break
 case 19:t.$2(4,B.h)
-t.$2(6,B.x)
+t.$2(6,B.y)
 t.$2(11,B.D)
 break
 case 20:t.$2(4,B.h)
@@ -2621,11 +2625,11 @@ t.$2(7,B.d)
 t.$2(11,B.D)
 break
 case 24:t.$2(3,B.n)
-t.$2(6,B.x)
+t.$2(6,B.y)
 t.$2(10,B.i)
 break
 case 25:t.$2(3,B.n)
-t.$2(6,B.x)
+t.$2(6,B.y)
 t.$2(9,B.ae)
 break}s=new A.ct(n,o)
 for(r=A.aP(a,a.r,A.a(a).c),q=r.$ti.c;r.k();){p=r.d
@@ -2767,7 +2771,7 @@ h4(a){var t,s=a.b,r=a.a
 if(s===r)return!1
 t=a.e.p(0,A.aw(s,r))
 if(t==null)return!1
-return t===B.h||t===B.n||t===B.d||t===B.x||t===B.w||t===B.S||t===B.i||t===B.D||t===B.ae},
+return t===B.h||t===B.n||t===B.d||t===B.y||t===B.w||t===B.S||t===B.i||t===B.D||t===B.ae},
 e_(a){var t,s,r,q,p
 if(A.h5(a))return B.ca
 t=a.b
@@ -4514,7 +4518,7 @@ A.d6.prototype={
 $2(a,b){var t,s,r=!0
 if(b.a){t=a.a
 if(t.c===B.P){r=t.d
-r=r.a!==1||!r.h(0,B.y)}}if(r)return!1
+r=r.a!==1||!r.h(0,B.x)}}if(r)return!1
 r=a.a
 s=A.ej(this.a,r,r.f,!0,null,!0)
 r=s==null
@@ -4958,7 +4962,7 @@ B.H=new A.o(2,"sharp9")
 B.O=new A.o(3,"addSharp9")
 B.q=new A.o(4,"eleven")
 B.o=new A.o(5,"sharp11")
-B.y=new A.o(6,"flat13")
+B.x=new A.o(6,"flat13")
 B.p=new A.o(7,"thirteen")
 B.z=new A.o(8,"add9")
 B.I=new A.o(9,"add11")
@@ -5002,7 +5006,7 @@ B.R=new A.n(10,"sus4")
 B.ab=new A.n(11,"eleven")
 B.Y=new A.n(12,"sharp11")
 B.ac=new A.n(13,"add11")
-B.x=new A.n(14,"flat5")
+B.y=new A.n(14,"flat5")
 B.d=new A.n(15,"perfect5")
 B.w=new A.n(16,"sharp5")
 B.S=new A.n(17,"sixth")

--- a/lib/features/theory/domain/analysis/chord_analyzer.dart
+++ b/lib/features/theory/domain/analysis/chord_analyzer.dart
@@ -110,7 +110,7 @@ abstract final class ChordAnalyzer {
 
   // Dominant-stack coherence bonuses.
   static const _domStackPartial = 0.8; // root-position dom7 + 9 + #11
-  static const _domStackFull = 2.1; // root-position dom7 + 9 + #11 + 13
+  static const _domStackFull = 2.1; // dom7 + 9 + #11 + 13/b13 coherent stack
   static const _fifthlessExtensionStackBonus =
       2.4; // root-position fifthless natural 9 + #11/13 stacks
 
@@ -479,6 +479,7 @@ abstract final class ChordAnalyzer {
     final dominantStackDelta = _dominantStackCoherenceBonus(
       quality: template.quality,
       extensions: extensions,
+      relMask: relMask,
       bassInterval: bassInterval,
     );
     if (dominantStackDelta != 0) {
@@ -677,17 +678,31 @@ abstract final class ChordAnalyzer {
   static double _dominantStackCoherenceBonus({
     required ChordQualityToken quality,
     required Set<ChordExtension> extensions,
+    required int relMask,
     required int bassInterval,
   }) {
-    // Lydian-dominant stacks are commonly voiced as root-position dominant
-    // chords with 9/#11 color. Without this small structural bonus, the scorer
-    // overvalues remote altered-fifth slash readings that happen to reinterpret
-    // one color tone as a required chord tone.
+    // Lydian-dominant stacks are commonly voiced as dominant chords with 9/#11
+    // color. Without this small structural bonus, the scorer overvalues remote
+    // altered-fifth slash readings that happen to reinterpret one color tone as
+    // a required chord tone.
     if (quality != ChordQualityToken.dominant7) return 0;
-    if (bassInterval != 0) return 0;
     if (!extensions.contains(ChordExtension.nine)) return 0;
     if (!extensions.contains(ChordExtension.sharp11)) return 0;
-    if (!extensions.contains(ChordExtension.thirteen)) return _domStackPartial;
+
+    final hasNaturalThirteenth = extensions.contains(ChordExtension.thirteen);
+    final hasFlatThirteenth = extensions.contains(ChordExtension.flat13);
+    if (!hasNaturalThirteenth && !hasFlatThirteenth) {
+      return bassInterval == 0 ? _domStackPartial : 0;
+    }
+
+    if (hasNaturalThirteenth && !hasFlatThirteenth) {
+      return bassInterval == 0 ? _domStackFull : 0;
+    }
+
+    if (hasFlatThirteenth && (relMask & (1 << perfectFifthInterval)) == 0) {
+      return 0;
+    }
+
     return _domStackFull;
   }
 

--- a/test/chord_analyzer_ranking_golden_test.dart
+++ b/test/chord_analyzer_ranking_golden_test.dart
@@ -601,6 +601,57 @@ void main() {
 
     golden(
       description:
+          'complete lydian flat-thirteen dominant beats remote altered fifth dominant',
+      expectedSymbol: 'F#9(#11,b13) / B#',
+      expectedAlternateSymbols: ['E13#5#11 / B#'],
+      pcs: ['C', 'Db', 'D', 'E', 'F#', 'Ab', 'Bb'],
+      bass: 'C',
+      expectedRoot: 'F#',
+      expectedBass: 'B#',
+      expectedQuality: ChordQualityToken.dominant7,
+      expectedExtensions: {
+        ChordExtension.nine,
+        ChordExtension.sharp11,
+        ChordExtension.flat13,
+      },
+    ),
+
+    golden(
+      description:
+          'complete lydian flat-thirteen dominant handles flat-thirteen bass',
+      expectedSymbol: 'F#9(#11,b13) / D',
+      expectedAlternateSymbols: ['E13#5#11 / D'],
+      pcs: ['C', 'Db', 'D', 'E', 'F#', 'Ab', 'Bb'],
+      bass: 'D',
+      expectedRoot: 'F#',
+      expectedBass: 'D',
+      expectedQuality: ChordQualityToken.dominant7,
+      expectedExtensions: {
+        ChordExtension.nine,
+        ChordExtension.sharp11,
+        ChordExtension.flat13,
+      },
+    ),
+
+    golden(
+      description:
+          'complete lydian flat-thirteen dominant handles major-third bass',
+      expectedSymbol: 'F#9(#11,b13) / A#',
+      expectedAlternateSymbols: ['E13#5#11 / A#'],
+      pcs: ['C', 'Db', 'D', 'E', 'F#', 'Ab', 'Bb'],
+      bass: 'Bb',
+      expectedRoot: 'F#',
+      expectedBass: 'A#',
+      expectedQuality: ChordQualityToken.dominant7,
+      expectedExtensions: {
+        ChordExtension.nine,
+        ChordExtension.sharp11,
+        ChordExtension.flat13,
+      },
+    ),
+
+    golden(
+      description:
           'altered sharp-five dominant beats natural-eleventh sharp-five dominant',
       expectedSymbol: 'C7#5(b9,#11) / E',
       expectedAlternateSymbols: ['Ab11#5 / E'],

--- a/tool/chord_oracle_reviewed.json
+++ b/tool/chord_oracle_reviewed.json
@@ -7,6 +7,34 @@
     "label": "genuine-ambiguity",
     "note": "F♯7(♯11,♭13)/A♯ is preferred because it is a complete tritone-related dominant with its major third in the bass, while C9♭5♭9/B♭ is a complete altered dominant in third inversion with simultaneous flat and natural ninths. Tonal supports the F♯ reading and music21 supports the C reading, confirming genuine ambiguity. Related bass cases consistently favor whichever dominant receives the more conventional bass role."
   },
+  "0-1-2-4-6-8-10_b0": {
+    "label": "oracle-limitation",
+    "note": "F♯9(♯11,♭13)/B♯ is preferred because the voicing contains the complete F♯ dominant stack F♯-A♯-C♯-E plus G♯, B♯, and D. Tonal agrees with F#9#11b13/C. Music21's B♭9♯5/C add E,D♭ is a related altered-fifth bookkeeping label, but it omits the direct Lydian-dominant-flat-thirteen identity."
+  },
+  "0-1-2-4-6-8-10_b1": {
+    "label": "oracle-limitation",
+    "note": "F♯9(♯11,♭13)/C♯ is preferred because C♯ is the fifth of the complete F♯9♯11♭13 stack. Tonal agrees. Music21's C♯m(maj7) add F♯,D,A♯ re-roots the same pitch material away from the complete dominant shell."
+  },
+  "0-1-2-4-6-8-10_b2": {
+    "label": "oracle-limitation",
+    "note": "F♯9(♯11,♭13)/D is preferred because D is the flat thirteenth of a complete F♯ Lydian-dominant-flat-thirteen sonority. Tonal agrees. Music21's C9♯5/D add C♯,F♯ preserves some altered-dominant color but misses the complete F♯ dominant organization."
+  },
+  "0-1-2-4-6-8-10_b4": {
+    "label": "oracle-limitation",
+    "note": "F♯9(♯11,♭13)/E is preferred because E is the dominant seventh of the complete F♯9♯11♭13 stack. Tonal agrees. Music21's E9♯5 add C♯,A♯ is a related altered-fifth add-tone spelling, but it treats F♯ as the ninth of E rather than the clearer dominant root."
+  },
+  "0-1-2-4-6-8-10_b6": {
+    "label": "oracle-limitation",
+    "note": "F♯9(♯11,♭13) is preferred because it is root position and names every tone as part of a complete dominant stack. Tonal agrees. Music21's F♯9 add B♯,D keeps the root but drops the sharp-eleventh and flat-thirteenth identity into add tones."
+  },
+  "0-1-2-4-6-8-10_b8": {
+    "label": "oracle-limitation",
+    "note": "F♯9(♯11,♭13)/G♯ is preferred because G♯ is the ninth of the complete F♯9♯11♭13 stack. Tonal agrees. Music21's G♯7♭5 add E,A♯,C♯ describes related pitch classes but loses the complete F♯ dominant shell."
+  },
+  "0-1-2-4-6-8-10_b10": {
+    "label": "oracle-limitation",
+    "note": "F♯9(♯11,♭13)/A♯ is preferred because A♯ is the major third of the complete F♯9♯11♭13 stack. Tonal agrees. Music21's A♭9♯5/B♭ add D,D♭ is an enharmonic altered-fifth bookkeeping label rather than the direct Lydian-dominant-flat-thirteen reading."
+  },
   "0-1-2-5-8_b5": {
     "label": "genuine-ambiguity",
     "note": "Fm6b13 is correct; F-Ab-C-D is a complete root-position Fm6 (enharmonically Dm7b5/F), while Db is a dissonant b13/lower-neighbor color; Dbmaj7b9/F is equally complete but inverted and requires Ebb for its b9; oracle split confirms genuine ambiguity; no engine change needed"


### PR DESCRIPTION
Generalize the dominant-stack coherence bonus so complete 9#11b13 dominants with a real fifth compete naturally in slash-bass voicings. This fixes the C Db D E F# Ab Bb cluster, where F#9(#11,b13) now beats remote E13#5#11 spellings by score instead of needing a hard ranking override.

The change is deliberately narrower than a blanket #11 boost. Natural-13 slash cases are not promoted, and flat-thirteen cases without a perfect fifth still avoid the bonus so altered-fifth readings can win when they are the clearer spelling.

Tonal corroborates F#9#11b13 across the affected basses. music21 returns related altered-fifth or add-tone labels, so those remaining splits are recorded as oracle limitations.