### PR TITLE
Cut redundant Analysis vs. Explore section from chord symbols article

### DIFF
--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -369,27 +369,6 @@
             <span class="chord">C9 / D</span>.
           </p>
 
-          <h2>Analysis vs. Explore</h2>
-
-          <p>
-            Analysis and Explore are WhatChord's two modes, and the online
-            <a href="/try">try page</a> mirrors Analysis. Analysis names the
-            observed notes and ranks plausible identities. Explore builds clear,
-            canonical examples of a selected symbol. They share the same symbol
-            formatter, but their note-selection goals differ:
-          </p>
-
-          <ul>
-            <li>
-              Analysis may recognize a conventional chord even when an omittable
-              tone is absent.
-            </li>
-            <li>
-              Explore supplies the implied members of a headline extension so
-              its example clearly demonstrates the selected symbol.
-            </li>
-          </ul>
-
           <h2>References</h2>
 
           <p>


### PR DESCRIPTION
The Chord Symbol Guide is a reference for how symbols are formatted, deliberately abstracted away from voicing. The Analysis vs. Explore section described mode-level note-selection behavior instead, which is off-topic for that goal. Its one formatting-relevant point, that Analysis may name a chord with an omittable tone absent, is already covered by the Omissions section, so nothing is lost by removing it.