### PR TITLE
Cut suspended major-seventh chord promotion example

### DIFF
--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -298,10 +298,7 @@
             present lower extension is folded in rather than spelled out
             separately, while alterations stay explicit. So a dominant
             thirteenth with a flat ninth and sharp eleventh is
-            <span class="chord">C13(♭9,♯11)</span>. The same promotion applies
-            to suspended major-seventh chords: textual
-            <span class="chord">Cmaj9sus4</span> and symbolic
-            <span class="chord">CΔ9sus4</span> name the same chord.
+            <span class="chord">C13(♭9,♯11)</span>.
           </p>
 
           <h3>Sixth chords</h3>


### PR DESCRIPTION
This wasn't adding anything because the preceding rule already naturally covers this chord as well.