### PR TITLE
Clarify chord symbols reference wording

### DIFF
--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -426,8 +426,8 @@
 
           <p>
             Where these references differ, WhatChord favors the modern consensus
-            and its own readability priorities while keeping the clarity
-            principles that both share.
+            and its own readability priorities while keeping their shared
+            clarity principles.
           </p>
 
           <div class="article-cta">


### PR DESCRIPTION
Update the guide's closing reference note so it no longer implies there are only two cited sources.