### PR TITLE
Name plain major-seventh sharp-nine color

### DIFF
--- a/docs/site/articles/under-the-hood.html
+++ b/docs/site/articles/under-the-hood.html
@@ -716,10 +716,11 @@
           <p>
             Interval 3 is normally a minor third, but the analyzer allows a few
             narrow musical exceptions where that pitch clearly functions as
-            sharp-nine color instead: dominant 7th shells with ♯9 color, and
-            major-family split-third voicings. These exceptions keep common
-            blues and altered-dominant sounds from being misread as
-            contradictions.
+            sharp-nine color instead: dominant 7th shells with ♯9 color, plain
+            major seventh chords with both the major third and major seventh
+            present, and major-family split-third voicings. These exceptions
+            keep common blues, altered-dominant sounds, and explicit altered
+            major-seventh colors from being misread as contradictions.
           </p>
 
           <h2>How the weights were tuned</h2>

--- a/docs/site/js/chord-id.js
+++ b/docs/site/js/chord-id.js
@@ -22,7 +22,7 @@ a[c]=function(){if(a[b]===t){a[b]=d()}a[c]=function(){return this[b]}
 return a[b]}}function lazyFinal(a,b,c,d){var t=a
 a[b]=t
 a[c]=function(){if(a[b]===t){var s=d()
-if(a[b]!==t){A.lX(b)}a[b]=s}var r=a[b]
+if(a[b]!==t){A.lZ(b)}a[b]=s}var r=a[b]
 a[c]=function(){return r}
 return r}}function makeConstList(a,b){if(b!=null)A.i(a,b)
 a.$flags=7
@@ -84,12 +84,12 @@ dZ(a){if(a==null)return a
 if(Array.isArray(a))return J.k.prototype
 if(!(a instanceof A.p))return J.ad.prototype
 return a},
-kL(a){if(typeof a=="string")return J.ag.prototype
+kM(a){if(typeof a=="string")return J.ag.prototype
 if(a==null)return a
 if(Array.isArray(a))return J.k.prototype
 if(!(a instanceof A.p))return J.ad.prototype
 return a},
-kM(a){if(typeof a=="number")return J.aH.prototype
+kN(a){if(typeof a=="number")return J.aH.prototype
 if(typeof a=="string")return J.ag.prototype
 if(a==null)return a
 if(!(a instanceof A.p))return J.ad.prototype
@@ -103,11 +103,11 @@ if(typeof a!="object")return b!=null&&a===b
 return J.az(a).B(a,b)},
 b1(a,b){return J.dZ(a).l(a,b)},
 e4(a,b){return J.fp(a).aw(a,b)},
-fM(a,b){return J.kM(a).A(a,b)},
+fM(a,b){return J.kN(a).A(a,b)},
 fN(a,b){return J.dZ(a).K(a,b)},
 t(a){return J.az(a).gv(a)},
 dw(a){return J.dZ(a).gq(a)},
-bF(a){return J.kL(a).gt(a)},
+bF(a){return J.kM(a).gt(a)},
 fO(a){return J.az(a).gN(a)},
 fP(a,b,c){return J.fp(a).D(a,b,c)},
 bG(a){return J.az(a).j(a)},
@@ -140,7 +140,7 @@ a^=a>>>11
 return a+((a&16383)<<15)&536870911},
 fk(a,b,c){return a},
 e_(a){var t,s
-for(t=$.O.length,s=0;s<t;++s)if(a===$.O[s])return!0
+for(t=$.P.length,s=0;s<t;++s)if(a===$.P[s])return!0
 return!1},
 ew(a,b,c,d){A.dN(b,"start")
 A.dN(c,"end")
@@ -162,7 +162,7 @@ _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-M:function M(a,b,c){this.a=a
+N:function N(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
 ar:function ar(a,b,c){this.a=a
@@ -201,13 +201,13 @@ if(isNaN(t)){s=B.c.G(a)
 if(s==="NaN"||s==="+NaN"||s==="-NaN")return t
 return null}return t},
 c6(a){var t,s,r,q
-if(a instanceof A.p)return A.N(A.cn(a),null)
+if(a instanceof A.p)return A.O(A.cn(a),null)
 t=J.az(a)
 if(t===B.bD||t===B.bE||u.A.b(a)){s=B.b3(a)
 if(s!=="Object"&&s!=="")return s
 r=a.constructor
 if(typeof r=="function"){q=r.name
-if(typeof q=="string"&&q!=="Object"&&q!=="")return q}}return A.N(A.cn(a),null)},
+if(typeof q=="string"&&q!=="Object"&&q!=="")return q}}return A.O(A.cn(a),null)},
 ep(a){var t,s,r
 if(a==null||typeof a=="number"||A.dW(a))return J.bG(a)
 if(typeof a=="string")return JSON.stringify(a)
@@ -227,16 +227,16 @@ if(!A.f8(b))return new A.W(!0,b,s,null)
 t=J.bF(a)
 if(b<0||b>=t)return A.dD(b,t,a,s)
 return A.eq(b,s)},
-kB(a){return new A.W(!0,a,null,null)},
+kC(a){return new A.W(!0,a,null,null)},
 d(a){return A.F(a,new Error())},
 F(a,b){var t
 if(a==null)a=new A.bv()
 b.dartException=a
-t=A.lY
+t=A.m_
 if("defineProperty" in Object){Object.defineProperty(b,"message",{get:t})
 b.name=""}else b.toString=t
 return b},
-lY(){return J.bG(this.dartException)},
+m_(){return J.bG(this.dartException)},
 b_(a,b){throw A.F(a,b==null?new Error():b)},
 co(a,b,c){var t
 if(b==null)b=0
@@ -276,10 +276,10 @@ return new A.c2(a,s,t?null:b.receiver)},
 e1(a){if(a==null)return new A.cT(a)
 if(typeof a!=="object")return a
 if("dartException" in a)return A.aC(a,a.dartException)
-return A.kA(a)},
+return A.kB(a)},
 aC(a,b){if(u.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
 return b},
-kA(a){var t,s,r,q,p,o,n,m,l,k,j,i,h
+kB(a){var t,s,r,q,p,o,n,m,l,k,j,i,h
 if(!("message" in a))return a
 t=a.message
 if("number" in a&&typeof a.number=="number"){s=a.number
@@ -308,11 +308,11 @@ return a},
 e0(a){if(a==null)return J.t(a)
 if(typeof a=="object")return A.bm(a)
 return J.t(a)},
-kD(a){if(typeof a=="number")return B.L.gv(a)
+kE(a){if(typeof a=="number")return B.L.gv(a)
 if(a instanceof A.cl)return A.bm(a)
 if(a instanceof A.a4)return a.gv(a)
 return A.e0(a)},
-kK(a,b){var t,s,r,q=a.length
+kL(a,b){var t,s,r,q=a.length
 for(t=0;t<q;t=r){s=t+1
 r=s+1
 b.u(0,a[t],a[s])}return b},
@@ -322,12 +322,12 @@ case 1:return a.$1(c)
 case 2:return a.$2(c,d)
 case 3:return a.$3(c,d,e)
 case 4:return a.$4(c,d,e,f)}throw A.d(new A.d3("Unsupported number of arguments for wrapped closure"))},
-kE(a,b){var t=a.$identity
+kF(a,b){var t=a.$identity
 if(!!t)return t
-t=A.kF(a,b)
+t=A.kG(a,b)
 a.$identity=t
 return t},
-kF(a,b){var t
+kG(a,b){var t
 switch(b){case 0:t=a.$0
 break
 case 1:t=a.$1
@@ -408,7 +408,7 @@ iz(a,b){var t,s
 for(t=0;t<a.length;++t){s=a[t]
 if(!(t<b.length))return A.c(b,t)
 if(!J.a_(s,b[t]))return!1}return!0},
-kH(a,b){var t=b.length,s=v.rttc[""+t+";"+a]
+kI(a,b){var t=b.length,s=v.rttc[""+t+";"+a]
 if(s==null)return null
 if(t===0)return s
 if(t===s.length)return s.apply(null,b)
@@ -416,33 +416,33 @@ return s(b)},
 em(a,b,c,d,e,f){var t=b?"m":"",s=c?"":"i",r=d?"u":"",q=e?"s":"",p=function(g,h){try{return new RegExp(g,h)}catch(o){return o}}(a,t+s+r+q+f)
 if(p instanceof RegExp)return p
 throw A.d(A.eh("Illegal RegExp pattern ("+String(p)+")",a))},
-lS(a,b,c){var t=a.indexOf(b,c)
+lU(a,b,c){var t=a.indexOf(b,c)
 return t>=0},
 fo(a){if(a.indexOf("$",0)>=0)return a.replace(/\$/g,"$$$$")
 return a},
 fs(a){if(/[[\]{}()*+?.\\^$|]/.test(a))return a.replace(/[[\]{}()*+?.\\^$|]/g,"\\$&")
 return a},
 U(a,b,c){var t
-if(typeof b=="string")return A.lU(a,b,c)
+if(typeof b=="string")return A.lW(a,b,c)
 if(b instanceof A.aJ){t=b.gap()
 t.lastIndex=0
-return a.replace(t,A.fo(c))}return A.lT(a,b,c)},
-lT(a,b,c){var t,s,r,q
+return a.replace(t,A.fo(c))}return A.lV(a,b,c)},
+lV(a,b,c){var t,s,r,q
 for(t=J.e4(b,a),t=t.gq(t),s=0,r="";t.k();){q=t.gn()
 r=r+a.substring(s,q.ga5())+c
 s=q.ga0()}t=r+a.substring(s)
 return t.charCodeAt(0)==0?t:t},
-lU(a,b,c){var t,s,r
+lW(a,b,c){var t,s,r
 if(b===""){if(a==="")return c
 t=a.length
 for(s=c,r=0;r<t;++r)s=s+a[r]+c
 return s.charCodeAt(0)==0?s:s}if(a.indexOf(b,0)<0)return a
 if(a.length<500||c.indexOf("$",0)>=0)return a.split(b).join(c)
 return a.replace(new RegExp(A.fs(b),"g"),A.fo(c))},
-lV(a,b,c,d){var t=a.indexOf(b,d)
+lX(a,b,c,d){var t=a.indexOf(b,d)
 if(t<0)return a
-return A.lW(a,t,t+b.length,c)},
-lW(a,b,c,d){return a.substring(0,b)+d+a.substring(c)},
+return A.lY(a,t,t+b.length,c)},
+lY(a,b,c,d){return a.substring(0,b)+d+a.substring(c)},
 aU:function aU(a,b,c){this.a=a
 this.b=b
 this.c=c},
@@ -511,7 +511,7 @@ _.b=b
 _.c=c
 _.d=null
 _.$ti=d},
-L:function L(a,b){this.a=a
+M:function M(a,b){this.a=a
 this.$ti=b},
 bf:function bf(a,b,c,d){var _=this
 _.a=a
@@ -556,7 +556,7 @@ es(a){var t=a.w
 if(t===6||t===7)return A.es(a.x)
 return t===11||t===12},
 i8(a){return a.as},
-kU(a,b){var t,s=b.length
+kV(a,b){var t,s=b.length
 for(t=0;t<s;++t)if(!a[t].b(b[t]))return!1
 return!0},
 E(a){return A.db(v.typeUniverse,a,!1)},
@@ -588,7 +588,7 @@ return A.eK(a0,l,j)
 case 11:i=a1.x
 h=A.ax(a0,i,a2,a3)
 g=a1.y
-f=A.kx(a0,g,a2,a3)
+f=A.ky(a0,g,a2,a3)
 if(h===i&&f===g)return a1
 return A.eH(a0,h,f)
 case 12:e=a1.y
@@ -609,14 +609,14 @@ for(t=!1,s=0;s<p;++s){r=b[s]
 q=A.ax(a,r,c,d)
 if(q!==r)t=!0
 o[s]=q}return t?o:b},
-ky(a,b,c,d){var t,s,r,q,p,o,n=b.length,m=A.dc(n)
+kz(a,b,c,d){var t,s,r,q,p,o,n=b.length,m=A.dc(n)
 for(t=!1,s=0;s<n;s+=3){r=b[s]
 q=b[s+1]
 p=b[s+2]
 o=A.ax(a,p,c,d)
 if(o!==p)t=!0
 m.splice(s,3,r,q,o)}return t?m:b},
-kx(a,b,c,d){var t,s=b.a,r=A.aV(a,s,c,d),q=b.b,p=A.aV(a,q,c,d),o=b.c,n=A.ky(a,o,c,d)
+ky(a,b,c,d){var t,s=b.a,r=A.aV(a,s,c,d),q=b.b,p=A.aV(a,q,c,d),o=b.c,n=A.kz(a,o,c,d)
 if(r===s&&p===q&&n===o)return b
 t=new A.cg()
 t.a=r
@@ -626,9 +626,9 @@ return t},
 i(a,b){a[v.arrayRti]=b
 return a},
 fl(a){var t=a.$S
-if(t!=null){if(typeof t=="number")return A.kO(t)
+if(t!=null){if(typeof t=="number")return A.kP(t)
 return a.$S()}return null},
-kR(a,b){var t
+kS(a,b){var t
 if(A.es(b))if(a instanceof A.af){t=A.fl(a)
 if(t!=null)return t}return A.cn(a)},
 cn(a){if(a instanceof A.p)return A.a(a)
@@ -646,13 +646,13 @@ return A.j6(a,t)},
 j6(a,b){var t=a instanceof A.af?Object.getPrototypeOf(Object.getPrototypeOf(a)).constructor:b,s=A.iH(v.typeUniverse,t.name)
 b.$ccache=s
 return s},
-kO(a){var t,s=v.types,r=s[a]
+kP(a){var t,s=v.types,r=s[a]
 if(typeof r=="string"){t=A.db(v.typeUniverse,r,!1)
 s[a]=t
 return t}return r},
-kN(a){return A.ay(A.a(a))},
+kO(a){return A.ay(A.a(a))},
 dX(a){var t
-if(a instanceof A.a4)return A.kI(a.$r,a.ab())
+if(a instanceof A.a4)return A.kJ(a.$r,a.ab())
 t=a instanceof A.af?A.fl(a):null
 if(t!=null)return t
 if(u.R.b(a))return J.fO(a).a
@@ -660,33 +660,33 @@ if(Array.isArray(a))return A.H(a)
 return A.cn(a)},
 ay(a){var t=a.r
 return t==null?a.r=new A.cl(a):t},
-kI(a,b){var t,s,r=b,q=r.length
+kJ(a,b){var t,s,r=b,q=r.length
 if(q===0)return u.F
 if(0>=q)return A.c(r,0)
 t=A.bE(v.typeUniverse,A.dX(r[0]),"@<0>")
 for(s=1;s<q;++s){if(!(s<r.length))return A.c(r,s)
 t=A.eL(v.typeUniverse,t,A.dX(r[s]))}return A.bE(v.typeUniverse,t,a)},
-lZ(a){return A.ay(A.db(v.typeUniverse,a,!1))},
+m0(a){return A.ay(A.db(v.typeUniverse,a,!1))},
 j5(a){var t=this
-t.b=A.kt(t)
+t.b=A.ku(t)
 return t.b(a)},
-kt(a){var t,s,r,q,p
+ku(a){var t,s,r,q,p
 if(a===u.K)return A.jm
 if(A.aA(a))return A.jt
 t=a.w
 if(t===6)return A.j2
 if(t===1)return A.fa
 if(t===7)return A.je
-s=A.ks(a)
+s=A.kt(a)
 if(s!=null)return s
 if(t===8){r=a.x
 if(a.y.every(A.aA)){a.f="$i"+r
 if(r==="ai")return A.jh
 if(a===u.m)return A.jg
-return A.js}}else if(t===10){q=A.kH(a.x,a.y)
+return A.js}}else if(t===10){q=A.kI(a.x,a.y)
 p=q==null?A.fa:q
 return p==null?A.dS(p):p}return A.j0},
-ks(a){if(a.w===8){if(a===u.S)return A.f8
+kt(a){if(a.w===8){if(a===u.S)return A.f8
 if(a===u.i||a===u.H)return A.jl
 if(a===u.N)return A.jr
 if(a===u.y)return A.dW}return null},
@@ -709,7 +709,7 @@ t.a=s
 return t.a(a)},
 j0(a){var t=this
 if(a==null)return A.aW(t)
-return A.kS(v.typeUniverse,A.kR(a,t),t)},
+return A.kT(v.typeUniverse,A.kS(a,t),t)},
 j2(a){if(a==null)return!0
 return this.x.b(a)},
 js(a){var t,s=this
@@ -738,8 +738,8 @@ throw A.F(A.eW(a,t),new Error())},
 j1(a){var t=this
 if(a==null||t.b(a))return a
 throw A.F(A.eW(a,t),new Error())},
-eW(a,b){return new A.bA("TypeError: "+A.eA(a,A.N(b,null)))},
-eA(a,b){return A.bW(a)+": type '"+A.N(A.dX(a),null)+"' is not a subtype of type '"+b+"'"},
+eW(a,b){return new A.bA("TypeError: "+A.eA(a,A.O(b,null)))},
+eA(a,b){return A.bW(a)+": type '"+A.O(A.dX(a),null)+"' is not a subtype of type '"+b+"'"},
 S(a,b){return new A.bA("TypeError: "+A.eA(a,b))},
 je(a){var t=this
 return t.x.b(a)||A.dO(v.typeUniverse,t).b(a)},
@@ -786,16 +786,16 @@ iP(a){if(a==null)return a
 if(A.f9(a))return a
 throw A.F(A.S(a,"JSObject?"),new Error())},
 fj(a,b){var t,s,r
-for(t="",s="",r=0;r<a.length;++r,s=", ")t+=s+A.N(a[r],b)
+for(t="",s="",r=0;r<a.length;++r,s=", ")t+=s+A.O(a[r],b)
 return t},
-kp(a,b){var t,s,r,q,p,o,n=a.x,m=a.y
+kq(a,b){var t,s,r,q,p,o,n=a.x,m=a.y
 if(""===n)return"("+A.fj(m,b)+")"
 t=m.length
 s=n.split(",")
 r=s.length-t
 for(q="(",p="",o=0;o<t;++o,p=", "){q+=p
 if(r===0)q+="{"
-q+=A.N(m[o],b)
+q+=A.O(m[o],b)
 if(r>=0)q+=" "+s[r];++r}return q+"})"},
 eY(a2,a3,a4){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0=", ",a1=null
 if(a4!=null){t=a4.length
@@ -809,7 +809,7 @@ if(!(m>=0))return A.c(a3,m)
 p=p+o+a3[m]
 l=a4[r]
 k=l.w
-if(!(k===2||k===3||k===4||k===5||l===q))p+=" extends "+A.N(l,a3)}p+=">"}else p=""
+if(!(k===2||k===3||k===4||k===5||l===q))p+=" extends "+A.O(l,a3)}p+=">"}else p=""
 q=a2.x
 j=a2.y
 i=j.a
@@ -818,28 +818,28 @@ g=j.b
 f=g.length
 e=j.c
 d=e.length
-c=A.N(q,a3)
-for(b="",a="",r=0;r<h;++r,a=a0)b+=a+A.N(i[r],a3)
+c=A.O(q,a3)
+for(b="",a="",r=0;r<h;++r,a=a0)b+=a+A.O(i[r],a3)
 if(f>0){b+=a+"["
-for(a="",r=0;r<f;++r,a=a0)b+=a+A.N(g[r],a3)
+for(a="",r=0;r<f;++r,a=a0)b+=a+A.O(g[r],a3)
 b+="]"}if(d>0){b+=a+"{"
 for(a="",r=0;r<d;r+=3,a=a0){b+=a
 if(e[r+1])b+="required "
-b+=A.N(e[r+2],a3)+" "+e[r]}b+="}"}if(a1!=null){a3.toString
+b+=A.O(e[r+2],a3)+" "+e[r]}b+="}"}if(a1!=null){a3.toString
 a3.length=a1}return p+"("+b+") => "+c},
-N(a,b){var t,s,r,q,p,o,n,m=a.w
+O(a,b){var t,s,r,q,p,o,n,m=a.w
 if(m===5)return"erased"
 if(m===2)return"dynamic"
 if(m===3)return"void"
 if(m===1)return"Never"
 if(m===4)return"any"
 if(m===6){t=a.x
-s=A.N(t,b)
+s=A.O(t,b)
 r=t.w
-return(r===11||r===12?"("+s+")":s)+"?"}if(m===7)return"FutureOr<"+A.N(a.x,b)+">"
-if(m===8){q=A.kz(a.x)
+return(r===11||r===12?"("+s+")":s)+"?"}if(m===7)return"FutureOr<"+A.O(a.x,b)+">"
+if(m===8){q=A.kA(a.x)
 p=a.y
-return p.length>0?q+("<"+A.fj(p,b)+">"):q}if(m===10)return A.kp(a,b)
+return p.length>0?q+("<"+A.fj(p,b)+">"):q}if(m===10)return A.kq(a,b)
 if(m===11)return A.eY(a,b,null)
 if(m===12)return A.eY(a.x,b,a.y)
 if(m===13){o=a.x
@@ -847,7 +847,7 @@ n=b.length
 o=n-1-o
 if(!(o>=0&&o<n))return A.c(b,o)
 return b[o]}return"?"},
-kz(a){var t=v.mangledGlobalNames[a]
+kA(a){var t=v.mangledGlobalNames[a]
 if(t!=null)return t
 return"minified:"+a},
 iI(a,b){var t=a.tR[b]
@@ -1150,7 +1150,7 @@ if(r!==8)throw A.d(A.bK("Indexed base must be an interface type"))
 t=b.y
 if(c<=t.length)return t[c-1]
 throw A.d(A.bK("Bad index "+c+" for "+b.j(0)))},
-kS(a,b,c){var t,s=b.d
+kT(a,b,c){var t,s=b.d
 if(s==null)s=b.d=new Map()
 t=s.get(c)
 if(t==null){t=A.B(a,b,null,c,null)
@@ -1265,7 +1265,7 @@ cl:function cl(a){this.a=a},
 cf:function cf(){},
 bA:function bA(a){this.a=a},
 i_(a,b){return new A.X(a.i("@<0>").V(b).i("X<1,2>"))},
-dI(a,b,c){return b.i("@<0>").V(c).i("dH<1,2>").a(A.kK(a,new A.X(b.i("@<0>").V(c).i("X<1,2>"))))},
+dI(a,b,c){return b.i("@<0>").V(c).i("dH<1,2>").a(A.kL(a,new A.X(b.i("@<0>").V(c).i("X<1,2>"))))},
 aL(a,b){return new A.X(a.i("@<0>").V(b).i("X<1,2>"))},
 i0(a){return new A.au(a.i("au<0>"))},
 cN(a){return new A.au(a.i("au<0>"))},
@@ -1283,12 +1283,12 @@ dL(a){var t,s
 if(A.e_(a))return"{...}"
 t=new A.aR("")
 try{s={}
-B.b.l($.O,a)
+B.b.l($.P,a)
 t.a+="{"
 s.a=!0
 a.W(0,new A.cP(s,t))
-t.a+="}"}finally{if(0>=$.O.length)return A.c($.O,-1)
-$.O.pop()}s=t.a
+t.a+="}"}finally{if(0>=$.P.length)return A.c($.P,-1)
+$.P.pop()}s=t.a
 return s.charCodeAt(0)==0?s:s},
 au:function au(a){var _=this
 _.a=0
@@ -1309,7 +1309,7 @@ aa:function aa(){},
 bz:function bz(){},
 en(a,b,c){return new A.be(a,b)},
 iW(a){return a.a3()},
-ir(a,b){return new A.d4(a,[],A.kG())},
+ir(a,b){return new A.d4(a,[],A.kH())},
 is(a,b,c){var t,s=new A.aR(""),r=A.ir(s,b)
 r.a4(a)
 t=s.a
@@ -1372,17 +1372,17 @@ eh(a,b){return new A.cG(a,b)},
 hV(a,b,c){var t,s
 if(A.e_(a)){if(b==="("&&c===")")return"(...)"
 return b+"..."+c}t=A.i([],u.s)
-B.b.l($.O,a)
-try{A.jv(a,t)}finally{if(0>=$.O.length)return A.c($.O,-1)
-$.O.pop()}s=A.ev(b,u.W.a(t),", ")+c
+B.b.l($.P,a)
+try{A.jv(a,t)}finally{if(0>=$.P.length)return A.c($.P,-1)
+$.P.pop()}s=A.ev(b,u.W.a(t),", ")+c
 return s.charCodeAt(0)==0?s:s},
 ej(a,b,c){var t,s
 if(A.e_(a))return b+"..."+c
 t=new A.aR(b)
-B.b.l($.O,a)
+B.b.l($.P,a)
 try{s=t
-s.a=A.ev(s.a,a,", ")}finally{if(0>=$.O.length)return A.c($.O,-1)
-$.O.pop()}t.a+=c
+s.a=A.ev(s.a,a,", ")}finally{if(0>=$.P.length)return A.c($.P,-1)
+$.P.pop()}t.a+=c
 s=t.a
 return s.charCodeAt(0)==0?s:s},
 jv(a,b){var t,s,r,q,p,o,n,m=a.gq(a),l=0,k=0
@@ -1498,7 +1498,7 @@ if(t.a!==1||!t.h(0,B.r))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 if(!s.h(0,B.h)||!s.h(0,B.e)||!s.h(0,B.i)||s.h(0,B.d))return!1
-r=A.P(a.b,a.a)
+r=A.K(a.b,a.a)
 if(r!==1)return!1
 return t.p(0,r)===B.S},
 fX(a){var t,s,r,q=a.c
@@ -1529,7 +1529,7 @@ t=!t.h(0,B.v)||t.M(0,new A.cq())}else t=!0
 if(t)return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
-return s.h(0,B.h)&&s.h(0,B.e)&&s.h(0,B.d)&&s.h(0,B.F)&&s.h(0,B.a1)},
+return s.h(0,B.h)&&s.h(0,B.e)&&s.h(0,B.d)&&s.h(0,B.F)&&s.h(0,B.a2)},
 fY(a){var t,s,r,q=a.c,p=q===B.x
 if(!p&&q!==B.G)return!1
 if(a.d.M(0,new A.cp(q)))return!1
@@ -1558,7 +1558,7 @@ s=a.b
 if(t===s)return!1
 r=a.d
 if(r.a!==1||!r.h(0,B.f))return!1
-if(A.P(s,t)!==2)return!1
+if(A.K(s,t)!==2)return!1
 t=a.e
 q=new A.b(t,A.a(t).i("b<2>"))
 p=q.h(0,B.e)||q.h(0,B.m)||q.h(0,B.Q)||q.h(0,B.J)
@@ -1573,7 +1573,7 @@ r=a.d
 if(r.a===1)r=!(r.h(0,B.z)||r.h(0,B.n))
 else r=!0
 if(r)return!1
-if(A.P(s,t)!==5)return!1
+if(A.K(s,t)!==5)return!1
 t=a.e
 q=new A.b(t,A.a(t).i("b<2>"))
 return q.h(0,B.h)&&q.h(0,B.m)&&q.h(0,B.d)&&q.h(0,B.i)},
@@ -1584,7 +1584,7 @@ h6(a,b){var t,s,r,q
 if(!b)return!1
 t=a.c
 s=t===B.ai
-if(!s&&t!==B.a3)return!1
+if(!s&&t!==B.a4)return!1
 r=a.e
 q=new A.b(r,A.a(r).i("b<2>"))
 return(s?q.h(0,B.Q):q.h(0,B.J))&&q.h(0,B.i)},
@@ -1603,30 +1603,30 @@ if(a.c!==B.p)return!1
 t=a.a
 s=a.b
 if(t===s)return!1
-r=A.fV(a.e.p(0,A.P(s,t)))
+r=A.fV(a.e.p(0,A.K(s,t)))
 for(t=a.d,t=A.a2(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){q=t.d
 if(q==null)q=s.a(q)
 if(q===r)continue
 if(q===B.r||q===B.B||q===B.o||q===B.t)return!0}return!1},
 fV(a){var t
 A:{if(B.S===a){t=B.r
-break A}if(B.a0===a){t=B.B
+break A}if(B.a1===a){t=B.B
 break A}if(B.K===a){t=B.o
 break A}if(B.aj===a){t=B.t
 break A}if(B.T===a){t=B.f
 break A}if(B.a7===a){t=B.n
 break A}if(B.R===a){t=B.l
-break A}if(B.a1===a){t=B.v
+break A}if(B.a2===a){t=B.v
 break A}if(B.aR===a){t=B.X
 break A}if(B.ar===a){t=B.X
 break A}if(B.a8===a){t=B.z
 break A}if(B.aq===a){t=B.af
 break A}t=null
 break A}return t},
-fT(a){var t=a.e.p(0,A.P(a.b,a.a))
+fT(a){var t=a.e.p(0,A.K(a.b,a.a))
 if(t==null)return!1
 return!(t===B.h||t===B.e||t===B.m||t===B.d||t===B.y||t===B.w||t===B.F||t===B.i||t===B.u||t===B.a9)},
-dy(a){var t=A.P(a.b,a.a)
+dy(a){var t=A.K(a.b,a.a)
 if(t===0)return 0
 if(t===3||t===4)return 1
 if(t===7)return 2
@@ -1688,8 +1688,8 @@ m.u(0,t,s)
 return s}r=A.hd(a,b,!1,d)
 q=A.ew(r,0,A.fk(c,"count",u.S),A.H(r).c)
 p=q.$ti
-o=p.i("M<G.E,I>")
-q=A.aj(new A.M(q,p.i("I(G.E)").a(new A.cu()),o),o.i("G.E"))
+o=p.i("N<G.E,I>")
+q=A.aj(new A.N(q,p.i("I(G.E)").a(new A.cu()),o),o.i("G.E"))
 q.$flags=1
 n=q
 m.u(0,t,n)
@@ -1786,6 +1786,7 @@ if(!a.h(0,B.r))if(!a.h(0,B.B))t=a.h(0,B.o)&&!A.ee(b)||a.h(0,B.t)
 return t},
 hg(a,b,c){var t=c.a
 if(A.hn(a,b)&&A.hk(t,b))return 8
+if(t===B.Z&&(b&16)!==0&&(b&8)!==0&&(b&2048)!==0)return 8
 if(!(t===B.p||t===B.C||t===B.D))return 0
 if(!((b&16)!==0&&(b&1024)!==0))return 0
 if((b&8)===0)return 0
@@ -1803,7 +1804,7 @@ return(b&128)===0},
 hj(a,b){switch(b.a){case 6:case 12:case 17:return a===2
 case 7:case 13:case 18:return a===5
 default:return!1}},
-hf(a,b,c,d){if(!(c===B.C||c===B.Z))return!1
+hf(a,b,c,d){if(!(c===B.C||c===B.a_))return!1
 if((d&128)===0&&a===10&&b.a===2&&b.h(0,B.f)&&b.h(0,B.l))return!1
 return b.h(0,B.l)||b.h(0,B.af)},
 hc(a,b,c,d){var t,s,r,q
@@ -1823,7 +1824,7 @@ hi(a,b,c,d){if(c!==B.p)return!1
 if(a!==2)return!1
 if(b.a!==2||!b.h(0,B.f)||!b.h(0,B.l))return!1
 return(d&1)!==0&&(d&4)!==0&&(d&16)!==0&&(d&128)!==0&&(d&512)!==0&&(d&1024)!==0},
-he(a,b,c,d){var t,s,r=c===B.a4
+he(a,b,c,d){var t,s,r=c===B.Z
 if(!r&&c!==B.p)return 0
 if(!b.h(0,B.f))return 0
 if(b.h(0,B.t))return 0
@@ -1880,7 +1881,7 @@ for(q=t.length,p=f0!=null,r=0;r<t.length;t.length===q||(0,A.V)(t),++r){o=t[r].a
 n=o.c
 m=o.a===o.b
 l=o.d
-k=A.kJ(l,A.ee(n))
+k=A.kK(l,A.ee(n))
 j=A.dy(o)
 i=n===B.P
 h=i||n===B.I
@@ -1918,9 +1919,9 @@ c2=A.h6(o,m)
 c3=!1
 if(m)if(n===B.x||n===B.G||n===B.E||n===B.Y){c3=k.a
 c3=c3[1]===0&&c3[2]===0}c4=A.h8(o,m)
-d=n===B.H||n===B.ai||n===B.a3||!d||n===B.D||n===B.am||n===B.aa||n===B.Z||n===B.a_
+d=n===B.H||n===B.ai||n===B.a4||!d||n===B.D||n===B.am||n===B.aa||n===B.a_||n===B.a0
 c5=A.e9(o,B.cg,B.r,B.S,B.d,B.p)
-A.e9(o,B.aV,B.B,B.a0,B.d,B.p)
+A.e9(o,B.aV,B.B,B.a1,B.d,B.p)
 c6=A.fX(o)
 c7=A.h3(o)
 l=l.a
@@ -1996,7 +1997,7 @@ n=s}}return n===-1?0:n},
 hp(a,b,c,d,e){var t,s,r,q=b.b-a.b
 for(t=$.fK(),s=0;s<21;++s){r=t[s].b.$5(a,b,c,d,e)
 if(r!=null&&r!==0)return new A.aO(r,!0)}if(Math.abs(q)>0.2)return new A.aO(q>0?1:-1,!1)
-for(t=$.fL(),s=0;s<35;++s){r=t[s].b.$5(a,b,c,d,e)
+for(t=$.fL(),s=0;s<36;++s){r=t[s].b.$5(a,b,c,d,e)
 if(r!=null&&r!==0)return new A.aO(r,!1)}return new A.aO(B.a.A(a.a.a,b.a.a),!1)},
 aO:function aO(a,b){this.a=a
 this.d=b},
@@ -2009,7 +2010,7 @@ _.b=b
 _.c=c
 _.d=d
 _.e=e},
-kX(a,b,c,d,e){var t,s,r,q,p,o=null
+kY(a,b,c,d,e){var t,s,r,q,p,o=null
 if(Math.abs(a.b-b.b)>0.15)return o
 if(c.xr!==d.xr)return o
 if(c.p4!==d.p4)return o
@@ -2030,7 +2031,7 @@ if(s.a===0)return a.c.b
 t=A.aj(s,A.a(s).c)
 B.b.S(t,new A.df())
 s=A.H(t)
-return a.c.b+"|"+new A.M(t,s.i("h(1)").a(new A.dg()),s.i("M<1,h>")).I(0,",")},
+return a.c.b+"|"+new A.N(t,s.i("h(1)").a(new A.dg()),s.i("N<1,h>")).I(0,",")},
 df:function df(){},
 dg:function dg(){},
 e(a,b){return new A.bi(a,b)},
@@ -2038,7 +2039,7 @@ jU(a,b,c,d,e){var t,s=null,r=a.a,q=A.fe(r),p=b.a,o=A.fe(p),n=A.fd(r),m=A.fd(p)
 if(!(q&&m))t=!(o&&n)
 else t=!1
 if(t)return s
-if(A.P(r.a,p.a)!==6)return s
+if(A.K(r.a,p.a)!==6)return s
 r=c.p1
 p=d.p1
 if(r===p)return s
@@ -2052,11 +2053,11 @@ fd(a){var t
 if(a.c===B.p){t=a.d
 t=t.a===2&&t.h(0,B.o)&&t.h(0,B.t)}else t=!1
 return t},
-kd(a,b,c,d,e){var t,s,r,q,p=c.w
+ke(a,b,c,d,e){var t,s,r,q,p=c.w
 if(p===d.w)return null
 t=p?b:a
 s=!(p?d:c).a
-r=s&&t.a.c===B.a3
+r=s&&t.a.c===B.a4
 q=s&&t.a.c===B.ap
 if(!r&&!q)return null
 if((p?a:b).b+1.3<t.b)return null
@@ -2086,7 +2087,7 @@ eZ(a,b){var t,s
 if(!b.y||b.a)return!1
 t=a.d
 if(t.a!==1||!t.h(0,B.v))return!1
-s=A.P(a.b,a.a)
+s=A.K(a.b,a.a)
 return s===(a.c===B.x?4:3)||s===7},
 j3(a,b){var t,s
 if(a.c!==B.H)return!1
@@ -2094,7 +2095,7 @@ t=a.e.p(0,8)
 if(t==null)return!1
 s=A.a5(A.aZ(a.a+8,A.aY(a,b),t,b))
 return s==="B#"||s==="Cb"||s==="E#"||s==="Fb"||B.c.h(s,"x")||B.c.h(s,"bb")},
-kn(a,b,c,d,e){var t=c.y1
+ko(a,b,c,d,e){var t=c.y1
 if(t===d.y1)return null
 return t?-1:1},
 jx(a,b,c,d,e){var t,s,r=c.b
@@ -2124,7 +2125,7 @@ if(!t.h(0,B.B))return!1
 if(t.M(0,new A.di()))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
-return s.h(0,B.h)&&s.h(0,B.a0)&&s.h(0,B.e)&&s.h(0,B.d)&&s.h(0,B.i)},
+return s.h(0,B.h)&&s.h(0,B.a1)&&s.h(0,B.e)&&s.h(0,B.d)&&s.h(0,B.i)},
 jH(a,b,c,d,e){var t,s=A.f0(a.a)
 if(s===A.f0(b.a))return null
 t=s?d:c
@@ -2150,7 +2151,7 @@ else s=r
 else s=r
 else s=!0}else s=!0
 return s},
-kj(a,b,c,d,e){var t,s,r=null,q=A.cm(a.a,c)
+kk(a,b,c,d,e){var t,s,r=null,q=A.cm(a.a,c)
 if(q===A.cm(b.a,d))return r
 t=q?b:a
 s=t.a
@@ -2164,7 +2165,7 @@ t=p?b:a
 s=p?d:c
 if(!s.a)return q
 r=t.a.c
-if(r!==B.Z&&r!==B.a_)return q
+if(r!==B.a_&&r!==B.a0)return q
 if(s.R8===0)return q
 if((p?a:b).b+0.55<t.b)return q
 return p?-1:1},
@@ -2197,7 +2198,7 @@ if(!r.ok)return q
 if(!r.p2)return q
 if(!s.x1)return q
 return p?-1:1},
-km(a,b,c,d,e){var t,s,r,q=null
+kn(a,b,c,d,e){var t,s,r,q=null
 if(!c.dx||!d.dx)return q
 if(c.a===d.a)return q
 t=c.fy
@@ -2207,14 +2208,14 @@ if(!s.fy||!r.fx)return q
 if(!s.go||!r.go)return q
 if(s.p2&&!s.id)return t?-1:1
 else return t?1:-1},
-kc(a,b,c,d,e){var t,s=null,r=A.cm(a.a,c)
+kd(a,b,c,d,e){var t,s=null,r=A.cm(a.a,c)
 if(r===A.cm(b.a,d))return s
 t=r?d:c
 if(!t.dy)return s
 if(!t.ok)return s
 if(!t.go)return s
 return r?-1:1},
-kh(a,b,c,d,e){var t,s,r,q=null,p=A.fb(a.a)
+ki(a,b,c,d,e){var t,s,r,q=null,p=A.fb(a.a)
 if(p===A.fb(b.a))return q
 t=(p?b:a).a
 s=!1
@@ -2227,11 +2228,11 @@ return p?-1:1},
 fb(a){var t,s=!1
 if(a.c===B.D){t=a.d
 if(t.a===2)s=(t.h(0,B.f)||t.h(0,B.r))&&t.h(0,B.o)}return s},
-kb(a,b,c,d,e){var t,s,r,q,p,o=c.CW
+kc(a,b,c,d,e){var t,s,r,q,p,o=c.CW
 if(o===d.CW)return null
 t=o?a.a:b.a
 if((o?c:d).rx.a[1]>0){s=!1
-if(t.b===t.a)if(t.c===B.a3){s=t.d
+if(t.b===t.a)if(t.c===B.a4){s=t.d
 s=s.a===1&&s.h(0,B.r)}s=!s}else s=!1
 if(s)return null
 r=o?d:c
@@ -2255,7 +2256,7 @@ t=a.d
 if(!t.h(0,B.v)||!t.h(0,B.o))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
-return s.h(0,B.h)&&s.h(0,B.e)&&s.h(0,B.d)&&s.h(0,B.F)&&s.h(0,B.a1)&&s.h(0,B.K)},
+return s.h(0,B.h)&&s.h(0,B.e)&&s.h(0,B.d)&&s.h(0,B.F)&&s.h(0,B.a2)&&s.h(0,B.K)},
 jj(a){var t,s
 if(a.c!==B.aa)return!1
 t=a.d
@@ -2274,7 +2275,7 @@ if(!b.go)return!1
 t=a.d
 if(!t.h(0,B.f))return!1
 if(!t.h(0,B.o))return!1
-s=A.P(a.b,a.a)
+s=A.K(a.b,a.a)
 return s===0||s===4||s===7||s===10},
 jO(a,b,c,d,e){var t,s,r=A.f5(a.a)
 if(r===A.f5(b.a))return null
@@ -2288,7 +2289,7 @@ t=a.d
 if(t.a!==2||!t.h(0,B.B)||!t.h(0,B.l))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
-return s.h(0,B.h)&&s.h(0,B.a0)&&s.h(0,B.e)&&s.h(0,B.d)&&s.h(0,B.R)&&s.h(0,B.i)},
+return s.h(0,B.h)&&s.h(0,B.a1)&&s.h(0,B.e)&&s.h(0,B.d)&&s.h(0,B.R)&&s.h(0,B.i)},
 jb(a,b){var t,s
 if(a.c!==B.E||!b.p3)return!1
 t=a.d
@@ -2308,7 +2309,7 @@ t=a.d
 if(t.a!==3||!t.h(0,B.B)||!t.h(0,B.o)||!t.h(0,B.l))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
-return s.h(0,B.h)&&s.h(0,B.a0)&&s.h(0,B.e)&&s.h(0,B.K)&&s.h(0,B.d)&&s.h(0,B.R)&&s.h(0,B.i)},
+return s.h(0,B.h)&&s.h(0,B.a1)&&s.h(0,B.e)&&s.h(0,B.K)&&s.h(0,B.d)&&s.h(0,B.R)&&s.h(0,B.i)},
 ja(a,b){var t,s
 if(a.c!==B.O||!b.p3)return!1
 t=a.d
@@ -2335,7 +2336,7 @@ t=a.d
 if(t.a!==2||!t.h(0,B.v)||!t.h(0,B.z))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
-return s.h(0,B.h)&&s.h(0,B.a1)&&s.h(0,B.m)&&s.h(0,B.a8)&&s.h(0,B.d)&&s.h(0,B.F)},
+return s.h(0,B.h)&&s.h(0,B.a2)&&s.h(0,B.m)&&s.h(0,B.a8)&&s.h(0,B.d)&&s.h(0,B.F)},
 jD(a,b,c,d,e){var t,s,r,q,p=null,o=A.dV(a.a)
 if(o===A.dV(b.a))return p
 t=o?b:a
@@ -2397,7 +2398,7 @@ if(s.dy)return p
 if(!t.x1)return p
 if(r.b+0.25<q.b)return p
 return o?-1:1},
-k8(a,b,c,d,e){var t,s,r,q=null,p=c.at
+k9(a,b,c,d,e){var t,s,r,q=null,p=c.at
 if(p===d.at)return q
 t=p?d:c
 s=p?a:b
@@ -2406,7 +2407,7 @@ if(!t.ok)return q
 if(t.R8===0&&!t.db)return q
 if(s.b+0.55<r.b)return q
 return p?-1:1},
-k6(a,b,c,d,e){var t,s,r=A.f2(a.a)
+k7(a,b,c,d,e){var t,s,r=A.f2(a.a)
 if(r===A.f2(b.a))return null
 t=r?a:b
 s=r?b:a
@@ -2423,16 +2424,16 @@ if(r!==B.f&&r!==B.t)return!1}t=a.e
 q=new A.b(t,A.a(t).i("b<2>"))
 return q.h(0,B.h)&&q.h(0,B.m)&&q.h(0,B.d)&&q.h(0,B.u)&&q.h(0,B.T)},
 jp(a,b){var t,s,r,q
-if(a.c!==B.a_)return!1
+if(a.c!==B.a0)return!1
 t=a.d
 if(!t.h(0,B.l))return!1
 for(t=A.a2(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){r=t.d
 if(r==null)r=s.a(r)
-if(r!==B.l&&r!==B.n)return!1}if(A.P(b.a,a.a)!==9)return!1
+if(r!==B.l&&r!==B.n)return!1}if(A.K(b.a,a.a)!==9)return!1
 t=a.e
 q=new A.b(t,A.a(t).i("b<2>"))
 return q.h(0,B.h)&&q.h(0,B.e)&&q.h(0,B.w)&&q.h(0,B.u)&&q.h(0,B.R)},
-k5(a,b,c,d,e){var t,s,r,q=null,p=c.ax
+k6(a,b,c,d,e){var t,s,r,q=null,p=c.ax
 if(p===d.ax)return q
 t=p?d:c
 s=p?a:b
@@ -2441,7 +2442,7 @@ if(!t.ok)return q
 if(r.a.c!==B.H)return q
 if(s.b+0.55<r.b)return q
 return p?-1:1},
-ka(a,b,c,d,e){var t,s,r,q,p,o=null
+kb(a,b,c,d,e){var t,s,r,q,p,o=null
 if(!c.dy||!d.dy)return o
 t=c.a
 if(t===d.a)return o
@@ -2484,7 +2485,7 @@ if(!t.ay)return p
 if(!s.ch)return p
 if(r.b+0.35<q.b)return p
 return o?-1:1},
-k9(a,b,c,d,e){var t,s,r,q=c.cx
+ka(a,b,c,d,e){var t,s,r,q=c.cx
 if(q===d.cx)return null
 t=q?d:c
 if(!t.f||!t.ok)return null
@@ -2504,7 +2505,7 @@ t=q.rx.a
 if(t[1]>0)return p
 if(t[2]>0)return p
 return s?-1:1},
-ki(a,b,c,d,e){var t,s,r,q,p=null,o=!c.c&&!c.f&&c.x2
+kj(a,b,c,d,e){var t,s,r,q,p=null,o=!c.c&&!c.f&&c.x2
 if(o===(!d.c&&!d.f&&d.x2))return p
 t=o?d:c
 if(!t.c)return p
@@ -2549,10 +2550,19 @@ return s?-1:1},
 k_(a,b,c,d,e){var t=B.a.A(c.R8,d.R8)
 if(t===0)return null
 return t},
+k4(a,b,c,d,e){var t,s=null,r=a.b>b.b,q=r?a:b,p=r?b:a,o=r?c:d,n=r?d:c
+if(q.b===p.b)return s
+if(!o.c||!n.c)return s
+if(!o.ok||!n.ok)return s
+if(o.p2)return s
+if(!n.p2)return s
+t=q.a
+if(A.K(t.b,t.a)!==11)return s
+return r?-1:1},
 jV(a,b,c,d,e){var t=e.P(a.a),s=e.P(b.a)!=null
 if(t!=null===s)return null
 return s?1:-1},
-ke(a,b,c,d,e){var t,s,r,q,p,o,n,m,l,k=a.a.c===B.O
+kf(a,b,c,d,e){var t,s,r,q,p,o,n,m,l,k=a.a.c===B.O
 if(k===(b.a.c===B.O))return null
 t=k?a:b
 s=k?c:d
@@ -2569,7 +2579,7 @@ if(p===1)l=(o.h(0,B.z)||o.h(0,B.n))&&n.a===1&&n.h(0,B.v)
 else l=!1
 if(!m&&!l)return null
 return k?-1:1},
-kf(a,b,c,d,e){var t,s=A.fc(a.a)
+kg(a,b,c,d,e){var t,s=A.fc(a.a)
 if(s===A.fc(b.a))return null
 t=s?a:b
 if(!A.jd((s?b:a).a,t.a))return null
@@ -2582,14 +2592,14 @@ else t=!0
 if(t)return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
-if(s.h(0,B.h))t=(s.h(0,B.a1)||s.h(0,B.T))&&s.h(0,B.m)&&s.h(0,B.d)&&s.h(0,B.F)
+if(s.h(0,B.h))t=(s.h(0,B.a2)||s.h(0,B.T))&&s.h(0,B.m)&&s.h(0,B.d)&&s.h(0,B.F)
 else t=!1
 return t},
 jd(a,b){var t,s
 if(a.c!==B.I)return!1
 t=b.a
 if(a.b!==t)return!1
-if(A.P(a.a,t)!==9)return!1
+if(A.K(a.a,t)!==9)return!1
 t=a.d
 if(t.a===1)t=!t.h(0,B.n)&&!t.h(0,B.z)
 else t=!0
@@ -2599,18 +2609,18 @@ s=new A.b(t,A.a(t).i("b<2>"))
 t=!1
 if(s.h(0,B.h))if(s.h(0,B.m))if(s.h(0,B.y))if(s.h(0,B.i))t=s.h(0,B.a7)||s.h(0,B.a8)
 return t},
-kl(a,b,c,d,e){var t,s=e.P(a.a),r=e.P(b.a)
+km(a,b,c,d,e){var t,s=e.P(a.a),r=e.P(b.a)
 if(s==null||r==null)return null
 t=r===B.W
 if(s===B.W===t)return null
 return t?1:-1},
-kk(a,b,c,d,e){var t,s=a.a,r=e.P(s),q=e.P(b.a)
+kl(a,b,c,d,e){var t,s=a.a,r=e.P(s),q=e.P(b.a)
 if(r==null||q==null)return null
 if(s.b!==e.a.e)return null
 t=q===B.W
 if(r===B.W===t)return null
 return t?1:-1},
-k7(a,b,c,d,e){var t,s,r,q,p=d.rx.a,o=c.rx.a,n=B.a.A(p[2],o[2])
+k8(a,b,c,d,e){var t,s,r,q,p=d.rx.a,o=c.rx.a,n=B.a.A(p[2],o[2])
 if(n!==0){p=n<0
 t=p?c:d
 s=p?d:c
@@ -2620,7 +2630,7 @@ if(r!==0)return r
 q=B.a.A(o[3],p[3])
 if(q!==0)return q
 return null},
-k4(a,b,c,d,e){var t,s,r=A.f6(a.a)
+k5(a,b,c,d,e){var t,s,r=A.f6(a.a)
 if(r===A.f6(b.a))return null
 t=r?a:b
 s=(r?b:a).a
@@ -2628,34 +2638,34 @@ if(t.a.a!==s.a)return null
 if(!A.ji(s))return null
 return r?-1:1},
 f6(a){var t,s
-if(a.c!==B.a4)return!1
+if(a.c!==B.Z)return!1
 t=a.d
 if(t.a!==2||!t.h(0,B.f)||!t.h(0,B.o))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.h)&&s.h(0,B.e)&&s.h(0,B.u)&&s.h(0,B.T)&&s.h(0,B.K)&&!s.h(0,B.d)},
 ji(a){var t,s
-if(a.c!==B.Z)return!1
+if(a.c!==B.a_)return!1
 t=a.d
 if(t.a!==1||!t.h(0,B.f))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.h)&&s.h(0,B.e)&&s.h(0,B.y)&&s.h(0,B.u)&&s.h(0,B.T)},
-kg(a,b,c,d,e){var t=d.a
+kh(a,b,c,d,e){var t=d.a
 if(c.a===t)return null
 return t?1:-1},
 jT(a,b,c,d,e){var t=B.a.A(c.p1,d.p1)
 if(t===0)return null
 return t},
 jA(a,b,c,d,e){var t,s,r=a.a,q=b.a
-if(!(r.c===B.C&&q.c===B.C&&r.d.a===0&&q.d.a===0&&A.P(r.a,q.a)===6))return null
+if(!(r.c===B.C&&q.c===B.C&&r.d.a===0&&q.d.a===0&&A.K(r.a,q.a)===6))return null
 if(Math.abs(a.b-b.b)>0.05)return null
 t=A.eU(r,e)
 s=A.eU(q,e)
 if(t===s)return null
 return t<s?-1:1},
 eU(a,b){var t,s,r,q=A.aY(a,b),p=A.fi(q)
-for(t=a.e,t=new A.L(t,A.a(t).i("L<1,2>")).gq(0),s=a.a;t.k();){r=t.d
+for(t=a.e,t=new A.M(t,A.a(t).i("M<1,2>")).gq(0),s=a.a;t.k();){r=t.d
 p+=A.fi(A.aZ(B.a.m(s+r.a,12),q,r.b,b))}return p},
 fi(a){var t,s,r,q,p,o,n=A.a5(a)
 if(n.length===0)return 1000
@@ -2727,7 +2737,7 @@ hw(a){switch(a.a){case 1:case 4:case 7:return!0
 default:return!1}},
 hv(a){switch(a.a){case 0:case 2:case 5:case 6:return!0
 default:return!1}},
-kJ(a,b){var t,s,r,q,p,o
+kK(a,b){var t,s,r,q,p,o
 for(t=A.a2(a,a.r,A.a(a).c),s=t.$ti.c,r=0,q=0,p=0;t.k();){o=t.d
 if(o==null)o=s.a(o)
 if(A.bL(o))++p
@@ -2755,12 +2765,12 @@ r=(r^J.t(q==null?s.a(q):q))>>>0}return r},
 hx(a,b,c,d){var t,s,r
 if(a===b)return!0
 if(a.a!==b.a)return!1
-for(t=new A.L(a,A.a(a).i("L<1,2>")).gq(0);t.k();){s=t.d
+for(t=new A.M(a,A.a(a).i("M<1,2>")).gq(0);t.k();){s=t.d
 r=s.a
 if(!b.U(r))return!1
 if(!J.a_(b.p(0,r),s.b))return!1}return!0},
 hy(a,b,c){var t,s,r
-for(t=new A.L(a,A.a(a).i("L<1,2>")).gq(0),s=0;t.k();){r=t.d
+for(t=new A.M(a,A.a(a).i("M<1,2>")).gq(0),s=0;t.k();){r=t.d
 s^=A.aq(r.a,r.b,B.k,B.k,B.k,B.k)}return s},
 Q(a){switch(a.a){case 11:case 12:case 13:case 14:case 15:case 16:case 17:case 18:case 19:case 20:case 21:case 22:case 23:case 24:case 25:return B.A
 default:return B.bb}},
@@ -2792,7 +2802,7 @@ break A}if(B.J===a){t=4
 break A}if(B.y===a||B.d===a||B.w===a){t=5
 break A}if(B.F===a){t=6
 break A}if(B.a9===a||B.i===a||B.u===a){t=7
-break A}if(B.S===a||B.T===a||B.a0===a||B.a1===a||B.aR===a){t=9
+break A}if(B.S===a||B.T===a||B.a1===a||B.a2===a||B.aR===a){t=9
 break A}if(B.a7===a||B.K===a||B.a8===a){t=11
 break A}if(B.aj===a||B.R===a||B.aq===a){t=13
 break A}t=null}return t},
@@ -2972,7 +2982,7 @@ switch((p==null?q.a(p):p).a){case 0:case 11:s.$2(1,B.S)
 break
 case 1:s.$2(2,B.T)
 break
-case 2:s.$2(3,B.a0)
+case 2:s.$2(3,B.a1)
 break
 case 3:s.$2(3,B.ar)
 break
@@ -2984,7 +2994,7 @@ case 6:s.$2(8,B.aj)
 break
 case 7:s.$2(9,B.R)
 break
-case 8:s.$2(2,B.a1)
+case 8:s.$2(2,B.a2)
 break
 case 9:s.$2(5,B.a8)
 break
@@ -3014,7 +3024,7 @@ aY(a,b){var t,s,r,q,p,o,n,m,l=a.a,k=A.aX(l,b),j=A.eS(A.dG(b).a,b.a.d)
 if(new A.b(j,A.a(j).i("b<2>")).h(0,A.a5(k)))return k
 t=A.iU(l)
 for(l=t.length,s=null,r=0;r<t.length;t.length===l||(0,A.V)(t),++r){q=t[r]
-p=A.kr(a,q,k,b)
+p=A.ks(a,q,k,b)
 o=new A.d9(q,p)
 n=!0
 if(s!=null){m=s.b
@@ -3022,7 +3032,7 @@ if(p>=m)n=p===m&&q===k}if(n)s=o}l=s==null?null:s.a
 return l==null?k:l},
 aX(a,b){var t=B.a.m(a,12),s=A.dG(b).a,r=b.a.d,q=A.eS(s,r),p=q.p(0,t)
 if(p!=null)return p
-return A.kw(t,q,s,r)},
+return A.kx(t,q,s,r)},
 eN(a){var t,s,r,q=A.aL(u.N,u.S)
 for(t=0;t<7;++t)q.u(0,B.N[t],0)
 if(a>0)for(s=0;s<a;++s){if(!(s<7))return A.c(B.aT,s)
@@ -3037,7 +3047,7 @@ p.toString
 o=l.p(0,q)
 o.toString
 s.u(0,B.a.m(p+o,12),q+A.dd(o))}return s},
-kw(a,b,c,d){var t,s,r,q,p,o,n,m,l,k,j,i=A.eN(c),h=A.a(b).i("b<2>"),g=new A.dp(A.dJ(new A.b(b,h),h.i("f.E")))
+kx(a,b,c,d){var t,s,r,q,p,o,n,m,l,k,j,i=A.eN(c),h=A.a(b).i("b<2>"),g=new A.dp(A.dJ(new A.b(b,h),h.i("f.E")))
 for(h=c<0,t=c>0,s=null,r=0;r<7;++r){q=B.N[r]
 p=i.p(0,q)
 p.toString
@@ -3073,9 +3083,9 @@ q=B.a.m(p-r,12)
 if(q>6)q-=12
 if(q<-1||q>1)continue
 B.b.l(o,s+A.dd(q))}return o},
-kr(a,b,c,d){var t,s,r,q=b!==c?3:0
+ks(a,b,c,d){var t,s,r,q=b!==c?3:0
 q+=A.fg(b)
-for(t=a.e,t=new A.L(t,A.a(t).i("L<1,2>")).gq(0),s=a.a;t.k();){r=t.d
+for(t=a.e,t=new A.M(t,A.a(t).i("M<1,2>")).gq(0),s=a.a;t.k();){r=t.d
 q+=A.fg(A.aZ(B.a.m(s+r.a,12),b,r.b,d))}return q},
 fg(a){var t,s,r,q,p,o,n=A.a5(a)
 if(n.length===0)return 1000
@@ -3107,7 +3117,7 @@ r=B.a.m(q-p,12)
 return A.cx(s)===r},
 ht(a){var t,s=a.b,r=a.a
 if(s===r)return!1
-t=a.e.p(0,A.P(s,r))
+t=a.e.p(0,A.K(s,r))
 if(t==null)return!1
 return t===B.e||t===B.m||t===B.d||t===B.y||t===B.w||t===B.F||t===B.i||t===B.u||t===B.a9},
 eb(a){var t,s,r,q,p
@@ -3135,13 +3145,13 @@ return t},
 iZ(a,b,c){var t=A.eT(a,b,c)
 if(t.length===0)return""
 return" with "+A.iY(t)},
-ko(a,b){var t,s,r=A.ed(b,B.al),q=A.dT(a,b)
+kp(a,b){var t,s,r=A.ed(b,B.al),q=A.dT(a,b)
 if(q==null)return r
 A:{if(B.f===q){t="ninth"
 break A}if(B.n===q){t="eleventh"
 break A}if(B.l===q){t="thirteenth"
 break A}t=A.dz(q)
-break A}s=A.kq(r,t)
+break A}s=A.kr(r,t)
 return s===r?r:s},
 dT(a,b){if(A.Q(b)!==B.A||b===B.P)return null
 if(a.h(0,B.l))return B.l
@@ -3153,7 +3163,7 @@ case B.n:return a===B.f||a===B.n
 case B.l:return a===B.f||a===B.n||a===B.l
 case B.v:return a===B.v
 default:return!1}},
-kq(a,b){if(B.c.h(a,"seventh"))return A.lV(a,"seventh",b,0)
+kr(a,b){if(B.c.h(a,"seventh"))return A.lX(a,"seventh",b,0)
 return a},
 ff(a,b,c){var t
 switch(b.a){case 0:t=new A.a3(c).J(a)
@@ -3192,7 +3202,7 @@ if(k){if(i===B.f||i===B.n||i===B.z)continue}else if(l)if(i===B.f)continue
 B.b.l(o,A.hC(i,a2))}h=A.dA(a2,c)
 if(o.length===0){if(h==null)return b
 return a2===B.ah||a2===B.I?b+"("+h+")":b+h}m=u.Y
-g=A.aj(new A.M(o,u.q.a(new A.cA()),m),m.i("G.E"))
+g=A.aj(new A.N(o,u.q.a(new A.cA()),m),m.i("G.E"))
 f=A.hE(o,a1,a2)
 if(h==null){if(f)m=b+"("+B.b.I(g,a1===B.ag?"":",")+")"
 else m=b+B.b.aA(g)
@@ -3376,16 +3386,16 @@ break
 case 2:t="unlikely"
 break
 default:t=null}return t},
-kP(b9,c0,c1){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8=null
+kQ(b9,c0,c1){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8=null
 if(b9.length>512)return new A.ae(!1,B.M,"",A.ft(A.fr(c0)),B.ac,B.M,B.c0)
 t=A.fr(c0)
 s=A.dG(t)
 r=A.ft(t)
-q=A.lR(b9)
+q=A.lT(b9)
 p=q.length
 if(p===0)return new A.ae(!1,B.M,"",r,B.ac,B.M,B.bX)
 if(p>128)return new A.ae(!1,B.M,"",r,B.ac,B.M,B.bW)
-o=A.kV(q)
+o=A.kW(q)
 p=o.b
 if(p.length===0){p=A.i([],u.s)
 n=o.e
@@ -3402,7 +3412,7 @@ i=A.fh(p)
 h=l.length
 p=h!==0?h:p.length
 i=(i&j)>>>0===0?1:0
-g=A.kQ(o,t)
+g=A.kR(o,t)
 f=o.c.p(0,k)
 h=f!=null?A.a5(f):A.aX(k,t)
 e=new A.a3(B.V).J(h)
@@ -3437,16 +3447,16 @@ b0=b1==null?b0:b0+" / "+b1
 b2=A.aY(p,t)
 a4=A.ff(b2,B.aO,B.V)
 b3=A.eb(p)
-a6=A.ko(b3,h)
+a6=A.kp(b3,h)
 b4=A.iZ(b3,A.dT(b3,h),A.dA(h,B.al))
 b5=A.eT(b3,A.dT(b3,h),A.dA(h,B.al)).length
 b6=a4+" "+a6+b4
 if(i){a5=A.ff(A.aZ(m,b2,p.e.p(0,B.a.m(m-j,12)),t),B.aO,B.V)
 if(a5!==a4){b7=A.ht(p)?"slash":"over"
 b6=b6+(b5>=2?",":"")+" "+b7+" "+a5}}m=a2.b
-B.b.l(a0,new A.bM(a1,b0,B.c.G(b6),A.kv(p,t),A.ku(p,o,t),m,m-b,a3))}return new A.ae(!0,g,e,r,a0,n,B.M)},
-lR(a){var t=B.c.aI(a,A.er("[\\s,-]+")),s=A.H(t),r=s.i("M<1,h>")
-r=new A.M(t,s.i("h(1)").a(new A.dt()),r).aL(0,r.i("D(G.E)").a(new A.du()))
+B.b.l(a0,new A.bM(a1,b0,B.c.G(b6),A.kw(p,t),A.kv(p,o,t),m,m-b,a3))}return new A.ae(!0,g,e,r,a0,n,B.M)},
+lT(a){var t=B.c.aI(a,A.er("[\\s,-]+")),s=A.H(t),r=s.i("N<1,h>")
+r=new A.N(t,s.i("h(1)").a(new A.dt()),r).aL(0,r.i("D(G.E)").a(new A.du()))
 t=A.aj(r,r.$ti.i("f.E"))
 return t},
 fr(a){var t,s,r,q,p,o,n,m,l,k,j,i,h,g=B.c.G(a)
@@ -3469,7 +3479,7 @@ break}++k}}s=null
 try{i=A.io(A.a5(t))
 s=i==null?B.ae:i}catch(h){if(A.e1(h) instanceof A.W)s=B.ae
 else throw h}return new A.j(s,m)},
-kV(a){var t,s,r,q,p,o,n=u.t,m=A.i([],n),l=A.i([],n),k=A.aL(u.S,u.N),j=A.i([],u.k),i=A.i([],u.s)
+kW(a){var t,s,r,q,p,o,n=u.t,m=A.i([],n),l=A.i([],n),k=A.aL(u.S,u.N),j=A.i([],u.k),i=A.i([],u.s)
 for(n=a.length,r=0;r<a.length;a.length===n||(0,A.V)(a),++r){t=B.c.G(a[r])
 if(J.bF(t)===0)continue
 q=A.i5(t,null)
@@ -3478,25 +3488,25 @@ continue}B.b.l(m,q)
 p=B.a.m(q,12)
 J.b1(l,p)
 J.b1(j,new A.aU(q,null,p))
-continue}try{s=A.kW(t)
+continue}try{s=A.kX(t)
 J.b1(l,s)
 k.bd(s,new A.ds(t))
 J.b1(j,new A.aU(null,t,s))}catch(o){if(A.e1(o) instanceof A.W)J.b1(i,t)
 else throw o}}return new A.cR(m,l,k,j,i)},
-kQ(a,b){var t,s,r,q,p,o=A.cN(u.S),n=A.i([],u.s)
+kR(a,b){var t,s,r,q,p,o=A.cN(u.S),n=A.i([],u.s)
 for(t=a.d,s=t.length,r=0;r<t.length;t.length===s||(0,A.V)(t),++r){q=t[r]
 p=q.a
 if(p==null||o.l(0,p)){p=q.b
 p=p!=null?A.a5(p):A.aX(q.c,b)
 n.push(new A.a3(B.V).J(p))}}return n},
-kv(a,b){var t,s,r,q,p,o,n=A.aY(a,b),m=A.aL(u.S,u.u)
+kw(a,b){var t,s,r,q,p,o,n=A.aY(a,b),m=A.aL(u.S,u.u)
 m.u(0,0,B.h)
 m.T(0,a.e)
 t=A.hL(new A.a7(m,m.$ti.i("a7<1>")),a,m)
 s=A.i([],u.s)
 for(r=t.length,q=a.a,p=0;p<r;++p){o=t[p]
 s.push(new A.a3(B.V).J(A.aZ(B.a.m(q+o,12),n,m.p(0,o),b)))}return B.b.I(s," ")},
-ku(a,b,c){var t,s,r,q,p,o=a.e,n=u.S,m=new A.a7(o,A.a(o).i("a7<1>")).b6(0,B.a.L(1,a.a),new A.dn(a),n),l=A.cN(n)
+kv(a,b,c){var t,s,r,q,p,o=a.e,n=u.S,m=new A.a7(o,A.a(o).i("a7<1>")).b6(0,B.a.L(1,a.a),new A.dn(a),n),l=A.cN(n)
 n=A.i([],u.s)
 for(o=b.d,t=o.length,s=0;s<o.length;o.length===t||(0,A.V)(o),++s){r=o[s]
 q=r.c
@@ -3506,7 +3516,7 @@ n.push(new A.a3(B.V).J(q))}}return B.b.I(n," ")},
 fh(a){var t,s,r
 for(t=a.length,s=0,r=0;r<t;++r)s=(s|B.a.R(1,B.a.m(a[r],12)))>>>0
 return s},
-eX(a){var t=A.ew(a,0,A.fk(5,"count",u.S),A.H(a).c),s=t.$ti,r=new A.M(t,s.i("h(G.E)").a(new A.dh()),s.i("M<G.E,h>")).I(0,", "),q=a.length-5
+eX(a){var t=A.ew(a,0,A.fk(5,"count",u.S),A.H(a).c),s=t.$ti,r=new A.N(t,s.i("h(G.E)").a(new A.dh()),s.i("N<G.E,h>")).I(0,", "),q=a.length-5
 return q>0?r+", and "+q+" more":r},
 b3:function b3(a,b){this.a=a
 this.b=b},
@@ -3539,14 +3549,14 @@ _.e=e},
 ds:function ds(a){this.a=a},
 dn:function dn(a){this.a=a},
 dh:function dh(){},
-kT(){var t,s=v.G,r=new A.dr()
+kU(){var t,s=v.G,r=new A.dr()
 if(typeof r=="function")A.b_(A.dx("Attempting to rewrap a JS function."))
 t=function(a,b){return function(c,d,e){return a(b,c,d,e,arguments.length)}}(A.iT,r)
 t[$.e2()]=r
 s.whatchordIdentify=t
 s.whatchordReady=!0},
 dr:function dr(){},
-lX(a){throw A.F(new A.c4("Field '"+a+"' has been assigned during initialization."),new Error())},
+lZ(a){throw A.F(new A.c4("Field '"+a+"' has been assigned during initialization."),new Error())},
 iT(a,b,c,d,e){u.Z.a(a)
 A.T(e)
 if(e>=3)return a.$3(b,c,d)
@@ -3559,7 +3569,7 @@ t=a.b
 s=a.a
 if(t===s)return!1
 r=a.e
-q=r.p(0,A.P(t,s))
+q=r.p(0,A.K(t,s))
 if(q==null||A.ez(q))return!1
 t=A.a(r).i("b<2>")
 p=A.dJ(new A.b(r,t),t.i("f.E"))
@@ -3581,7 +3591,7 @@ if(j==null||j<=k)return!1}t=i[1]
 i=i[0]
 return t-i>=3},
 ip(a){var t,s,r,q=A.cN(u.S)
-for(t=a.e,t=new A.L(t,A.a(t).i("L<1,2>")).gq(0),s=a.a;t.k();){r=t.d
+for(t=a.e,t=new A.M(t,A.a(t).i("M<1,2>")).gq(0),s=a.a;t.k();){r=t.d
 if(A.ez(r.b))q.l(0,B.a.m(s+r.a,12))}return q},
 ez(a){var t
 A:{t=B.h===a||B.Q===a||B.J===a||B.m===a||B.e===a||B.y===a||B.d===a||B.w===a||B.F===a||B.a9===a||B.i===a||B.u===a
@@ -3610,9 +3620,9 @@ break A}if(0===q)break A
 if(1===q){n="#"
 break A}if(2===q){n="x"
 break A}break A}return t+n},
-P(a,b){var t=B.a.m(a-b,12)
+K(a,b){var t=B.a.m(a-b,12)
 return t},
-kW(a){var t,s,r,q,p,o,n,m=A.a5(a)
+kX(a){var t,s,r,q,p,o,n,m=A.a5(a)
 if(0>=m.length)return A.c(m,0)
 t=m[0]
 A:{if("C"===t){s=0
@@ -3652,7 +3662,7 @@ k=A.ie(q)
 if((p&k)!==k)return j
 if(!A.i9(a,i,p&l,f))return j
 if((p&~(l|k))!==0)return j
-A.lQ(h.bf(f),t)
+A.lS(h.bf(f),t)
 A.il(h,f)
 A.ih(h,f)
 return new A.cW(h,f)},
@@ -3713,28 +3723,28 @@ if(!A.et(a,q,d))return!1}return!0},
 ia(a,b){var t
 switch(a.a){case 0:switch(b.a){case 0:t=B.ad
 break
-case 1:t=B.a2
+case 1:t=B.a3
 break
-case 2:t=B.a2
+case 2:t=B.a3
 break
 case 3:t=B.ad
 break
 case 4:t=B.aW
 break
-case 5:t=B.a2
+case 5:t=B.a3
 break
 case 6:t=B.aA
 break
 default:t=null}return t
-case 1:switch(b.a){case 0:t=B.a2
+case 1:switch(b.a){case 0:t=B.a3
 break
 case 1:t=B.aA
 break
 case 2:t=B.ad
 break
-case 3:t=B.a2
+case 3:t=B.a3
 break
-case 4:t=B.a2
+case 4:t=B.a3
 break
 case 5:t=B.ad
 break
@@ -3747,7 +3757,7 @@ case 1:t=B.aA
 break
 case 2:t=B.ce
 break
-case 3:t=B.a2
+case 3:t=B.a3
 break
 case 4:t=B.cd
 break
@@ -3802,14 +3812,14 @@ break
 case 6:t="leading tone"
 break
 default:t=null}return t},
-lQ(a,b){var t
+lS(a,b){var t
 A:{if(B.p===b){t=a+"7"
 break A}if(B.C===b){t=a+"7b5"
 break A}if(B.D===b){t=a+"7#5"
 break A}if(B.ab===b){t=a+"#5"
-break A}if(B.a4===b){t=a+"maj7"
-break A}if(B.Z===b){t=a+"maj7b5"
-break A}if(B.a_===b){t=a+"maj7#5"
+break A}if(B.Z===b){t=a+"maj7"
+break A}if(B.a_===b){t=a+"maj7b5"
+break A}if(B.a0===b){t=a+"maj7#5"
 break A}if(B.O===b){t=a+"7"
 break A}if(B.H===b){t=a+"7#5"
 break A}if(B.U===b){t=a+"(maj7)"
@@ -3907,7 +3917,7 @@ o=b.$2(s,r)
 if(typeof o!=="number")return o.bm()
 if(o>0){a[0]=r
 a[1]=s}return}q=0
-if(o.c.b(null))for(p=0;p<a.length;++p)if(a[p]===void 0){a[p]=null;++q}a.sort(A.kE(b,2))
+if(o.c.b(null))for(p=0;p<a.length;++p)if(a[p]===void 0){a[p]=null;++q}a.sort(A.kF(b,2))
 if(q>0)this.b0(a,q)},
 aH(a){return this.S(a,null)},
 b0(a,b){var t,s=a.length
@@ -3998,7 +4008,7 @@ m(a,b){var t=a%b
 if(t===0)return 0
 if(t>0)return t
 return t+b},
-R(a,b){if(b<0)throw A.d(A.kB(b))
+R(a,b){if(b<0)throw A.d(A.kC(b))
 return b>31?0:a<<b>>>0},
 L(a,b){return b>31?0:a<<b>>>0},
 ar(a,b){var t
@@ -4009,7 +4019,7 @@ b1(a,b){return b>31?0:a>>>b},
 gN(a){return A.ay(u.H)},
 $ia6:1,
 $ial:1,
-$iK:1}
+$iL:1}
 J.ba.prototype={
 gN(a){return A.ay(u.S)},
 $iab:1,
@@ -4065,7 +4075,7 @@ if(b===0)break
 t+=t}return s},
 X(a,b){var t=a.indexOf(b,0)
 return t},
-h(a,b){return A.lS(a,b,0)},
+h(a,b){return A.lU(a,b,0)},
 A(a,b){var t
 A.Z(b)
 if(a===b)t=0
@@ -4125,7 +4135,7 @@ if(t>=q){s.d=null
 return!1}s.d=r.K(0,t);++s.c
 return!0},
 $iy:1}
-A.M.prototype={
+A.N.prototype={
 gt(a){return J.bF(this.a)},
 K(a,b){return this.b.$1(J.fN(this.a,b))}}
 A.ar.prototype={
@@ -4385,7 +4395,7 @@ return!1}else{s.d=t.b
 s.c=t.c
 return!0}},
 $iy:1}
-A.L.prototype={
+A.M.prototype={
 gt(a){return this.a.a},
 gq(a){var t=this.a
 return new A.bf(t,t.r,t.e,this.$ti.i("bf<1,2>"))}}
@@ -4402,7 +4412,7 @@ s.c=t.c
 return!0}},
 $iy:1}
 A.bd.prototype={
-Y(a){return A.kD(a)&1073741823},
+Y(a){return A.kE(a)&1073741823},
 Z(a,b){var t,s
 if(a==null)return-1
 t=a.length
@@ -4518,7 +4528,7 @@ i(a){return A.bE(v.typeUniverse,this,a)},
 V(a){return A.eL(v.typeUniverse,this,a)}}
 A.cg.prototype={}
 A.cl.prototype={
-j(a){return A.N(this.a,null)}}
+j(a){return A.O(this.a,null)}}
 A.cf.prototype={
 j(a){return this.a}}
 A.bA.prototype={}
@@ -4840,7 +4850,7 @@ A.p.prototype={$ip:1,
 B(a,b){return this===b},
 gv(a){return A.bm(this)},
 j(a){return"Instance of '"+A.c6(this)+"'"},
-gN(a){return A.kN(this)},
+gN(a){return A.kO(this)},
 toString(){return this.j(this)}}
 A.aP.prototype={
 gn(){return this.d},
@@ -5278,69 +5288,70 @@ $S:10}
 A.dr.prototype={
 $3(a,b,c){A.Z(a)
 A.Z(b)
-return B.b4.b3(A.kP(a,b,A.Z(c)==="symbolic"?B.ag:B.aP).a3(),null)},
+return B.b4.b3(A.kQ(a,b,A.Z(c)==="symbolic"?B.ag:B.aP).a3(),null)},
 $S:14};(function aliases(){var t=J.ah.prototype
 t.aM=t.j
 t=A.f.prototype
 t.aL=t.bi})();(function installTearOffs(){var t=hunkHelpers._static_2,s=hunkHelpers._static_1,r=hunkHelpers.installStaticTearOff
 t(J,"j7","hX",15)
-s(A,"kG","iW",16)
-r(A,"kC",5,null,["$5"],["kX"],0,0)
-r(A,"ll",5,null,["$5"],["jU"],0,0)
-r(A,"lF",5,null,["$5"],["kd"],0,0)
-r(A,"lc",5,null,["$5"],["jL"],0,0)
-r(A,"l2",5,null,["$5"],["jB"],0,0)
-r(A,"lP",5,null,["$5"],["kn"],0,0)
-r(A,"kZ",5,null,["$5"],["jx"],0,0)
-r(A,"li",5,null,["$5"],["jR"],0,0)
-r(A,"l7",5,null,["$5"],["jG"],0,0)
-r(A,"l8",5,null,["$5"],["jH"],0,0)
-r(A,"lL",5,null,["$5"],["kj"],0,0)
-r(A,"l3",5,null,["$5"],["jC"],0,0)
-r(A,"l6",5,null,["$5"],["jF"],0,0)
-r(A,"lt",5,null,["$5"],["k1"],0,0)
-r(A,"l0",5,null,["$5"],["jz"],0,0)
-r(A,"lO",5,null,["$5"],["km"],0,0)
-r(A,"lE",5,null,["$5"],["kc"],0,0)
-r(A,"lJ",5,null,["$5"],["kh"],0,0)
-r(A,"lD",5,null,["$5"],["kb"],0,0)
-r(A,"la",5,null,["$5"],["jJ"],0,0)
-r(A,"l9",5,null,["$5"],["jI"],0,0)
-r(A,"lb",5,null,["$5"],["jK"],0,0)
-r(A,"lf",5,null,["$5"],["jO"],0,0)
-r(A,"l5",5,null,["$5"],["jE"],0,0)
-r(A,"le",5,null,["$5"],["jN"],0,0)
-r(A,"l4",5,null,["$5"],["jD"],0,0)
-r(A,"ln",5,null,["$5"],["jW"],0,0)
-r(A,"lp",5,null,["$5"],["jY"],0,0)
-r(A,"lo",5,null,["$5"],["jX"],0,0)
-r(A,"lA",5,null,["$5"],["k8"],0,0)
-r(A,"ly",5,null,["$5"],["k6"],0,0)
-r(A,"lx",5,null,["$5"],["k5"],0,0)
-r(A,"lC",5,null,["$5"],["ka"],0,0)
-r(A,"lj",5,null,["$5"],["jS"],0,0)
-r(A,"ld",5,null,["$5"],["jM"],0,0)
-r(A,"lB",5,null,["$5"],["k9"],0,0)
-r(A,"lg",5,null,["$5"],["jP"],0,0)
-r(A,"lK",5,null,["$5"],["ki"],0,0)
-r(A,"lh",5,null,["$5"],["jQ"],0,0)
-r(A,"lq",5,null,["$5"],["jZ"],0,0)
-r(A,"lu",5,null,["$5"],["k2"],0,0)
-r(A,"lv",5,null,["$5"],["k3"],0,0)
-r(A,"lr",5,null,["$5"],["k_"],0,0)
-r(A,"lm",5,null,["$5"],["jV"],0,0)
-r(A,"lG",5,null,["$5"],["ke"],0,0)
-r(A,"lH",5,null,["$5"],["kf"],0,0)
-r(A,"lN",5,null,["$5"],["kl"],0,0)
-r(A,"lM",5,null,["$5"],["kk"],0,0)
-r(A,"lz",5,null,["$5"],["k7"],0,0)
-r(A,"lw",5,null,["$5"],["k4"],0,0)
-r(A,"lI",5,null,["$5"],["kg"],0,0)
-r(A,"lk",5,null,["$5"],["jT"],0,0)
-r(A,"l1",5,null,["$5"],["jA"],0,0)
-r(A,"l_",5,null,["$5"],["jy"],0,0)
-r(A,"ls",5,null,["$5"],["k0"],0,0)
-r(A,"kY",5,null,["$5"],["iS"],0,0)})();(function inheritance(){var t=hunkHelpers.inherit,s=hunkHelpers.inheritMany
+s(A,"kH","iW",16)
+r(A,"kD",5,null,["$5"],["kY"],0,0)
+r(A,"lm",5,null,["$5"],["jU"],0,0)
+r(A,"lH",5,null,["$5"],["ke"],0,0)
+r(A,"ld",5,null,["$5"],["jL"],0,0)
+r(A,"l3",5,null,["$5"],["jB"],0,0)
+r(A,"lR",5,null,["$5"],["ko"],0,0)
+r(A,"l_",5,null,["$5"],["jx"],0,0)
+r(A,"lj",5,null,["$5"],["jR"],0,0)
+r(A,"l8",5,null,["$5"],["jG"],0,0)
+r(A,"l9",5,null,["$5"],["jH"],0,0)
+r(A,"lN",5,null,["$5"],["kk"],0,0)
+r(A,"l4",5,null,["$5"],["jC"],0,0)
+r(A,"l7",5,null,["$5"],["jF"],0,0)
+r(A,"lu",5,null,["$5"],["k1"],0,0)
+r(A,"l1",5,null,["$5"],["jz"],0,0)
+r(A,"lQ",5,null,["$5"],["kn"],0,0)
+r(A,"lG",5,null,["$5"],["kd"],0,0)
+r(A,"lL",5,null,["$5"],["ki"],0,0)
+r(A,"lF",5,null,["$5"],["kc"],0,0)
+r(A,"lb",5,null,["$5"],["jJ"],0,0)
+r(A,"la",5,null,["$5"],["jI"],0,0)
+r(A,"lc",5,null,["$5"],["jK"],0,0)
+r(A,"lg",5,null,["$5"],["jO"],0,0)
+r(A,"l6",5,null,["$5"],["jE"],0,0)
+r(A,"lf",5,null,["$5"],["jN"],0,0)
+r(A,"l5",5,null,["$5"],["jD"],0,0)
+r(A,"lo",5,null,["$5"],["jW"],0,0)
+r(A,"lq",5,null,["$5"],["jY"],0,0)
+r(A,"lp",5,null,["$5"],["jX"],0,0)
+r(A,"lC",5,null,["$5"],["k9"],0,0)
+r(A,"lA",5,null,["$5"],["k7"],0,0)
+r(A,"lz",5,null,["$5"],["k6"],0,0)
+r(A,"lE",5,null,["$5"],["kb"],0,0)
+r(A,"lk",5,null,["$5"],["jS"],0,0)
+r(A,"le",5,null,["$5"],["jM"],0,0)
+r(A,"lD",5,null,["$5"],["ka"],0,0)
+r(A,"lh",5,null,["$5"],["jP"],0,0)
+r(A,"lM",5,null,["$5"],["kj"],0,0)
+r(A,"li",5,null,["$5"],["jQ"],0,0)
+r(A,"lr",5,null,["$5"],["jZ"],0,0)
+r(A,"lv",5,null,["$5"],["k2"],0,0)
+r(A,"lw",5,null,["$5"],["k3"],0,0)
+r(A,"ls",5,null,["$5"],["k_"],0,0)
+r(A,"lx",5,null,["$5"],["k4"],0,0)
+r(A,"ln",5,null,["$5"],["jV"],0,0)
+r(A,"lI",5,null,["$5"],["kf"],0,0)
+r(A,"lJ",5,null,["$5"],["kg"],0,0)
+r(A,"lP",5,null,["$5"],["km"],0,0)
+r(A,"lO",5,null,["$5"],["kl"],0,0)
+r(A,"lB",5,null,["$5"],["k8"],0,0)
+r(A,"ly",5,null,["$5"],["k5"],0,0)
+r(A,"lK",5,null,["$5"],["kh"],0,0)
+r(A,"ll",5,null,["$5"],["jT"],0,0)
+r(A,"l2",5,null,["$5"],["jA"],0,0)
+r(A,"l0",5,null,["$5"],["jy"],0,0)
+r(A,"lt",5,null,["$5"],["k0"],0,0)
+r(A,"kZ",5,null,["$5"],["iS"],0,0)})();(function inheritance(){var t=hunkHelpers.inherit,s=hunkHelpers.inheritMany
 t(A.p,null)
 s(A.p,[A.dE,J.bY,A.bp,J.b2,A.w,A.cY,A.f,A.bh,A.bx,A.a4,A.b8,A.at,A.aa,A.d_,A.cT,A.af,A.aM,A.cM,A.ao,A.bg,A.bf,A.aJ,A.ci,A.ce,A.c9,A.ck,A.Y,A.cg,A.cl,A.ch,A.av,A.bT,A.bV,A.d5,A.d2,A.c5,A.br,A.d3,A.cG,A.ap,A.bj,A.aP,A.aR,A.a0,A.cX,A.as,A.da,A.aO,A.b7,A.bi,A.bH,A.I,A.bN,A.bO,A.C,A.cS,A.bl,A.cW,A.j,A.m,A.d1,A.d9,A.dC,A.a3,A.d7,A.bM,A.ae,A.cR])
 s(J.bY,[J.c0,J.bb,J.aK,J.aH,J.ag])
@@ -5351,8 +5362,8 @@ t(J.cI,J.k)
 s(J.aH,[J.ba,J.c1])
 s(A.w,[A.c4,A.bv,A.c2,A.cc,A.c7,A.cf,A.be,A.bJ,A.W,A.bw,A.bs,A.bU])
 s(A.f,[A.b9,A.ar,A.cd,A.cj])
-s(A.b9,[A.G,A.a7,A.b,A.L])
-s(A.G,[A.bt,A.M])
+s(A.b9,[A.G,A.a7,A.b,A.M])
+s(A.G,[A.bt,A.N])
 s(A.a4,[A.aS,A.aT])
 t(A.aU,A.aS)
 t(A.by,A.aT)
@@ -5374,11 +5385,11 @@ t(A.d4,A.d5)
 s(A.W,[A.bn,A.bX])
 s(A.d2,[A.o,A.l,A.bQ,A.n,A.a9,A.aQ,A.cb,A.x,A.bP,A.cQ,A.cy,A.b6,A.b5,A.b3])
 t(A.ds,A.bR)})()
-var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{q:"int",al:"double",K:"num",h:"String",D:"bool",bj:"Null",ai:"List",p:"Object",a8:"Map",aI:"JSObject"},mangledNames:{},types:["q?(I,I,a0,a0,j)","D(o)","q(q,q)","q(o,o)","~(p?,p?)","I(as)","h(o)","D(I,a0)","~(q,n)","D(h)","h(h)","~(h,al{detail:h?,intervals:q?})","D(q)","h()","h(h,h,h)","q(@,@)","@(@)"],arrayRti:Symbol("$ti"),rttc:{"3;midi,name,pc":(a,b,c)=>d=>d instanceof A.aU&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"4;addCount,alterationCount,naturalCount,totalCount":a=>b=>b instanceof A.by&&A.kU(a,b.a)}}
-A.iG(v.typeUniverse,JSON.parse('{"bc":"ah","cV":"ah","ad":"ah","c0":{"D":[],"ab":[]},"bb":{"ab":[]},"aK":{"aI":[]},"ah":{"aI":[]},"k":{"ai":["1"],"aI":[],"f":["1"]},"c_":{"bp":[]},"cI":{"k":["1"],"ai":["1"],"aI":[],"f":["1"]},"b2":{"y":["1"]},"aH":{"al":[],"K":[],"a6":["K"]},"ba":{"al":[],"q":[],"K":[],"a6":["K"],"ab":[]},"c1":{"al":[],"K":[],"a6":["K"],"ab":[]},"ag":{"h":[],"a6":["h"],"cU":[],"ab":[]},"c4":{"w":[]},"b9":{"f":["1"]},"G":{"f":["1"]},"bt":{"G":["1"],"f":["1"],"f.E":"1","G.E":"1"},"bh":{"y":["1"]},"M":{"G":["2"],"f":["2"],"f.E":"2","G.E":"2"},"ar":{"f":["1"],"f.E":"1"},"bx":{"y":["1"]},"aU":{"aS":[],"a4":[]},"by":{"aT":[],"a4":[]},"b8":{"a8":["1","2"]},"aG":{"b8":["1","2"],"a8":["1","2"]},"at":{"y":["1"]},"aF":{"aa":["1"],"bq":["1"],"f":["1"]},"am":{"aF":["1"],"aa":["1"],"bq":["1"],"f":["1"]},"J":{"aF":["1"],"aa":["1"],"bq":["1"],"f":["1"]},"bk":{"w":[]},"c2":{"w":[]},"cc":{"w":[]},"af":{"an":[]},"bR":{"an":[]},"bS":{"an":[]},"ca":{"an":[]},"c8":{"an":[]},"aD":{"an":[]},"c7":{"w":[]},"X":{"aM":["1","2"],"dH":["1","2"],"a8":["1","2"]},"a7":{"f":["1"],"f.E":"1"},"ao":{"y":["1"]},"b":{"f":["1"],"f.E":"1"},"bg":{"y":["1"]},"L":{"f":["ap<1,2>"],"f.E":"ap<1,2>"},"bf":{"y":["ap<1,2>"]},"bd":{"X":["1","2"],"aM":["1","2"],"dH":["1","2"],"a8":["1","2"]},"aS":{"a4":[]},"aT":{"a4":[]},"aJ":{"i7":[],"cU":[]},"ci":{"bo":[],"aN":[]},"cd":{"f":["bo"],"f.E":"bo"},"ce":{"y":["bo"]},"c9":{"aN":[]},"cj":{"f":["aN"],"f.E":"aN"},"ck":{"y":["aN"]},"cf":{"w":[]},"bA":{"w":[]},"au":{"aa":["1"],"bq":["1"],"f":["1"]},"av":{"y":["1"]},"aM":{"a8":["1","2"]},"aa":{"bq":["1"],"f":["1"]},"bz":{"aa":["1"],"bq":["1"],"f":["1"]},"be":{"w":[]},"c3":{"w":[]},"al":{"K":[],"a6":["K"]},"q":{"K":[],"a6":["K"]},"ai":{"f":["1"]},"K":{"a6":["K"]},"bo":{"aN":[]},"h":{"a6":["h"],"cU":[]},"bJ":{"w":[]},"bv":{"w":[]},"W":{"w":[]},"bn":{"w":[]},"bX":{"w":[]},"bw":{"w":[]},"bs":{"w":[]},"bU":{"w":[]},"c5":{"w":[]},"br":{"w":[]},"aP":{"y":["q"]},"aR":{"im":[]}}'))
+var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{q:"int",al:"double",L:"num",h:"String",D:"bool",bj:"Null",ai:"List",p:"Object",a8:"Map",aI:"JSObject"},mangledNames:{},types:["q?(I,I,a0,a0,j)","D(o)","q(q,q)","q(o,o)","~(p?,p?)","I(as)","h(o)","D(I,a0)","~(q,n)","D(h)","h(h)","~(h,al{detail:h?,intervals:q?})","D(q)","h()","h(h,h,h)","q(@,@)","@(@)"],arrayRti:Symbol("$ti"),rttc:{"3;midi,name,pc":(a,b,c)=>d=>d instanceof A.aU&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"4;addCount,alterationCount,naturalCount,totalCount":a=>b=>b instanceof A.by&&A.kV(a,b.a)}}
+A.iG(v.typeUniverse,JSON.parse('{"bc":"ah","cV":"ah","ad":"ah","c0":{"D":[],"ab":[]},"bb":{"ab":[]},"aK":{"aI":[]},"ah":{"aI":[]},"k":{"ai":["1"],"aI":[],"f":["1"]},"c_":{"bp":[]},"cI":{"k":["1"],"ai":["1"],"aI":[],"f":["1"]},"b2":{"y":["1"]},"aH":{"al":[],"L":[],"a6":["L"]},"ba":{"al":[],"q":[],"L":[],"a6":["L"],"ab":[]},"c1":{"al":[],"L":[],"a6":["L"],"ab":[]},"ag":{"h":[],"a6":["h"],"cU":[],"ab":[]},"c4":{"w":[]},"b9":{"f":["1"]},"G":{"f":["1"]},"bt":{"G":["1"],"f":["1"],"f.E":"1","G.E":"1"},"bh":{"y":["1"]},"N":{"G":["2"],"f":["2"],"f.E":"2","G.E":"2"},"ar":{"f":["1"],"f.E":"1"},"bx":{"y":["1"]},"aU":{"aS":[],"a4":[]},"by":{"aT":[],"a4":[]},"b8":{"a8":["1","2"]},"aG":{"b8":["1","2"],"a8":["1","2"]},"at":{"y":["1"]},"aF":{"aa":["1"],"bq":["1"],"f":["1"]},"am":{"aF":["1"],"aa":["1"],"bq":["1"],"f":["1"]},"J":{"aF":["1"],"aa":["1"],"bq":["1"],"f":["1"]},"bk":{"w":[]},"c2":{"w":[]},"cc":{"w":[]},"af":{"an":[]},"bR":{"an":[]},"bS":{"an":[]},"ca":{"an":[]},"c8":{"an":[]},"aD":{"an":[]},"c7":{"w":[]},"X":{"aM":["1","2"],"dH":["1","2"],"a8":["1","2"]},"a7":{"f":["1"],"f.E":"1"},"ao":{"y":["1"]},"b":{"f":["1"],"f.E":"1"},"bg":{"y":["1"]},"M":{"f":["ap<1,2>"],"f.E":"ap<1,2>"},"bf":{"y":["ap<1,2>"]},"bd":{"X":["1","2"],"aM":["1","2"],"dH":["1","2"],"a8":["1","2"]},"aS":{"a4":[]},"aT":{"a4":[]},"aJ":{"i7":[],"cU":[]},"ci":{"bo":[],"aN":[]},"cd":{"f":["bo"],"f.E":"bo"},"ce":{"y":["bo"]},"c9":{"aN":[]},"cj":{"f":["aN"],"f.E":"aN"},"ck":{"y":["aN"]},"cf":{"w":[]},"bA":{"w":[]},"au":{"aa":["1"],"bq":["1"],"f":["1"]},"av":{"y":["1"]},"aM":{"a8":["1","2"]},"aa":{"bq":["1"],"f":["1"]},"bz":{"aa":["1"],"bq":["1"],"f":["1"]},"be":{"w":[]},"c3":{"w":[]},"al":{"L":[],"a6":["L"]},"q":{"L":[],"a6":["L"]},"ai":{"f":["1"]},"L":{"a6":["L"]},"bo":{"aN":[]},"h":{"a6":["h"],"cU":[]},"bJ":{"w":[]},"bv":{"w":[]},"W":{"w":[]},"bn":{"w":[]},"bX":{"w":[]},"bw":{"w":[]},"bs":{"w":[]},"bU":{"w":[]},"c5":{"w":[]},"br":{"w":[]},"aP":{"y":["q"]},"aR":{"im":[]}}'))
 A.iF(v.typeUniverse,JSON.parse('{"b9":1,"bz":1,"bT":2,"bV":2}'))
 var u=(function rtii(){var t=A.E
-return{G:t("o"),u:t("n"),V:t("a6<@>"),I:t("aG<h,q>"),C:t("w"),Z:t("an"),h:t("J<l>"),W:t("f<@>"),p:t("k<a0>"),B:t("k<I>"),_:t("k<o>"),U:t("k<bM>"),d:t("k<a8<h,p?>>"),k:t("k<+midi,name,pc(q?,h?,q)>"),f:t("k<aQ>"),s:t("k<h>"),r:t("k<as>"),b:t("k<@>"),t:t("k<q>"),T:t("bb"),m:t("aI"),L:t("bc"),v:t("ai<D>"),j:t("ai<@>"),J:t("a8<@,@>"),Y:t("M<o,h>"),P:t("bj"),K:t("p"),M:t("m2"),F:t("+()"),e:t("bo"),N:t("h"),q:t("h(o)"),R:t("ab"),A:t("ad"),o:t("as"),y:t("D"),i:t("al"),S:t("q"),O:t("ei<bj>?"),z:t("aI?"),X:t("p?"),w:t("h?"),g:t("ch?"),c:t("D?"),x:t("al?"),D:t("q?"),n:t("K?"),H:t("K")}})();(function constants(){var t=hunkHelpers.makeConstList
+return{G:t("o"),u:t("n"),V:t("a6<@>"),I:t("aG<h,q>"),C:t("w"),Z:t("an"),h:t("J<l>"),W:t("f<@>"),p:t("k<a0>"),B:t("k<I>"),_:t("k<o>"),U:t("k<bM>"),d:t("k<a8<h,p?>>"),k:t("k<+midi,name,pc(q?,h?,q)>"),f:t("k<aQ>"),s:t("k<h>"),r:t("k<as>"),b:t("k<@>"),t:t("k<q>"),T:t("bb"),m:t("aI"),L:t("bc"),v:t("ai<D>"),j:t("ai<@>"),J:t("a8<@,@>"),Y:t("N<o,h>"),P:t("bj"),K:t("p"),M:t("m4"),F:t("+()"),e:t("bo"),N:t("h"),q:t("h(o)"),R:t("ab"),A:t("ad"),o:t("as"),y:t("D"),i:t("al"),S:t("q"),O:t("ei<bj>?"),z:t("aI?"),X:t("p?"),w:t("h?"),g:t("ch?"),c:t("D?"),x:t("al?"),D:t("q?"),n:t("L?"),H:t("L")}})();(function constants(){var t=hunkHelpers.makeConstList
 B.bD=J.bY.prototype
 B.b=J.k.prototype
 B.a=J.ba.prototype
@@ -5423,15 +5434,15 @@ B.ah=new A.l(1,"majorFlat5")
 B.Y=new A.l(10,"minor6")
 B.p=new A.l(11,"dominant7")
 B.ai=new A.l(12,"dominant7sus2")
-B.a3=new A.l(13,"dominant7sus4")
+B.a4=new A.l(13,"dominant7sus4")
 B.C=new A.l(14,"dominant7Flat5")
 B.D=new A.l(15,"dominant7Sharp5")
-B.a4=new A.l(16,"major7")
+B.Z=new A.l(16,"major7")
 B.am=new A.l(17,"major7sus2")
 B.aa=new A.l(18,"major7sus4")
-B.Z=new A.l(19,"major7Flat5")
+B.a_=new A.l(19,"major7Flat5")
 B.G=new A.l(2,"minor")
-B.a_=new A.l(20,"major7Sharp5")
+B.a0=new A.l(20,"major7Sharp5")
 B.O=new A.l(21,"minor7")
 B.H=new A.l(22,"minor7Sharp5")
 B.U=new A.l(23,"minorMajor7")
@@ -5462,8 +5473,8 @@ B.a9=new A.n(21,"dim7")
 B.i=new A.n(22,"flat7")
 B.u=new A.n(23,"major7")
 B.T=new A.n(3,"nine")
-B.a0=new A.n(4,"sharp9")
-B.a1=new A.n(5,"add9")
+B.a1=new A.n(4,"sharp9")
+B.a2=new A.n(5,"add9")
 B.aR=new A.n(6,"addSharp9")
 B.m=new A.n(7,"minor3")
 B.ar=new A.n(8,"splitMinor3")
@@ -5568,14 +5579,14 @@ B.bB=new A.m(B.E,657,128)
 B.bd=new A.m(B.Y,649,128)
 B.be=new A.m(B.p,1169,128)
 B.bf=new A.m(B.ai,1157,128)
-B.bg=new A.m(B.a3,1185,128)
+B.bg=new A.m(B.a4,1185,128)
 B.bh=new A.m(B.C,1105,0)
 B.bi=new A.m(B.D,1297,0)
-B.bj=new A.m(B.a4,2193,128)
+B.bj=new A.m(B.Z,2193,128)
 B.bk=new A.m(B.am,2181,128)
 B.bl=new A.m(B.aa,2209,128)
-B.bm=new A.m(B.Z,2129,0)
-B.bo=new A.m(B.a_,2321,0)
+B.bm=new A.m(B.a_,2129,0)
+B.bo=new A.m(B.a0,2321,0)
 B.bp=new A.m(B.O,1161,128)
 B.bq=new A.m(B.H,1289,0)
 B.br=new A.m(B.U,2185,128)
@@ -5598,48 +5609,48 @@ B.ay=new A.a9(5,"six")
 B.az=new A.a9(6,"seven")
 B.ca={A:0,B:1,C:2,D:3,E:4,F:5,G:6}
 B.cc=new A.am(B.ca,7,A.E("am<h>"))
-B.ad=new A.J([B.x,B.a4],u.h)
+B.ad=new A.J([B.x,B.Z],u.h)
 B.cd=new A.J([B.x,B.p,B.D],u.h)
-B.ce=new A.J([B.a6,B.a_],u.h)
+B.ce=new A.J([B.a6,B.a0],u.h)
 B.cf=new A.J([B.G,B.U],u.h)
-B.a2=new A.J([B.G,B.O],u.h)
+B.a3=new A.J([B.G,B.O],u.h)
 B.cg=new A.J([B.B,B.o],A.E("J<o>"))
 B.c8={}
 B.aV=new A.am(B.c8,0,A.E("am<o>"))
 B.ch=new A.J([B.a5,B.P],u.h)
 B.aA=new A.J([B.a5,B.I],u.h)
 B.aW=new A.J([B.x,B.p],u.h)
-B.cO=A.lZ("p")})();(function staticFields(){$.O=A.i([],A.E("k<p>"))
+B.cO=A.m0("p")})();(function staticFields(){$.P=A.i([],A.E("k<p>"))
 $.eo=null
 $.e7=null
 $.e6=null
 $.d8=A.i([],A.E("k<ai<p>?>"))})();(function lazyInitializers(){var t=hunkHelpers.lazyFinal
-t($,"m1","fw",()=>A.fq("_$dart_dartClosure"))
-t($,"m0","e2",()=>A.fq("_$dart_dartClosure_dartJSInterop"))
-t($,"mf","fI",()=>A.i([new J.c_()],A.E("k<bp>")))
-t($,"m4","fy",()=>A.ac(A.d0({
+t($,"m3","fw",()=>A.fq("_$dart_dartClosure"))
+t($,"m2","e2",()=>A.fq("_$dart_dartClosure_dartJSInterop"))
+t($,"mh","fI",()=>A.i([new J.c_()],A.E("k<bp>")))
+t($,"m6","fy",()=>A.ac(A.d0({
 toString:function(){return"$receiver$"}})))
-t($,"m5","fz",()=>A.ac(A.d0({$method$:null,
+t($,"m7","fz",()=>A.ac(A.d0({$method$:null,
 toString:function(){return"$receiver$"}})))
-t($,"m6","fA",()=>A.ac(A.d0(null)))
-t($,"m7","fB",()=>A.ac(function(){var $argumentsExpr$="$arguments$"
+t($,"m8","fA",()=>A.ac(A.d0(null)))
+t($,"m9","fB",()=>A.ac(function(){var $argumentsExpr$="$arguments$"
 try{null.$method$($argumentsExpr$)}catch(s){return s.message}}()))
-t($,"ma","fE",()=>A.ac(A.d0(void 0)))
-t($,"mb","fF",()=>A.ac(function(){var $argumentsExpr$="$arguments$"
+t($,"mc","fE",()=>A.ac(A.d0(void 0)))
+t($,"md","fF",()=>A.ac(function(){var $argumentsExpr$="$arguments$"
 try{(void 0).$method$($argumentsExpr$)}catch(s){return s.message}}()))
-t($,"m9","fD",()=>A.ac(A.ex(null)))
-t($,"m8","fC",()=>A.ac(function(){try{null.$method$}catch(s){return s.message}}()))
-t($,"md","fH",()=>A.ac(A.ex(void 0)))
-t($,"mc","fG",()=>A.ac(function(){try{(void 0).$method$}catch(s){return s.message}}()))
-t($,"me","b0",()=>A.e0(B.cO))
-t($,"m_","fv",()=>A.i_(u.S,A.E("ai<I>")))
-t($,"mh","e3",()=>A.i([A.v(A.u(B.x),3080,!1),A.v(A.u(B.ah),3208,!1),A.v(A.u(B.G),3088,!1),A.v(A.u(B.ab),3216,!1),A.v(A.u(B.a5),144,!1),A.v(A.u(B.a6),136,!1),A.v(A.u(B.an),3096,!1),A.v(A.u(B.ao),3096,!1),A.v(A.u(B.ap),0,!0),A.v(A.u(B.E),3080,!1),A.v(A.u(B.Y),3088,!1),A.v(A.u(B.p),2056,!1),A.v(A.u(B.ai),2104,!1),A.v(A.u(B.a3),2072,!1),A.v(A.u(B.C),2184,!1),A.v(A.u(B.D),2184,!1),A.v(A.u(B.a4),1032,!1),A.v(A.u(B.am),1080,!1),A.v(A.u(B.aa),1048,!1),A.v(A.u(B.Z),1160,!1),A.v(A.u(B.a_),1160,!1),A.v(A.u(B.O),2064,!1),A.v(A.u(B.H),2192,!1),A.v(A.u(B.U),1040,!1),A.v(A.u(B.I),2192,!1),A.v(A.u(B.P),3216,!1)],A.E("k<b7>")))
-t($,"mi","fK",()=>A.i([A.e("prefer complete dominant flat-nine over colored diminished7",A.l6()),A.e("prefer flat-nine-bass dominant over remote reinterpretation",A.lt()),A.e("prefer complete altered dominant inversion over altered major7",A.l3()),A.e("prefer complete dominant sharp-nine over split-third sixth",A.l7()),A.e("prefer stable extended dominant over double-accidental altered-fifth slash",A.lL()),A.e("prefer complete altered sharp-five dominant over remote spellings",A.l4()),A.e("prefer conventional inversion in split-nine tritone dominant ambiguity",A.ll()),A.e("prefer altered dominant7 over dim7 slash",A.l0()),A.e("prefer conventional altered seventh over add11 slash",A.lj()),A.e("prefer complete minor sharp11 over altered maj7sus4",A.ld()),A.e("prefer close root-position dominant7 over non-dominant slash",A.lo()),A.e("prefer ninth-bass seventh chord over altered slash",A.lA()),A.e("prefer minor-major ninth over augmented-major thirteenth",A.ly()),A.e("prefer minor7 eleventh-bass slash over minor7 sharp-five slash",A.lx()),A.e("prefer root-position altered-fifth dominant over slash",A.lC()),A.e("prefer root-position add-chord over sus slash",A.lB()),A.e("prefer complete triad over structurally deficient reading",A.lh()),A.e("prefer root-position minor-eleventh shell over sus slash",A.lF()),A.e("prefer complete major six-nine over inverted minor-seven sharp-five",A.lc()),A.e("prefer complete add-nine inversion over minor-seven sharp-five",A.l2()),A.e("prefer simple triad add-tone over seventh-family unusual quality",A.lK())],A.E("k<bi>")))
-t($,"mj","fL",()=>A.i([A.e("prefer voicing-supported upper-structure slash",A.lP()),A.e("prefer root-position 6th over inverted 7th",A.kZ()),A.e("prefer complete triad over incomplete inverted 6th",A.li()),A.e("prefer upper-structure dominant7 slash",A.lO()),A.e("prefer root-position dominant sus over slash",A.lD()),A.e("prefer stable extended dominant over altered-fifth slash",A.lE()),A.e("prefer complete sharp-nine thirteenth dominant over colored sixth",A.lf()),A.e("prefer complete altered thirteenth dominant over altered minor thirteenth",A.l5()),A.e("prefer complete natural thirteenth dominant over minor-six add-eleven",A.le()),A.e("prefer complete flat-nine flat-thirteen dominant over remote spelling",A.l8()),A.e("prefer sharp-five sharp-eleven dominant spelling over flat-five flat-thirteen",A.lJ()),A.e("prefer complete major inversion over minor sharp-five",A.la()),A.e("prefer complete lydian six-nine over major13sus4",A.l9()),A.e("prefer complete major inversion over seventh-family color-bass slash",A.lb()),A.e("prefer root-position diminished7",A.ln()),A.e("prefer dominant7 over dim7 slash",A.lp()),A.e("prefer dominant7 shell slash over non-dominant seventh-family slash",A.lq()),A.e("prefer voicing that names every tone",A.lu()),A.e("prefer harmonic-minor tonic over split-third inversion",A.lv()),A.e("prefer fewer altered/tension colors",A.lr()),A.e("prefer diatonic chords",A.lm()),A.e("prefer root-position relative minor7 over major6 slash",A.lG()),A.e("prefer tonic chord",A.lN()),A.e("prefer I chord when bass is tonic",A.lM()),A.e("prefer complete triad add-tone over seventh-family add-tone",A.lg()),A.e("prefer root-position minor six-nine over half-diminished slash",A.lH()),A.e("prefer natural extensions over adds, then fewer total",A.lz()),A.e("prefer lydian major-nine spelling over flat-five",A.lw()),A.e("prefer root position",A.lI()),A.e("prefer common naming preference",A.kC()),A.e("prefer cleaner tritone flat-five dominant spelling",A.l1()),A.e("prefer more conventional inversion",A.lk()),A.e("prefer 7th chords over triads",A.l_()),A.e("prefer fewer extensions",A.ls()),A.e("avoid suspended chords",A.kY())],A.E("k<bi>")))
-t($,"mg","fJ",()=>{var s,r,q=A.aL(A.E("l"),A.E("m"))
+t($,"mb","fD",()=>A.ac(A.ex(null)))
+t($,"ma","fC",()=>A.ac(function(){try{null.$method$}catch(s){return s.message}}()))
+t($,"mf","fH",()=>A.ac(A.ex(void 0)))
+t($,"me","fG",()=>A.ac(function(){try{(void 0).$method$}catch(s){return s.message}}()))
+t($,"mg","b0",()=>A.e0(B.cO))
+t($,"m1","fv",()=>A.i_(u.S,A.E("ai<I>")))
+t($,"mj","e3",()=>A.i([A.v(A.u(B.x),3080,!1),A.v(A.u(B.ah),3208,!1),A.v(A.u(B.G),3088,!1),A.v(A.u(B.ab),3216,!1),A.v(A.u(B.a5),144,!1),A.v(A.u(B.a6),136,!1),A.v(A.u(B.an),3096,!1),A.v(A.u(B.ao),3096,!1),A.v(A.u(B.ap),0,!0),A.v(A.u(B.E),3080,!1),A.v(A.u(B.Y),3088,!1),A.v(A.u(B.p),2056,!1),A.v(A.u(B.ai),2104,!1),A.v(A.u(B.a4),2072,!1),A.v(A.u(B.C),2184,!1),A.v(A.u(B.D),2184,!1),A.v(A.u(B.Z),1032,!1),A.v(A.u(B.am),1080,!1),A.v(A.u(B.aa),1048,!1),A.v(A.u(B.a_),1160,!1),A.v(A.u(B.a0),1160,!1),A.v(A.u(B.O),2064,!1),A.v(A.u(B.H),2192,!1),A.v(A.u(B.U),1040,!1),A.v(A.u(B.I),2192,!1),A.v(A.u(B.P),3216,!1)],A.E("k<b7>")))
+t($,"mk","fK",()=>A.i([A.e("prefer complete dominant flat-nine over colored diminished7",A.l7()),A.e("prefer flat-nine-bass dominant over remote reinterpretation",A.lu()),A.e("prefer complete altered dominant inversion over altered major7",A.l4()),A.e("prefer complete dominant sharp-nine over split-third sixth",A.l8()),A.e("prefer stable extended dominant over double-accidental altered-fifth slash",A.lN()),A.e("prefer complete altered sharp-five dominant over remote spellings",A.l5()),A.e("prefer conventional inversion in split-nine tritone dominant ambiguity",A.lm()),A.e("prefer altered dominant7 over dim7 slash",A.l1()),A.e("prefer conventional altered seventh over add11 slash",A.lk()),A.e("prefer complete minor sharp11 over altered maj7sus4",A.le()),A.e("prefer close root-position dominant7 over non-dominant slash",A.lp()),A.e("prefer ninth-bass seventh chord over altered slash",A.lC()),A.e("prefer minor-major ninth over augmented-major thirteenth",A.lA()),A.e("prefer minor7 eleventh-bass slash over minor7 sharp-five slash",A.lz()),A.e("prefer root-position altered-fifth dominant over slash",A.lE()),A.e("prefer root-position add-chord over sus slash",A.lD()),A.e("prefer complete triad over structurally deficient reading",A.li()),A.e("prefer root-position minor-eleventh shell over sus slash",A.lH()),A.e("prefer complete major six-nine over inverted minor-seven sharp-five",A.ld()),A.e("prefer complete add-nine inversion over minor-seven sharp-five",A.l3()),A.e("prefer simple triad add-tone over seventh-family unusual quality",A.lM())],A.E("k<bi>")))
+t($,"ml","fL",()=>A.i([A.e("prefer voicing-supported upper-structure slash",A.lR()),A.e("prefer root-position 6th over inverted 7th",A.l_()),A.e("prefer complete triad over incomplete inverted 6th",A.lj()),A.e("prefer upper-structure dominant7 slash",A.lQ()),A.e("prefer root-position dominant sus over slash",A.lF()),A.e("prefer stable extended dominant over altered-fifth slash",A.lG()),A.e("prefer complete sharp-nine thirteenth dominant over colored sixth",A.lg()),A.e("prefer complete altered thirteenth dominant over altered minor thirteenth",A.l6()),A.e("prefer complete natural thirteenth dominant over minor-six add-eleven",A.lf()),A.e("prefer complete flat-nine flat-thirteen dominant over remote spelling",A.l9()),A.e("prefer sharp-five sharp-eleven dominant spelling over flat-five flat-thirteen",A.lL()),A.e("prefer complete major inversion over minor sharp-five",A.lb()),A.e("prefer complete lydian six-nine over major13sus4",A.la()),A.e("prefer complete major inversion over seventh-family color-bass slash",A.lc()),A.e("prefer root-position diminished7",A.lo()),A.e("prefer dominant7 over dim7 slash",A.lq()),A.e("prefer dominant7 shell slash over non-dominant seventh-family slash",A.lr()),A.e("prefer voicing that names every tone",A.lv()),A.e("prefer harmonic-minor tonic over split-third inversion",A.lw()),A.e("prefer higher-scoring major-seventh-bass inversion over color-bass slash",A.lx()),A.e("prefer fewer altered/tension colors",A.ls()),A.e("prefer diatonic chords",A.ln()),A.e("prefer root-position relative minor7 over major6 slash",A.lI()),A.e("prefer tonic chord",A.lP()),A.e("prefer I chord when bass is tonic",A.lO()),A.e("prefer complete triad add-tone over seventh-family add-tone",A.lh()),A.e("prefer root-position minor six-nine over half-diminished slash",A.lJ()),A.e("prefer natural extensions over adds, then fewer total",A.lB()),A.e("prefer lydian major-nine spelling over flat-five",A.ly()),A.e("prefer root position",A.lK()),A.e("prefer common naming preference",A.kD()),A.e("prefer cleaner tritone flat-five dominant spelling",A.l2()),A.e("prefer more conventional inversion",A.ll()),A.e("prefer 7th chords over triads",A.l0()),A.e("prefer fewer extensions",A.lt()),A.e("avoid suspended chords",A.kZ())],A.E("k<bi>")))
+t($,"mi","fJ",()=>{var s,r,q=A.aL(A.E("l"),A.E("m"))
 for(s=0;s<26;++s){r=B.c5[s]
 q.u(0,r.a,r)}return q})
-t($,"m3","fx",()=>{var s,r,q,p=A.aL(A.E("l"),A.E("b7"))
+t($,"m5","fx",()=>{var s,r,q,p=A.aL(A.E("l"),A.E("b7"))
 for(s=$.e3(),r=0;r<26;++r){q=s[r]
 p.u(0,q.a,q)}return p})})();(function nativeSupport(){!function(){var t=function(a){var n={}
 n[a]=1
@@ -5665,5 +5676,5 @@ convertToFastObject($);(function(a){if(typeof document==="undefined"){a(null)
 return}if(typeof document.currentScript!="undefined"){a(document.currentScript)
 return}var t=document.scripts
 function onLoad(b){for(var r=0;r<t.length;++r){t[r].removeEventListener("load",onLoad,false)}a(b.target)}for(var s=0;s<t.length;++s){t[s].addEventListener("load",onLoad,false)}})(function(a){v.currentScript=a
-var t=A.kT
+var t=A.kU
 if(typeof dartMainRunner==="function"){dartMainRunner(t,[])}else{t([])}})})()

--- a/lib/features/theory/domain/analysis/chord_analyzer.dart
+++ b/lib/features/theory/domain/analysis/chord_analyzer.dart
@@ -626,6 +626,11 @@ abstract final class ChordAnalyzer {
       return 1 << minorThirdInterval;
     }
 
+    if (quality == ChordQualityToken.major7 &&
+        _hasMajorSeventhSharpNineColor(relMask)) {
+      return 1 << minorThirdInterval;
+    }
+
     final isSharpNineDominantQuality =
         quality == ChordQualityToken.dominant7 ||
         quality == ChordQualityToken.dominant7Flat5 ||
@@ -643,6 +648,16 @@ abstract final class ChordAnalyzer {
         1 << minorThirdInterval; // same interval, dominant function
     if ((relMask & sharpNineBit) == 0) return 0;
     return sharpNineBit;
+  }
+
+  static bool _hasMajorSeventhSharpNineColor(int relMask) {
+    const majorThirdBit = 1 << majorThirdInterval;
+    const sharpNineBit = 1 << minorThirdInterval;
+    const majorSeventhBit = 1 << majorSeventhInterval;
+
+    return (relMask & majorThirdBit) != 0 &&
+        (relMask & sharpNineBit) != 0 &&
+        (relMask & majorSeventhBit) != 0;
   }
 
   static bool _supportsSplitThirdMajorFamilyVoicing(

--- a/test/chord_analyzer_golden_test.dart
+++ b/test/chord_analyzer_golden_test.dart
@@ -167,6 +167,18 @@ void main() {
       expectedExtensions: {ChordExtension.nine},
     ),
 
+    golden(
+      description: 'altered major seventh keeps sharp ninth color',
+      expectedSymbol: 'Dmaj7(#9,b13) / A',
+      pcs: ['A', 'D', 'F', 'F#', 'A#', 'C#'],
+      bass: 'A',
+      expectedRoot: 'D',
+      expectedBass: 'A',
+      expectedQuality: ChordQualityToken.major7,
+      expectedExtensions: {ChordExtension.sharp9, ChordExtension.flat13},
+      expectedToneRolesByInterval: {3: ChordToneRole.sharp9},
+    ),
+
     // 13th (as 7 + 9 + 13).
     golden(
       description: 'dominant thirteenth with ninth',


### PR DESCRIPTION
Treat interval 3 as sharp-nine color for plain major-seventh candidates when the major third and major seventh are both present. This keeps altered major seventh symbols from dropping the sharp ninth into also-played tones without promoting altered-fifth major-seventh reinterpretations.

Add a regression for Dmaj7(#9,b13)/A and update the analysis article to match the engine behavior.