### PR TITLE
Reorder intro clause to fix a misreading

### DIFF
--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -99,9 +99,9 @@
             documents the conventions WhatChord applies: a practical style for
             contemporary lead-sheet and jazz notation (not classical
             figured-bass or Roman-numeral analysis). Where established practice
-            diverges, it takes a clear position and explains the reasoning
-            rather than cataloging every variant, favoring readability,
-            consistency, and unambiguous interpretation.
+            diverges, it takes a clear position and explains the reasoning,
+            favoring readability, consistency, and unambiguous interpretation
+            rather than cataloging every variant.
           </p>
         </header>
 


### PR DESCRIPTION
The phrase "favoring readability, consistency, and unambiguous interpretation" followed "rather than cataloging every variant," so it could be misread as more items being rejected. Move "rather than cataloging every variant" to the end so the favored qualities read as the position taken.