### PR TITLE
Use "alternatives" for the surfaced candidate set

### DIFF
--- a/docs/research/chord-oracle-comparison.md
+++ b/docs/research/chord-oracle-comparison.md
@@ -109,7 +109,7 @@ text. Each WhatChord row includes:
 - quality token;
 - score;
 - second-ranked candidate;
-- near-tie signal for diagnostics.
+- alternative flag for diagnostics.
 
 ## Running
 

--- a/docs/research/contrapunctus-benchmark-comparison.md
+++ b/docs/research/contrapunctus-benchmark-comparison.md
@@ -21,7 +21,7 @@ clearer boundaries around what the corpus can and cannot measure for WhatChord.
   diminished triad. Correcting it produced 124 clean-event gains and no clean
   losses in the initial benchmark.
 - No mainstream analyst root is currently absent from WhatChord's candidates or
-  hidden outside the near-tie alternatives shown to users.
+  hidden outside the alternatives shown to users.
 - The remaining primary-label disagreements are contextual or inherently
   ambiguous. They do not justify another isolated-voicing ranking change.
 
@@ -92,17 +92,17 @@ The benchmark uses these distinctions:
 | Metric                       | Meaning                                                                                                  |
 | ---------------------------- | -------------------------------------------------------------------------------------------------------- |
 | Root exact                   | WhatChord selects the analyst root.                                                                      |
-| Root visible                 | WhatChord selects the analyst root or surfaces it within the app's near-tie window.                      |
+| Root visible                 | WhatChord selects the analyst root or surfaces it as an alternative.                                     |
 | Candidate gap                | The analyst root is present in the sounding voicing but absent from WhatChord's full generated ranking.  |
-| Hidden ranking divergence    | WhatChord generates the analyst root but does not surface it within the near-tie window.                 |
-| Visible ranking divergence   | WhatChord selects a different root but surfaces the analyst root as a near-tie alternative.              |
+| Hidden ranking divergence    | WhatChord generates the analyst root but does not surface it as an alternative.                          |
+| Visible ranking divergence   | WhatChord selects a different root but surfaces the analyst root as an alternative.                      |
 | Rootless annotation          | The analyst root is absent from the sounding pitch set and excluded by WhatChord's no-ghost-root policy. |
 | Root + annotation bass exact | WhatChord selects the analyst root and the score's sounding bass matches the annotation inversion.       |
 
 Root-visible agreement is the product-relevant alternative-reading metric.
 Top-three presence remains in `summary.json` only for continuity with the first
 run; it is neither a product match nor a candidate-coverage boundary. Some
-near-tie alternatives rank below third but are still surfaced by the app.
+alternatives rank below third but are still surfaced by the app.
 
 Root + annotation bass is a corpus-alignment metric, not WhatChord inversion
 accuracy. WhatChord receives the score's actual lowest sounding note and
@@ -198,9 +198,9 @@ ambiguity family:
 - 404 analyst-labeled half-diminished seventh chords ranked second behind
   root-position minor-sixth chords.
 
-The analyst root is a visible near-tie candidate in every case. Chorales
-contribute 743 events, mostly first-inversion `ii6/5` and `iiø6/5` annotations.
-This is expected contextual Roman-numeral behavior, while WhatChord's selected
+The analyst root is a visible alternative in every case. Chorales contribute 743
+events, mostly first-inversion `ii6/5` and `iiø6/5` annotations. This is
+expected contextual Roman-numeral behavior, while WhatChord's selected
 sixth-chord label is a conventional isolated-voicing reading of the same pitch
 set and bass.
 
@@ -220,7 +220,7 @@ chord. That requires progression or voice-leading context outside WhatChord's
 current observed-voicing input.
 
 **Decision:** Keep the bass-rooted isolated-voicing preference, continue
-surfacing the inverted seventh as a near-tie alternative, and do not promote the
+surfacing the inverted seventh as an alternative, and do not promote the
 Roman-numeral root from key context alone.
 
 ### Rootless Annotations

--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Try WhatChord - Identify a Chord" />
     <meta
       property="og:description"
-      content="Type notes, get the chord name and possible alternatives. The same on-device engine that powers the WhatChord app, running in your browser."
+      content="Type notes, get the chord name and its alternatives. The same on-device engine that powers the WhatChord app, running in your browser."
     />
     <meta
       property="og:image"
@@ -37,7 +37,7 @@
     <meta name="twitter:title" content="Try WhatChord - Identify a Chord" />
     <meta
       name="twitter:description"
-      content="Type notes, get the chord name and possible alternatives. The same on-device engine that powers the WhatChord app, running in your browser."
+      content="Type notes, get the chord name and its alternatives. The same on-device engine that powers the WhatChord app, running in your browser."
     />
     <meta
       name="twitter:image"

--- a/lib/features/home/widgets/chord_ranking_details_sheet.dart
+++ b/lib/features/home/widgets/chord_ranking_details_sheet.dart
@@ -158,10 +158,9 @@ class _RankingDetailsBodyState extends State<_RankingDetailsBody> {
   @override
   Widget build(BuildContext context) {
     final visible = _visibleCandidates(widget.candidates);
-    final possibleAlternativeCount =
-        ChordCandidateRanking.nearTieAlternativeCount([
-          for (final row in widget.candidates) row.candidate,
-        ]);
+    final alternativeCount = ChordCandidateRanking.alternativeCount([
+      for (final row in widget.candidates) row.candidate,
+    ]);
 
     return _FadedVerticalScrollView(
       child: Column(
@@ -173,7 +172,7 @@ class _RankingDetailsBodyState extends State<_RankingDetailsBody> {
             row: visible[0],
             thisCandidate: visible[0].candidate,
             nextDecision: visible.length > 1 ? visible[1].vsPrevious : null,
-            isPossibleAlternative: false,
+            isAlternative: false,
             symbol: _symbolFor(visible[0].candidate.identity),
             tonality: widget.tonality,
             noteNameSystem: widget.noteNameSystem,
@@ -199,7 +198,7 @@ class _RankingDetailsBodyState extends State<_RankingDetailsBody> {
                 nextDecision: i + 1 < visible.length
                     ? visible[i + 1].vsPrevious
                     : null,
-                isPossibleAlternative: i <= possibleAlternativeCount,
+                isAlternative: i <= alternativeCount,
                 symbol: _symbolFor(visible[i].candidate.identity),
                 tonality: widget.tonality,
                 noteNameSystem: widget.noteNameSystem,
@@ -361,7 +360,7 @@ class _CandidateRankCard extends StatefulWidget {
     required this.row,
     required this.thisCandidate,
     required this.nextDecision,
-    required this.isPossibleAlternative,
+    required this.isAlternative,
     required this.symbol,
     required this.tonality,
     required this.noteNameSystem,
@@ -373,7 +372,7 @@ class _CandidateRankCard extends StatefulWidget {
   final RankedCandidateDebug row;
   final ChordCandidate thisCandidate;
   final RankingDecision? nextDecision;
-  final bool isPossibleAlternative;
+  final bool isAlternative;
   final String symbol;
   final Tonality tonality;
   final NoteNameSystem noteNameSystem;
@@ -397,7 +396,7 @@ class _CandidateRankCardState extends State<_CandidateRankCard> {
     final cs = theme.colorScheme;
     final fitLabel = widget.rank == 1
         ? 'Chosen'
-        : (widget.isPossibleAlternative ? 'Possible' : 'Unlikely');
+        : (widget.isAlternative ? 'Possible' : 'Unlikely');
     final disableAnimations =
         MediaQuery.maybeOf(context)?.disableAnimations ??
         WidgetsBinding

--- a/lib/features/theory/domain/analysis/chord_candidate_ranking.dart
+++ b/lib/features/theory/domain/analysis/chord_candidate_ranking.dart
@@ -84,22 +84,23 @@ abstract final class ChordCandidateRanking {
   static bool isNearTie(double bestScore, double candidateScore) =>
       bestScore - candidateScore <= nearTieWindow;
 
-  /// Returns the near-tie alternatives from a [ranked] candidate list.
+  /// Returns the alternatives from a [ranked] candidate list: the non-chosen
+  /// readings close enough in score to surface alongside the top pick.
   ///
-  /// The raw score window is anchored to the top pick, but [rank] order is not
-  /// strictly monotonic in score: tie-breakers can place a candidate outside
-  /// the window above one that is inside it. To keep the visible alternatives
-  /// coherent, include every ranked candidate through the last candidate that
-  /// qualifies by score.
-  static List<ChordCandidate> nearTieAlternatives(List<ChordCandidate> ranked) {
-    final count = nearTieAlternativeCount(ranked);
+  /// The near-tie score window is anchored to the top pick, but [rank] order is
+  /// not strictly monotonic in score: tie-breakers can place a candidate
+  /// outside the window above one that is inside it. To keep the surfaced
+  /// alternatives coherent, include every ranked candidate through the last
+  /// candidate that qualifies by score.
+  static List<ChordCandidate> alternatives(List<ChordCandidate> ranked) {
+    final count = alternativeCount(ranked);
     if (count == 0) return const <ChordCandidate>[];
     return ranked.sublist(1, count + 1);
   }
 
-  /// Number of ranked candidates after #1 that belong to the displayed near-tie
-  /// alternatives group.
-  static int nearTieAlternativeCount(List<ChordCandidate> ranked) {
+  /// Number of ranked candidates after #1 that belong to the alternatives
+  /// group.
+  static int alternativeCount(List<ChordCandidate> ranked) {
     if (ranked.length < 2) return 0;
     final bestScore = ranked.first.score;
     var lastNearTieIndex = -1;

--- a/lib/features/theory/state/providers/chord_candidates_providers.dart
+++ b/lib/features/theory/state/providers/chord_candidates_providers.dart
@@ -28,7 +28,7 @@ final alternativeChordCandidatesProvider = Provider<List<ChordCandidate>>((
   ref,
 ) {
   final candidates = ref.watch(chordCandidatesProvider);
-  return ChordCandidateRanking.nearTieAlternatives(candidates);
+  return ChordCandidateRanking.alternatives(candidates);
 });
 
 final rankedChordCandidateDebugProvider = Provider<List<RankedCandidateDebug>>((

--- a/test/chord_analyzer_golden_test.dart
+++ b/test/chord_analyzer_golden_test.dart
@@ -245,7 +245,7 @@ void main() {
     ),
 
     // In neutral context, prefer the familiar fifthless altered-dominant shell
-    // while retaining the bass-rooted reinterpretations as near-tie alternates.
+    // while retaining the bass-rooted reinterpretations as alternates.
     golden(
       description: 'flat-nine-bass dominant without fifth',
       expectedSymbol: 'C7b9 / Db',
@@ -660,9 +660,9 @@ void main() {
         expect(results.first.identity.rootPc, pc('Db'));
         expect(results.first.identity.quality, ChordQualityToken.major7Sharp5);
 
-        final nearTies = ChordCandidateRanking.nearTieAlternatives(results);
+        final alternatives = ChordCandidateRanking.alternatives(results);
         expect(
-          nearTies,
+          alternatives,
           contains(
             isA<ChordCandidate>()
                 .having((c) => c.identity.rootPc, 'root', pc('F'))
@@ -677,7 +677,7 @@ void main() {
                   contains(ChordExtension.flat13),
                 ),
           ),
-          reason: 'F7b13 should surface as a near-tie for bass $bass',
+          reason: 'F7b13 should surface as an alternative for bass $bass',
         );
       }
     },

--- a/test/chord_candidate_ranking_test.dart
+++ b/test/chord_candidate_ranking_test.dart
@@ -1338,9 +1338,9 @@ void main() {
         plain('F', 6.90),
       ];
 
-      final alternatives = ChordCandidateRanking.nearTieAlternatives(ranked);
+      final alternatives = ChordCandidateRanking.alternatives(ranked);
 
-      expect(ChordCandidateRanking.nearTieAlternativeCount(ranked), 3);
+      expect(ChordCandidateRanking.alternativeCount(ranked), 3);
       expect(alternatives.map((c) => c.identity.rootPc), [
         pc('D'),
         pc('E'),
@@ -1349,16 +1349,10 @@ void main() {
     });
 
     test('returns empty when there are fewer than two candidates', () {
-      expect(
-        ChordCandidateRanking.nearTieAlternativeCount([plain('C', 7.0)]),
-        0,
-      );
-      expect(ChordCandidateRanking.nearTieAlternativeCount(const []), 0);
-      expect(
-        ChordCandidateRanking.nearTieAlternatives([plain('C', 7.0)]),
-        isEmpty,
-      );
-      expect(ChordCandidateRanking.nearTieAlternatives(const []), isEmpty);
+      expect(ChordCandidateRanking.alternativeCount([plain('C', 7.0)]), 0);
+      expect(ChordCandidateRanking.alternativeCount(const []), 0);
+      expect(ChordCandidateRanking.alternatives([plain('C', 7.0)]), isEmpty);
+      expect(ChordCandidateRanking.alternatives(const []), isEmpty);
     });
   });
 }

--- a/test/voicing_evidence_test.dart
+++ b/test/voicing_evidence_test.dart
@@ -45,8 +45,8 @@ void main() {
       expect(results.first.identity.hasSlashBass, isTrue);
       expect(results.first.identity.bassPc, pc('D'));
 
-      // The displaced conventional reading stays a visible near-tie alternative.
-      final alternatives = ChordCandidateRanking.nearTieAlternatives(results);
+      // The displaced conventional reading stays a visible alternative.
+      final alternatives = ChordCandidateRanking.alternatives(results);
       expect(
         firstWhere(
           alternatives,

--- a/tool/chord_debug.dart
+++ b/tool/chord_debug.dart
@@ -191,10 +191,9 @@ void main(List<String> args) {
   }
 
   final bestScore = results.first.candidate.score;
-  final possibleAlternativeCount =
-      ChordCandidateRanking.nearTieAlternativeCount([
-        for (final result in results) result.candidate,
-      ]);
+  final alternativeCount = ChordCandidateRanking.alternativeCount([
+    for (final result in results) result.candidate,
+  ]);
 
   for (var i = 0; i < results.length; i++) {
     final r = results[i];
@@ -211,7 +210,7 @@ void main(List<String> args) {
 
     final score = c.score;
     final deltaBest = score - bestScore;
-    final possible = i != 0 && i <= possibleAlternativeCount;
+    final alternative = i != 0 && i <= alternativeCount;
 
     final rule = _formatRankingRule(r.vsPrevious?.decidedByRule);
 
@@ -222,12 +221,12 @@ void main(List<String> args) {
     final deltaStr = i == 0
         ? ''
         : '  Δ${_fmtSigned(deltaBest, width: 6, decimals: 2)}';
-    final possibleStr = possible ? ' ~possible' : '';
+    final alternativeStr = alternative ? ' ~alt' : '';
     final ruleStr = compact && i != 0 && rule.isNotEmpty
         ? '  (vs prev: $rule)'
         : '';
 
-    stdout.writeln('$rank) $sym $scoreStr$deltaStr$possibleStr$ruleStr');
+    stdout.writeln('$rank) $sym $scoreStr$deltaStr$alternativeStr$ruleStr');
 
     if (compact) continue;
 
@@ -711,10 +710,9 @@ Map<String, Object?> chordDebugJsonPayload({
   NoteParse? parsed,
 }) {
   final bestScore = results.isEmpty ? null : results.first.candidate.score;
-  final possibleAlternativeCount =
-      ChordCandidateRanking.nearTieAlternativeCount([
-        for (final result in results) result.candidate,
-      ]);
+  final alternativeCount = ChordCandidateRanking.alternativeCount([
+    for (final result in results) result.candidate,
+  ]);
   return <String, Object?>{
     'input': <String, Object?>{
       'noteCount': input.noteCount,
@@ -735,7 +733,7 @@ Map<String, Object?> chordDebugJsonPayload({
           rank: i + 1,
           result: results[i],
           bestScore: bestScore,
-          isPossibleAlternative: i != 0 && i <= possibleAlternativeCount,
+          isAlternative: i != 0 && i <= alternativeCount,
           context: context,
           notation: notation,
           spellingMode: spellingMode,
@@ -775,7 +773,7 @@ Map<String, Object?> _candidateJson({
   required int rank,
   required RankedCandidateDebug result,
   required double? bestScore,
-  required bool isPossibleAlternative,
+  required bool isAlternative,
   required AnalysisContext context,
   required ChordNotationStyle notation,
   required ChordDebugSpellingMode spellingMode,
@@ -811,7 +809,7 @@ Map<String, Object?> _candidateJson({
     'harte': HarteChordFormatter.format(id, rootName: rootName),
     'score': c.score,
     'deltaBest': deltaBest,
-    'possible': isPossibleAlternative,
+    'alternative': isAlternative,
     'rootPc': id.rootPc,
     'rootName': rootName,
     'bassPc': id.bassPc,

--- a/tool/chord_oracle_compare.py
+++ b/tool/chord_oracle_compare.py
@@ -40,7 +40,7 @@ DEFAULT_JOBS = 8
 REVIEW_FLAG_EXPLANATIONS = {
     "disagreement": "Comparable oracle labels were available, but none matched WhatChord's top label.",
     "oracle-split": "As many or more oracles disagreed with WhatChord as agreed.",
-    "ranking-divergence": "No oracle matched WhatChord's top label, but an oracle's top label matches a possible alternative the app surfaces. Identity agrees; ranking differs.",
+    "ranking-divergence": "No oracle matched WhatChord's top label, but an oracle's top label matches an alternative the app surfaces. Identity agrees; ranking differs.",
     "insufficient-oracle-labels": "Only one oracle returned a comparable primary label.",
     "unrecognized-by-oracles": "No oracle returned a comparable primary label.",
     "oracle-error": "At least one oracle failed while processing the row.",
@@ -807,15 +807,15 @@ def build_row(
         if name not in matching_oracles
         and semantic_key_matches(whatchord_key, keys, case.pcs)
     ]
-    # Possible alternatives are the non-headline candidates the app still
-    # surfaces. An oracle that leads with one of these agrees on identity but
-    # not on ranking -- a softer, separately actionable signal than a true
-    # disagreement on a reading we never show. Matching an unsurfaced lower
-    # candidate would never reach the user.
-    possible_alt_keys = [
+    # Alternatives are the non-headline candidates the app still surfaces. An
+    # oracle that leads with one of these agrees on identity but not on ranking
+    # -- a softer, separately actionable signal than a true disagreement on a
+    # reading we never show. Matching an unsurfaced lower candidate would never
+    # reach the user.
+    alt_keys = [
         key
         for candidate in candidates
-        if candidate.get("possible")
+        if candidate.get("alternative")
         for key in (semantic_key_from_whatchord(candidate),)
         if key is not None
     ]
@@ -825,7 +825,7 @@ def build_row(
         if name in primary_semantic_oracles
         and any(
             semantic_key_matches(alt_key, primary_semantic_oracles[name], case.pcs)
-            for alt_key in possible_alt_keys
+            for alt_key in alt_keys
         )
     ]
     disagreeing_oracles = [

--- a/tool/src/chord_id_engine.dart
+++ b/tool/src/chord_id_engine.dart
@@ -29,7 +29,7 @@ enum CandidateClass {
   /// The engine's chosen interpretation (rank 1).
   chosen,
 
-  /// Musically plausible alternative the app would surface.
+  /// Alternative the app surfaces alongside the chosen chord.
   possible,
 
   /// Ranked but well below the chosen score; shown for transparency.
@@ -242,14 +242,13 @@ ChordIdResult identifyChord(
   }
 
   final chosenScore = ranked.first.score;
-  final possibleAlternativeCount =
-      ChordCandidateRanking.nearTieAlternativeCount(ranked);
+  final alternativeCount = ChordCandidateRanking.alternativeCount(ranked);
   final candidates = <ChordIdCandidate>[];
   for (var i = 0; i < ranked.length; i++) {
     final c = ranked[i];
     final classification = i == 0
         ? CandidateClass.chosen
-        : (i <= possibleAlternativeCount
+        : (i <= alternativeCount
               ? CandidateClass.possible
               : CandidateClass.unlikely);
 

--- a/tool/when_in_rome_chord_batch.dart
+++ b/tool/when_in_rome_chord_batch.dart
@@ -32,8 +32,9 @@ void main() {
     final expectedRootIndex = allCandidates.indexWhere(
       (candidate) => candidate.identity.rootPc == expectedRootPc,
     );
-    final possibleAlternativeCount =
-        ChordCandidateRanking.nearTieAlternativeCount(allCandidates);
+    final alternativeCount = ChordCandidateRanking.alternativeCount(
+      allCandidates,
+    );
 
     stdout.writeln(
       jsonEncode(<String, Object?>{
@@ -42,9 +43,8 @@ void main() {
         'expectedRootRank': expectedRootIndex < 0
             ? null
             : expectedRootIndex + 1,
-        'expectedRootPossible':
-            expectedRootIndex > 0 &&
-            expectedRootIndex <= possibleAlternativeCount,
+        'expectedRootAlternative':
+            expectedRootIndex > 0 && expectedRootIndex <= alternativeCount,
         'candidates': [
           for (var i = 0; i < candidates.length; i++)
             <String, Object?>{
@@ -54,7 +54,7 @@ void main() {
               'score': candidates[i].score,
               'presentIntervalsMask':
                   candidates[i].identity.presentIntervalsMask,
-              'possible': i > 0 && i <= possibleAlternativeCount,
+              'alternative': i > 0 && i <= alternativeCount,
             },
         ],
       }),

--- a/tool/when_in_rome_chord_benchmark.py
+++ b/tool/when_in_rome_chord_benchmark.py
@@ -249,7 +249,7 @@ def score(events: list[dict], predictions: dict[str, dict]) -> list[dict]:
         top = candidates[0] if candidates else {}
         top_three_roots = {candidate["rootPc"] for candidate in candidates}
         candidate_roots = [candidate["rootPc"] for candidate in candidates]
-        expected_root_possible = prediction["expectedRootPossible"]
+        expected_root_alternative = prediction["expectedRootAlternative"]
         rows.append(
             {
                 **event,
@@ -264,10 +264,10 @@ def score(events: list[dict], predictions: dict[str, dict]) -> list[dict]:
                 "expectedRootRank": prediction["expectedRootRank"],
                 "rootExact": top.get("rootPc") == event["expectedRootPc"],
                 "rootTop3": event["expectedRootPc"] in top_three_roots,
-                "rootPossible": expected_root_possible,
+                "rootAlternative": expected_root_alternative,
                 "rootVisible": (
                     top.get("rootPc") == event["expectedRootPc"]
-                    or expected_root_possible
+                    or expected_root_alternative
                 ),
                 "bassMatchesAnnotation": event["bassPc"] == event["expectedBassPc"],
                 "rootAndAnnotationBassExact": (
@@ -297,7 +297,7 @@ def review_flag(event: dict, candidates: list[dict], prediction: dict) -> str:
         if event["bassPc"] != event["expectedBassPc"]:
             return "annotation-bass-difference"
         return "agree"
-    if prediction["expectedRootPossible"]:
+    if prediction["expectedRootAlternative"]:
         return "visible-ranking-divergence"
     if prediction["expectedRootGenerated"]:
         return "hidden-ranking-divergence"
@@ -350,7 +350,7 @@ def metrics(rows: list[dict]) -> dict:
         "root_exact": ratio(rows, "rootExact"),
         "root_visible": ratio(rows, "rootVisible"),
         "root_top3": ratio(rows, "rootTop3"),
-        "root_possible": ratio(rows, "rootPossible"),
+        "root_alternative": ratio(rows, "rootAlternative"),
         "root_and_annotation_bass_exact": ratio(
             rows, "rootAndAnnotationBassExact"
         ),
@@ -390,7 +390,7 @@ def print_report(rows: list[dict], piece_counts: Counter) -> None:
             f"root exact={result['root_exact']}% "
             f"root+annotation bass={result['root_and_annotation_bass_exact']}% "
             f"visible={result['root_visible']}% "
-            f"possible alternative={result['root_possible']}% "
+            f"alternative={result['root_alternative']}% "
             f"top3 legacy={result['root_top3']}%"
         )
 
@@ -441,7 +441,7 @@ def write_report(path: Path, rows: list[dict], piece_counts: Counter) -> None:
             "1. Candidate gaps: analyst root is absent from WhatChord's candidate list.",
             "2. Rootless annotations: analyst root is absent from the sounding voicing by design.",
             "3. Hidden ranking divergences: analyst root exists but the app does not surface it.",
-            "4. Visible ranking divergences: analyst root is a possible alternative.",
+            "4. Visible ranking divergences: analyst root is an alternative.",
             "5. Annotation bass differences: root agrees, score bass and annotation inversion do not.",
             "6. Symmetric, functional, and explicit-label cases: classify, but do not optimize against blindly.",
             "",


### PR DESCRIPTION
Reserve "possible" only for the tier.

The recent rename injected "possible" into method, variable, flag, and doc names for the non-chosen readings the app surfaces, where it was redundant next to "alternative" and collided with the user-facing Possible tier.

Keep "possible" only as the displayed tier (Chosen/Possible/Unlikely: CandidateClass, the Why This Chord modal, and the web pills). Everywhere else the surfaced subset is just "alternatives": ChordCandidateRanking.alternatives /alternativeCount, isAlternative, and the tool wire keys (chord_debug "alternative" flag, when_in_rome expectedRootAlternative). nearTieWindow stays the internal 0.2 scoring threshold.

The full hierarchy is:

- **candidates**: every reading we generate and rank
- **chosen**: #⁠1 ranked (tier "Chosen")
- **alternatives**: the non-chosen readings within the near-tie window
  that we surface (tier "Possible")
- the rest: ranked but outside the window (tier "Unlikely")