### PR TITLE
Clarify deep-link key fallback behavior

### DIFF
--- a/lib/features/links/models/chord_link.dart
+++ b/lib/features/links/models/chord_link.dart
@@ -94,9 +94,11 @@ class ChordLink {
     }
   }
 
-  /// Resolves the link's key, defaulting to C major when it is absent or
-  /// unparsable, so a keyless link reproduces the sharer's default context
-  /// rather than adopting the recipient's current key.
+  /// Resolves the link's key. Falls back to C major when the key is absent or
+  /// its tonic is unrecognized, so a keyless link reproduces the sharer's
+  /// default context rather than adopting the recipient's current key. A valid
+  /// tonic with an unrecognized mode keeps the tonic and defaults the mode to
+  /// major.
   static Tonality _parseKey(String? key) {
     if (key == null) return _defaultTonality;
     final parts = key.split(':');

--- a/test/chord_link_test.dart
+++ b/test/chord_link_test.dart
@@ -112,6 +112,16 @@ void main() {
       );
     });
 
+    test(
+      'keeps a valid tonic and defaults the mode when the mode is invalid',
+      () {
+        expect(
+          parse('https://${ChordLink.host}/try?notes=C&key=Eb:blah')!.tonality,
+          const Tonality(Tonic.eFlat, TonalityMode.major),
+        );
+      },
+    );
+
     test('rejects non-try links and other hosts', () {
       expect(parse('https://${ChordLink.host}/chords?notes=C'), isNull);
       expect(parse('https://example.com/try?notes=C'), isNull);


### PR DESCRIPTION
The \_parseKey dartdoc claimed links default to C major when the key is unparsable, but a valid tonic with a bad mode keeps the tonic and only defaults the mode to major. Reword the doc to match and add a test for the valid-tonic/invalid-mode case.