### PR TITLE
Tighten Omissions section in chord symbol guide

### DIFF
--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -412,7 +412,7 @@
 
           <p>
             Omission markers such as <code>no5</code> and <code>omit3</code> are
-            not printed.
+            not printed. This keeps symbols concise.
           </p>
 
           <p>
@@ -421,14 +421,8 @@
             Commonly omitted tones, especially perfect fifths in extended
             chords, are understood as part of that identity rather than turned
             into a performance instruction. Dropping a structurally important
-            tone is a different matter: it weakens the reading instead of
-            simplifying the symbol.
-          </p>
-
-          <p>
-            This keeps symbols concise and avoids implying that a player should
-            omit a tone merely because it was absent from the observed voicing.
-            The literal notes remain available when that detail is needed.
+            tone, like the third, is a different matter: it weakens the reading
+            instead of simplifying the symbol.
           </p>
 
           <h2>Slash bass</h2>


### PR DESCRIPTION
Remove the redundant closing paragraph, which restated the voicing-vs-identity point and leaned on an implied app feature (literal notes shown alongside the symbol) that does not fit the article's generic, authoritative voice.

Fold the practical payoff into the opening sentence (symbols stay concise) and let the following paragraph carry the principled reason on its own. Name the third as the example of a structurally important tone so the no5/omit3 pair introduced up top maps onto the two cases that follow.