### PR TITLE
Clarify chord symbol guide from reviewer feedback

### DIFF
--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -243,7 +243,14 @@
             </tbody>
           </table>
 
-          <p>The examples below use textual notation.</p>
+          <p>
+            In everyday practice these are not sealed systems; musicians often
+            mix them, writing a dash for a minor chord but spelling out
+            <code>maj7</code>, or reaching for <code>°</code> and
+            <code>ø7</code> while leaving the rest textual.
+          </p>
+
+          <p>The examples below use textual notation throughout.</p>
 
           <h2>Headline extensions</h2>
 
@@ -368,14 +375,20 @@
           <h3>Why not add2 or add4?</h3>
 
           <p>
-            Chord symbols say nothing about register. A D added to a C triad
-            serves as the ninth whether it is voiced next to the root or an
-            octave above it; the same principle makes F an added eleventh. The
-            labels
-            <code>add9</code> and <code>add11</code> are therefore used
-            consistently instead of changing to
-            <code class="not-used">add2</code> or
-            <code class="not-used">add4</code> based on voicing.
+            Chord symbols say nothing about register, so an added tone's label
+            never changes with its voicing: a D added to a C triad is the same
+            ninth whether it sits next to the root or an octave above, and the
+            same principle makes F an added eleventh. There is no need to switch
+            between <code class="not-used">add2</code> and <code>add9</code>
+            based on how the note happens to be voiced.
+          </p>
+
+          <p>
+            Register independence rules out voicing-based switching, but it does
+            not by itself favor <code>add9</code> over
+            <code class="not-used">add2</code>, since both ignore register
+            equally. No strict rule settles the choice; <code>add9</code> and
+            <code>add11</code> simply prevail as the common convention.
           </p>
 
           <p>
@@ -415,10 +428,10 @@
             When such a chord also carries other modifiers, the altered fifth
             joins them in the single trailing group rather than running the
             accidentals together or stranding a second set of parentheses: a
-            dominant ninth with a flat five and a flat nine is
-            <span class="chord">C9(♭5,♭9)</span>, and an extended
-            half-diminished chord is <span class="chord">Cm13(♭5,♭13)</span>,
-            not <span class="chord not-used">Cm13(♭5)♭13</span>.
+            dominant seventh with a flat five and a flat nine is
+            <span class="chord">C7(♭5,♭9)</span>, and an extended
+            half-diminished chord is <span class="chord">Cm9(♭5,♭13)</span>, not
+            <span class="chord not-used">Cm9(♭5)♭13</span>.
           </p>
 
           <p>
@@ -465,8 +478,8 @@
             <li>
               An altered fifth carried in the quality label joins the group when
               other modifiers are present:
-              <span class="chord">C9(♭5,♭9)</span> and
-              <span class="chord">Cm13(♭5,♭13)</span>.
+              <span class="chord">C7(♭5,♭9)</span> and
+              <span class="chord">Cm9(♭5,♭13)</span>.
             </li>
           </ul>
 


### PR DESCRIPTION
Address three issues raised in review of the chord symbol guide:

- Replace contradictory examples that asserted both a natural and an altered form of the same degree: C9(b5,b9) becomes C7(b5,b9) and Cm13(b5,b13) becomes Cm9(b5,b13), preserving the altered-fifth grouping point without the natural-9/13 collision.
- Reframe the add2/add4 rationale. Register independence only rules out voicing-based switching; it does not by itself pick add9 over add2. Attribute that choice to common convention rather than a strict rule.
- Note that textual and symbolic notation are not sealed systems and are often mixed in practice.

See:

- https://www.reddit.com/r/musictheory/comments/1udju6w/which_chord_symbol_conventions_are_worth/otjhgsi/