### PR TITLE
Replace coined "seventh-family" label with standard wording

### DIFF
--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -444,13 +444,14 @@
               <span class="chord">C7(♭9,♯11)</span>.
             </li>
             <li>
-              Added tones on seventh-family chords, including diminished
-              sevenths, are grouped: <span class="chord">Cm7(add11)</span> and
+              Added tones on chords that contain a seventh, including diminished
+              sevenths, are grouped:
+              <span class="chord">Cm7(add11)</span> and
               <span class="chord">Cdim7(add9)</span>.
             </li>
             <li>
-              Modifiers on suspended seventh-family chords are grouped rather
-              than run onto the suspension:
+              Modifiers on suspended seventh chords are grouped rather than run
+              onto the suspension:
               <span class="chord">C7sus4(♭13)</span>.
             </li>
             <li>


### PR DESCRIPTION
"Seventh family" is not a standardized music theory term.