### PR TITLE
Show home page when opening a shared chord link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ### Fixed
 
+- Opening a shared chord link now returns to the home screen, so the linked
+  chord is shown even when the app was last left on an Explore page.
 - Improved identification of fifthless extended major and dominant chords,
   favoring labels such as Dbmaj9#11, Eb13, and C9#5#11 over less direct altered
   sus, major-flat-five, or flat-five flat-thirteen readings.

--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -6,6 +6,7 @@ export 'models/app_palette.dart';
 export 'models/selection_colors.dart';
 
 export 'providers/app_activity_notifier.dart';
+export 'providers/app_navigator_key_provider.dart';
 export 'providers/app_palette_notifier.dart';
 export 'providers/app_resume_wakeup_provider.dart';
 export 'providers/app_theme_mode_notifier.dart';

--- a/lib/core/providers/app_navigator_key_provider.dart
+++ b/lib/core/providers/app_navigator_key_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Stable key for the root navigator, letting non-widget code (e.g. deep-link
+/// handling) drive navigation without a [BuildContext].
+final appNavigatorKeyProvider = Provider<GlobalKey<NavigatorState>>(
+  (ref) => GlobalKey<NavigatorState>(),
+);

--- a/lib/features/links/providers/deep_link_provider.dart
+++ b/lib/features/links/providers/deep_link_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:whatchord/core/core.dart';
 import 'package:whatchord/features/lookup/lookup.dart';
 import 'package:whatchord/features/theory/theory.dart';
 
@@ -33,6 +34,13 @@ final appDeepLinkProvider = Provider<void>((ref) {
     for (final pc in seed.pitchClasses) {
       lookup.addNote(pc);
     }
+
+    // A link may arrive while an Explore or Scale page sits atop the home
+    // page; pop back to it so the seeded chord is actually visible.
+    ref
+        .read(appNavigatorKeyProvider)
+        .currentState
+        ?.popUntil((route) => route.isFirst);
   }
 
   unawaited(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,7 @@ class MyApp extends ConsumerWidget {
     return MaterialApp(
       title: 'WhatChord',
       debugShowCheckedModeBanner: false,
+      navigatorKey: ref.watch(appNavigatorKeyProvider),
 
       themeMode: themeMode,
       theme: buildAppTheme(palette: palette, brightness: Brightness.light),


### PR DESCRIPTION
Shared /try deep links seed the lookup pad and tonality on the home page, but Explore Chords and Scale Explorer are routes pushed on top of it. A link arriving while one of those pages was open updated the home state underneath without revealing it, so the linked chord stayed hidden.

Add a root navigator key and pop back to the first route after seeding, so an incoming link always surfaces the home page and its seeded chord. This is a no-op on a cold start, where the home page is already the only route.