### PR TITLE
Promote symbolic major ninth sus chords

### DIFF
--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -223,6 +223,15 @@
                 </td>
               </tr>
               <tr>
+                <td>Minor-major seventh</td>
+                <td><code>mmaj7</code></td>
+                <td><code>−Δ7</code></td>
+                <td>
+                  <span class="chord">Cmmaj7</span> or
+                  <span class="chord">C−Δ7</span>
+                </td>
+              </tr>
+              <tr>
                 <td>Half-diminished seventh</td>
                 <td><code>m7(♭5)</code></td>
                 <td><code>ø7</code></td>
@@ -289,7 +298,10 @@
             present lower extension is folded in rather than spelled out
             separately, while alterations stay explicit. So a dominant
             thirteenth with a flat ninth and sharp eleventh is
-            <span class="chord">C13(♭9,♯11)</span>.
+            <span class="chord">C13(♭9,♯11)</span>. The same promotion applies
+            to suspended major-seventh chords: textual
+            <span class="chord">Cmaj9sus4</span> and symbolic
+            <span class="chord">CΔ9sus4</span> name the same chord.
           </p>
 
           <h3>Sixth chords</h3>
@@ -409,7 +421,7 @@
 
           <p>
             Where concatenation is already clear, the modifiers stay inline. A
-            single ordinary alteration or extension needs no group:
+            single ordinary modifier needs no group:
             <span class="chord">C7♭9</span>, <span class="chord">C13♯11</span>,
             or <span class="chord">Cadd♯9</span>. An added tone reads cleanly
             inline after a label that already ends in a self-contained mark: the

--- a/lib/features/theory/presentation/services/chord_quality_formatter.dart
+++ b/lib/features/theory/presentation/services/chord_quality_formatter.dart
@@ -172,17 +172,20 @@ class ChordQualityFormatter {
   }
 
   static String _replaceSeventhWithExtension(String base, String ext) {
-    // Suspended headline: 7sus4 -> 9sus4, maj7sus4 -> maj9sus4.
+    // Suspended headline: 7sus4 -> 9sus4, maj7sus4 -> maj9sus4,
+    // Δ7sus4 -> Δ9sus4.
     if (base.startsWith('7sus')) {
       return '$ext${base.substring(1)}';
     }
     if (base.startsWith('maj7sus')) {
       return 'maj$ext${base.substring(4)}';
     }
+    if (base.startsWith('Δ7sus')) {
+      return 'Δ$ext${base.substring(2)}';
+    }
 
     // Plain seventh-family cores end in '7': 7 -> 9, maj7 -> maj9, m7 -> m9,
-    // Δ7 -> Δ9, ø7 -> ø9, mmaj7 -> mmaj9. Symbolic major7sus (Δ7sus2/Δ7sus4) ends
-    // in its suspension and is left unpromoted.
+    // Δ7 -> Δ9, ø7 -> ø9, mmaj7 -> mmaj9.
     if (base == '7') return ext;
     if (base.endsWith('7')) {
       return '${base.substring(0, base.length - 1)}$ext';
@@ -199,7 +202,7 @@ class ChordQualityFormatter {
     if (mods.isEmpty) return false;
 
     // Suspended seventh-family chords group their modifiers instead of running
-    // them onto the sus label: C7sus4(b13), CΔ7sus4(9).
+    // them onto the sus label: C7sus4(b13), CΔ9sus4(b13).
     if (quality.isSeventhFamily && quality.isSus) return true;
 
     // Single modifier: generally inline, except add-tones on seventh-family chords.

--- a/test/chord_presentation_builder_test.dart
+++ b/test/chord_presentation_builder_test.dart
@@ -331,6 +331,23 @@ void main() {
     );
   });
 
+  test('promotes symbolic major seventh sus ninths into the headline', () {
+    final identity = _identity(
+      root: 'C',
+      quality: ChordQualityToken.major7sus4,
+      extensions: const {ChordExtension.nine},
+      intervals: const [0, 2, 5, 7, 11],
+    );
+
+    final presentation = ChordPresentationBuilder.fromIdentity(
+      identity: identity,
+      tonality: const Tonality(Tonic.c, TonalityMode.major),
+      notation: ChordNotationStyle.symbolic,
+    );
+
+    expect(presentation.symbol.toString(), 'CΔ9sus4');
+  });
+
   test(
     'inserts comma before bass connector when multiple modifiers present',
     () {


### PR DESCRIPTION
Render symbolic major-seventh suspended ninth chords as Δ9sus instead of leaving the ninth in a trailing modifier group.

Document minor-major chord labels in the chord-symbol reference and tighten the parentheses wording around single modifiers.