### PR TITLE
Clarify that the try page identifies notes by pitch, not spelling

### DIFF
--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -126,6 +126,7 @@
             <div class="try-hint" id="notes-hint">
               Separate with spaces, commas, or hyphens. Names like C, F#, Bb, or
               MIDI numbers like 60.<br />The first note is treated as the bass.
+              Notes are <em>identified by pitch</em>, not spelling.
             </div>
 
             <div class="try-controls">


### PR DESCRIPTION
Music theory users were surprised by the try page respelling their input enharmonically. Add a short line to the input hint noting that notes are identified by pitch, since the engine is intentionally spelling-blind to suit its primary MIDI input.