### PR TITLE
Quiet Dart build hook output in CLI tools

### DIFF
--- a/bin/chord-debug
+++ b/bin/chord-debug
@@ -18,4 +18,4 @@ fi
 
 ##### MAIN
 
-exec dart run "$repo_root/tool/chord_debug.dart" "$@"
+exec dart run --verbosity=error "$repo_root/tool/chord_debug.dart" "$@"

--- a/bin/chord-name
+++ b/bin/chord-name
@@ -18,4 +18,4 @@ fi
 
 ##### MAIN
 
-exec dart run "$repo_root/tool/chord_name.dart" "$@"
+exec dart run --verbosity=error "$repo_root/tool/chord_name.dart" "$@"

--- a/tool/benchmark.sh
+++ b/tool/benchmark.sh
@@ -14,12 +14,13 @@ cd "$(dirname "$0")/.."
 for arg in "$@"; do
   case "$arg" in
     -h|--help|--show-baseline|--calibrate-noise)
-      exec dart run benchmark/analyze_benchmark.dart "$@"
+      exec dart run --verbosity=error benchmark/analyze_benchmark.dart "$@"
       ;;
   esac
 done
 
 exec dart run \
+  --verbosity=error \
   --enable-vm-service \
   --define=whatchord.counters=true \
   benchmark/analyze_benchmark.dart "$@"


### PR DESCRIPTION
Add --verbosity=error to repo CLI dart run invocations so Dart's native asset build hook progress messages do not pollute chord-debug, chord-name, and benchmark output. This also keeps chord-oracle output clean through its existing bin/chord-debug path.