### PR TITLE
Use symbol font for scale degree glyphs

### DIFF
--- a/lib/features/theory/presentation/widgets/scale_degree_roman_text.dart
+++ b/lib/features/theory/presentation/widgets/scale_degree_roman_text.dart
@@ -1,21 +1,5 @@
 import 'package:flutter/widgets.dart';
 
-/// Builds the spans for a scale-degree roman numeral so the diminished (°) and
-/// half-diminished (ø) symbols render in Inter rather than the music symbol
-/// font, matching the scale-degree strip's conventions.
 List<InlineSpan> scaleDegreeRomanSpans(String roman) {
-  return [
-    for (final char in roman.characters)
-      TextSpan(
-        text: char,
-        style: _usesTextFont(char) ? _romanTextFontStyle : null,
-      ),
-  ];
+  return [for (final char in roman.characters) TextSpan(text: char)];
 }
-
-const _romanTextFontStyle = TextStyle(
-  fontFamily: 'Inter',
-  fontFamilyFallback: [],
-);
-
-bool _usesTextFont(String char) => char == '°' || char == 'ø';


### PR DESCRIPTION
Remove the scale-degree Roman numeral override that forced diminished and half-diminished symbols to render in Inter. Those glyphs now inherit the app's WhatChord Symbols font from the global theme.

Related to 1be7c816