### PR TITLE
Clarify parentheses conventions in the chord symbol guide

### DIFF
--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -93,7 +93,7 @@
           </p>
 
           <p class="article-deck">
-            Chord-symbol notation has never been governed by a single universal
+            Chord symbol notation has never been governed by a single universal
             standard. Different publishers, educators, software packages, and
             musical traditions use slightly different conventions. This guide
             documents the conventions WhatChord applies: a practical style for
@@ -401,16 +401,19 @@
 
           <p>
             An altered fifth that defines the base quality normally stays with
-            that quality label, whether inline as in
-            <span class="chord">C7♭5</span> and
-            <span class="chord">Cmaj7♯5</span>, or parenthesized as in
-            <span class="chord">Cm7(♭5)</span>. When such a chord also carries
-            other modifiers, the altered fifth joins them in the single trailing
-            group rather than running the accidentals together or stranding a
-            second set of parentheses: a dominant ninth with a flat five and a
-            flat nine is <span class="chord">C9(♭5,♭9)</span>, and an extended
+            that quality label. It is usually inline, as in
+            <span class="chord">C7♭5</span>, <span class="chord">Cmaj7♯5</span>,
+            and <span class="chord">Cm♯5</span>. The parenthesized
+            half-diminished spelling <span class="chord">Cm7(♭5)</span>, along
+            with <span class="chord">C(♭5)</span>, is a conventional form kept
+            for familiarity, much like <span class="chord">C6/9</span>. When
+            such a chord also carries other modifiers, the altered fifth joins
+            them in the single trailing group rather than running the
+            accidentals together or stranding a second set of parentheses: a
+            dominant ninth with a flat five and a flat nine is
+            <span class="chord">C9(♭5,♭9)</span>, and an extended
             half-diminished chord is <span class="chord">Cm13(♭5,♭13)</span>,
-            not <span class="chord">Cm13(♭5)♭13</span>.
+            not <code>Cm13(♭5)♭13</code>.
           </p>
 
           <p>
@@ -422,10 +425,20 @@
           <h2>Parentheses</h2>
 
           <p>
-            Parentheses group modifiers when grouping improves readability. A
-            symbol carries at most one such group, placed at the end, so it
-            never shows parentheses in the middle of the label or two separate
-            groups:
+            This guide reserves parentheses for grouping and disambiguation.
+            They are one of the least standardized parts of chord symbol
+            notation, used for all sorts of purposes depending on the source.
+            Some teaching styles, such as Berklee-derived materials,
+            parenthesize every tension and alteration as a rule, as in
+            <span class="chord">C7(♯11)</span>, where we prefer to keep a lone
+            alteration inline as <span class="chord">C7♯11</span>.
+          </p>
+
+          <p>
+            A symbol carries at most one parenthesized group, placed at the end,
+            so parentheses never appear in the middle of the label or as two
+            separate groups. A group forms only where running the modifiers
+            inline would be ambiguous or hard to read:
           </p>
 
           <ul>
@@ -439,8 +452,9 @@
               <span class="chord">Cdim7(add9)</span>.
             </li>
             <li>
-              Modifiers on suspended seventh-family chords are grouped to avoid
-              ambiguous strings such as <code>7sus49</code>.
+              Modifiers on suspended seventh-family chords are grouped rather
+              than run onto the suspension:
+              <span class="chord">C7sus4(♭13)</span>.
             </li>
             <li>
               An altered fifth carried in the quality label joins the group when
@@ -451,31 +465,30 @@
           </ul>
 
           <p>
-            A single ordinary modifier is normally inline:
+            Where concatenation is already clear, the modifiers stay inline. A
+            single ordinary alteration or extension needs no group:
             <span class="chord">C7♭9</span>, <span class="chord">C13♯11</span>,
-            or <span class="chord">Cadd♯9</span>. Added tones on triad-like
-            chords also remain inline because <code>add</code> already makes
-            their role clear: <span class="chord">Cadd9</span> or
-            <span class="chord">Cmadd11</span>. The spelled-out qualities
-            <code>aug</code> and <code>dim</code> are an exception, taking
-            parentheses so their letters do not run into <code>add</code>:
-            <span class="chord">Caug(add13)</span>.
-          </p>
-
-          <p>
-            Some house styles, including Berklee-derived teaching materials,
-            parenthesize every tension and alteration, such as
-            <span class="chord">C7(♯11)</span>. This guide reserves parentheses
-            for grouping and disambiguation, so a lone alteration stays inline
-            as <span class="chord">C7♯11</span>.
+            or <span class="chord">Cadd♯9</span>. An added tone reads cleanly
+            inline after a label that already ends in a self-contained mark: the
+            bare root (<span class="chord">Cadd9</span>), the fused
+            <code>m</code> (<span class="chord">Cmadd11</span>), and the
+            symbolic quality signs <code>+</code> and <code>°</code> (<span
+              class="chord"
+              >C+add13</span
+            >). The spelled-out words <code>aug</code> and <code>dim</code> are
+            the telling exception, since their letters would run straight into
+            <code>add</code>. They take the group instead: textual
+            <span class="chord">Caug(add13)</span> where symbolic writes
+            <span class="chord">C+add13</span>, the difference between a
+            readable symbol and <code>Caugadd13</code>.
           </p>
 
           <p>
             Textual notation separates grouped modifiers with commas for
-            readability, as in <span class="chord">C13(♭9,♯11)</span>. The more
-            compact symbolic notation omits them, relying on the accidental and
-            <code>add</code> prefixes that already mark where each modifier
-            begins.
+            readability, as in <span class="chord">C13(♭9,♯11)</span>. Symbolic
+            notation omits them for compactness, writing the same chord as
+            <span class="chord">C13(♭9♯11)</span>, since the accidentals already
+            mark where each modifier begins.
           </p>
 
           <h2>Omissions</h2>

--- a/lib/features/theory/domain/analysis/ranking_rules.dart
+++ b/lib/features/theory/domain/analysis/ranking_rules.dart
@@ -697,7 +697,7 @@ int? _preferCompleteDom7Flat9OverColoredDim7(
 /// Prefers a fifthless flat-nine-bass dominant shell over the two remote
 /// reinterpretations produced by the same four pitch classes.
 ///
-/// Example: {C, Db, E, Bb} with Db in the bass is C7b9/Db, not C#mmaj7(add13)
+/// Example: {C, Db, E, Bb} with Db in the bass is C7b9/Db, not C#mmaj13
 /// or A#dim(add9)/C#. The dominant names the familiar E-Bb tritone shell; the
 /// competitors require less common added-tone structures.
 ///
@@ -1017,8 +1017,8 @@ bool _isMajorThirteenSusFour(ChordIdentity id) {
 /// where the bass note only appears as a color-tone add-extension.
 ///
 /// Example: {A, B, C, F} with A in the bass reads naturally as F(#11)/A
-/// (first inversion, bass=M3), not Cmaj7sus4(add13)/A where the bass A is
-/// merely an add13 extension on an unrelated root. The inversion reading keeps
+/// (first inversion, bass=M3), not Cmaj13sus4/A where the bass A is
+/// merely a thirteenth on an unrelated root. The inversion reading keeps
 /// all four tones in a single coherent chord name without borrowing the bass
 /// as an ornament.
 int? _preferCompleteMajorInversionOverSeventhColorBassSlash(
@@ -1326,9 +1326,9 @@ int? _preferDom7RootOverNonDomSlash(
 ///
 /// Example: {C, D, E, G, Bb} with D in the bass is normally understood as
 /// C9/D (often written C7/D), not Em7#5#11/D. Likewise, a complete
-/// Dbm(maj9)/Eb is preferred over Emaj7#5(add13)/D#. The competing spellings
+/// Dbm(maj9)/Eb is preferred over Emaj13#5/D#. The competing spellings
 /// are pitch-class valid, but reinterpret a complete natural ninth chord as a
-/// remote altered seventh chord.
+/// remote altered chord.
 int? _preferNinthBassSeventhOverAlteredSlash(
   ChordCandidate a,
   ChordCandidate b,
@@ -1549,8 +1549,8 @@ int? _preferRootAddChordOverSusSlash(
 ///
 /// A complete triad with simple color tones (e.g., Bbmadd9/Db) is a more
 /// conventional and stable structure than forcing the same pitches into a
-/// seventh-family framework with unusual extension pairings (e.g.,
-/// Dbmaj7(add13) where a maj7(add13) is rare in practice).
+/// fifthless seventh-family reading (e.g., Dbmaj13, which drops the fifth to
+/// book a remote thirteenth).
 int? _preferCompleteTriadAddToneOverSeventhFamilyAddTone(
   ChordCandidate a,
   ChordCandidate b,
@@ -1640,11 +1640,11 @@ int? _preferSimpleTriadAddToneOverSeventhFamilyUnusualQuality(
 /// stable gestalt. The raw scorer can rank it below a larger template that
 /// books more "required" tones, even when that larger reading omits a core
 /// tone of its own. This prefers the complete triad over:
-/// - a seventh-family slash that omits every fifth (e.g. D♭maj7(add13)/F), and
+/// - a seventh-family slash that omits every fifth (e.g. D♭maj13/F), and
 /// - a plain suspended triad with no seventh (e.g. Fsus4♭13).
 ///
 /// Example: {F, B♭, C, D♭} with F in the bass is B♭m(add9)/F, not
-/// D♭maj7(add13)/F (fifthless) or Fsus4♭13 (no third, no seventh).
+/// D♭maj13/F (fifthless) or Fsus4♭13 (no third, no seventh).
 ///
 /// The deficient side is deliberately narrow so that complete seventh chords,
 /// altered-fifth chords (which keep a flat/sharp fifth), six chords, and

--- a/lib/features/theory/presentation/services/chord_quality_formatter.dart
+++ b/lib/features/theory/presentation/services/chord_quality_formatter.dart
@@ -198,8 +198,8 @@ class ChordQualityFormatter {
     if (quality == ChordQualityToken.diminished7) return true;
     if (mods.isEmpty) return false;
 
-    // Suspended seventh-family chords read poorly when modifiers are concatenated:
-    // "7sus49" is ambiguous; prefer "7sus4(9)".
+    // Suspended seventh-family chords group their modifiers instead of running
+    // them onto the sus label: C7sus4(b13), CΔ7sus4(9).
     if (quality.isSeventhFamily && quality.isSus) return true;
 
     // Single modifier: generally inline, except add-tones on seventh-family chords.
@@ -209,7 +209,7 @@ class ChordQualityFormatter {
       // Added tones read cleanly inline after the bare root (Cadd9), the fused
       // single-letter "m" (Cmadd9), and the symbolic +/° quality symbols, which
       // already delimit (C+add13). They need parentheses on seventh-family
-      // chords (C7(add13)) and after the spelled-out word qualities "aug"/"dim",
+      // chords (Cm7(add11)) and after the spelled-out word qualities "aug"/"dim",
       // whose letters would otherwise collide with "add" ("Caugadd13").
       if (ext.isAddTone) {
         if (quality.isSeventhFamily) return true;


### PR DESCRIPTION
Lead the Parentheses section with the decision to reserve parentheses for grouping and disambiguation, then briefly note that it is one of the least standardized areas before contrasting the Berklee every-tension style (C7(#11)) with our inline C7#11. Keep the aug(add13) vs +add13 contrast as the readability showcase, and mark anti-patterns like Caugadd13 and Cm13(b5)b13 as plain code rather than styled chord symbols.

Note the parenthesized Cm7(b5) spelling as a kept convention like 6/9, and refresh stale examples now that a seventh plus a thirteenth promotes to a 13 chord: C7(add13) and textual C7sus4(9) are no longer produced, so update the formatter and ranking-rule comments to their current forms (C13, C9sus4, Cm7(add11), maj13-family spellings).