### PR TITLE
Add an articles index and clean up article URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ app.*.map.json
 # Benchmark run output (transient; baseline is committed separately)
 /benchmark/last_run.json
 /benchmark/noise.json
+
+# Cloudflare Workers local dev state (wrangler dev / Miniflare)
+.wrangler/

--- a/docs/site/404.html
+++ b/docs/site/404.html
@@ -38,9 +38,7 @@
           <a class="btn btn-ghost" href="/try">Try chord identification</a>
         </div>
         <nav class="not-found-links" aria-label="WhatChord articles">
-          <a href="articles/why-chord-naming-is-hard.html">For Musicians</a>
-          <a href="articles/under-the-hood.html">Under the Hood</a>
-          <a href="articles/choco-chord-coverage.html">Chord Data</a>
+          <a href="articles/">Browse the articles</a>
         </nav>
       </div>
     </main>

--- a/docs/site/_redirects
+++ b/docs/site/_redirects
@@ -1,0 +1,7 @@
+# Serve the articles index at a clean, extensionless URL.
+/articles /articles/ 301
+/articles/ /articles/index.html 200
+
+# Permanent moves: articles renamed for clearer, more searchable slugs.
+/articles/under-the-hood.html /articles/chord-recognition-algorithm.html 301
+/articles/choco-chord-coverage.html /articles/million-chord-annotations.html 301

--- a/docs/site/articles/chord-naming.html
+++ b/docs/site/articles/chord-naming.html
@@ -58,9 +58,7 @@
         </a>
         <div class="nav-spacer"></div>
         <ul class="nav-links">
-          <li><a href="why-chord-naming-is-hard.html">For Musicians</a></li>
-          <li><a href="under-the-hood.html">Under the Hood</a></li>
-          <li><a href="choco-chord-coverage.html">Chord Data</a></li>
+          <li><a href="./">Articles</a></li>
         </ul>
         <a
           class="btn btn-ghost"
@@ -622,7 +620,7 @@
 
           <p>
             For the implementation details behind those scores, see
-            <a href="under-the-hood.html"
+            <a href="chord-recognition-algorithm.html"
               >Under the Hood: Building a Real-Time Chord Recognizer</a
             >.
           </p>

--- a/docs/site/articles/chord-recognition-algorithm.html
+++ b/docs/site/articles/chord-recognition-algorithm.html
@@ -45,9 +45,7 @@
         </a>
         <div class="nav-spacer"></div>
         <ul class="nav-links">
-          <li><a href="why-chord-naming-is-hard.html">For Musicians</a></li>
-          <li><a href="under-the-hood.html">Under the Hood</a></li>
-          <li><a href="choco-chord-coverage.html">Chord Data</a></li>
+          <li><a href="./">Articles</a></li>
         </ul>
         <a
           class="btn btn-ghost"
@@ -1206,7 +1204,7 @@ notes: F♯ B♭ C E  |  bass: F♯ (pc 6)  |  key: C major
             </a>
             <a
               class="article-card article-card-following"
-              href="choco-chord-coverage.html"
+              href="million-chord-annotations.html"
             >
               <div class="article-tag">Chord data</div>
               <h3>What We Learned From 1 Million Chord Annotations</h3>

--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -58,9 +58,7 @@
         </a>
         <div class="nav-spacer"></div>
         <ul class="nav-links">
-          <li><a href="why-chord-naming-is-hard.html">For Musicians</a></li>
-          <li><a href="under-the-hood.html">Under the Hood</a></li>
-          <li><a href="choco-chord-coverage.html">Chord Data</a></li>
+          <li><a href="./">Articles</a></li>
         </ul>
         <a
           class="btn btn-ghost"
@@ -605,8 +603,8 @@
               <div class="article-tag">Reference</div>
               <h3>Chord Naming Guide</h3>
               <p>
-                How to move from notes to a chord name using degree formulas,
-                default interval qualities, spelling, and candidate roots.
+                How to move from notes to a chord name using default interval
+                qualities, degree formulas, spelling, and candidate roots.
               </p>
               <span class="read-more">Read the guide →</span>
             </a>

--- a/docs/site/articles/index.html
+++ b/docs/site/articles/index.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <title>Articles | WhatChord</title>
+    <meta
+      name="description"
+      content="Writing on chords, harmony, and how WhatChord works: guides for musicians on naming, writing, and identifying chords, plus technical deep-dives into the analysis engine and the chord data behind it."
+    />
+    <meta property="og:title" content="WhatChord Articles" />
+    <meta
+      property="og:description"
+      content="Guides for musicians on naming, writing, and identifying chords, plus technical deep-dives into the analysis engine and the chord data behind it."
+    />
+    <meta
+      property="og:image"
+      content="https://whatchord.earthmanmuons.com/images/homepage_social.jpg"
+    />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="WhatChord: Identify chords. Understand harmony."
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://whatchord.earthmanmuons.com/articles/"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="WhatChord Articles" />
+    <meta
+      name="twitter:description"
+      content="Guides for musicians on naming, writing, and identifying chords, plus technical deep-dives into the analysis engine and the chord data behind it."
+    />
+    <meta
+      name="twitter:image"
+      content="https://whatchord.earthmanmuons.com/images/homepage_social.jpg"
+    />
+    <meta
+      name="twitter:image:alt"
+      content="WhatChord: Identify chords. Understand harmony."
+    />
+    <link
+      rel="canonical"
+      href="https://whatchord.earthmanmuons.com/articles/"
+    />
+    <link rel="icon" type="image/webp" href="../images/whatchord_logo.webp" />
+    <link rel="stylesheet" href="../css/style.css" />
+  </head>
+  <body>
+    <nav class="site-nav">
+      <div class="nav-inner">
+        <a class="nav-logo" href="../">
+          <img src="../images/whatchord_logo.webp" alt="WhatChord logo" />
+          <span>What<span class="logo-bold">Chord</span></span>
+        </a>
+        <div class="nav-spacer"></div>
+        <ul class="nav-links">
+          <li><a href="./" aria-current="page">Articles</a></li>
+        </ul>
+        <a
+          class="btn btn-ghost"
+          href="https://github.com/EarthmanMuons/whatchord"
+          ><img
+            class="github-icon"
+            src="../images/GitHub_Invertocat_White.png"
+            alt=""
+          /><span class="source-label">Source</span></a
+        >
+        <a
+          class="btn btn-primary btn-get-app"
+          href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
+          >Get the app</a
+        >
+      </div>
+    </nav>
+
+    <main>
+      <section class="articles-section articles-index">
+        <div class="wrap">
+          <div class="section-label">Articles</div>
+          <h1 class="section-title">
+            Writing on chords, harmony, and how WhatChord works.
+          </h1>
+          <p class="section-sub">
+            Guides for musicians on naming, writing, and identifying chords,
+            plus technical deep-dives into the analysis engine and the chord
+            data behind it.
+          </p>
+
+          <div class="article-group">
+            <h2>For Musicians</h2>
+            <div class="article-group-grid">
+              <a class="article-card" href="why-chord-naming-is-hard.html">
+                <h3>Why Chord Naming Is Harder Than It Looks</h3>
+                <p>
+                  The inversions, extensions, altered tones, and enharmonic
+                  ambiguities behind real chord recognition, and how WhatChord
+                  handles them.
+                </p>
+                <span class="read-more">Read the article →</span>
+              </a>
+              <a class="article-card" href="chord-naming.html">
+                <h3>Chord Naming Guide</h3>
+                <p>
+                  How to move from notes to a chord name using default interval
+                  qualities, degree formulas, spelling, and candidate roots.
+                </p>
+                <span class="read-more">Read the guide →</span>
+              </a>
+              <a class="article-card" href="chord-symbols.html">
+                <h3>Chord Symbol Guide</h3>
+                <p>
+                  How WhatChord formats chord symbols: extensions, added tones,
+                  alterations, parentheses, and slash bass, with the reasoning
+                  behind each choice.
+                </p>
+                <span class="read-more">Read the guide →</span>
+              </a>
+            </div>
+          </div>
+
+          <div class="article-group">
+            <h2>Technical Deep-Dives</h2>
+            <div class="article-group-grid">
+              <a class="article-card" href="chord-recognition-algorithm.html">
+                <h3>Under the Hood: Building a Real-Time Chord Recognizer</h3>
+                <p>
+                  The bitmasks, chord-quality templates, scoring and ranking
+                  heuristics, and LRU cache behind real-time chord recognition.
+                </p>
+                <span class="read-more">Read the article →</span>
+              </a>
+              <a class="article-card" href="million-chord-annotations.html">
+                <h3>What We Learned From 1 Million Chord Annotations</h3>
+                <p>
+                  How a large public chord corpus helped validate WhatChord's
+                  chord vocabulary and guide future recognition priorities.
+                </p>
+                <span class="read-more">Read the article →</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="try-teaser">
+        <div class="wrap">
+          <div class="try-teaser-card">
+            <div class="section-label">Try it now</div>
+            <h2>Identify a chord in your browser.</h2>
+            <p class="section-sub">
+              Nothing to install. Type a few notes and the same engine that
+              powers the app will name the voicing and its close alternatives.
+            </p>
+            <a class="btn btn-primary" href="/try"
+              >Open the chord identifier →</a
+            >
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <div class="footer-left">
+          <span class="footer-copy">
+            © 2025–2026
+            <a href="mailto:support@earthmanmuons.com">Aaron Bull Schaefer</a>
+            and contributors <span class="footer-separator">·</span>
+            <a
+              class="footer-license"
+              href="https://github.com/EarthmanMuons/whatchord/blob/main/LICENSE"
+              >0BSD License</a
+            >
+          </span>
+        </div>
+        <ul class="footer-links">
+          <li>
+            <a href="https://github.com/EarthmanMuons/whatchord">GitHub</a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/EarthmanMuons/whatchord/blob/main/PRIVACY.md"
+              >Privacy</a
+            >
+          </li>
+          <li>
+            <a
+              href="https://github.com/EarthmanMuons/whatchord/blob/main/SUPPORT.md"
+              >Support</a
+            >
+          </li>
+        </ul>
+      </div>
+    </footer>
+
+    <dialog id="android-dialog">
+      <div class="dialog-content">
+        <h3>Join the Android beta</h3>
+        <p>
+          WhatChord for Android is currently in closed testing. Email
+          <a
+            href="mailto:support@earthmanmuons.com?subject=WhatChord%20Android%20Beta"
+            >support@earthmanmuons.com</a
+          >
+          with your Gmail address and we'll add you to the tester pool.
+        </p>
+        <button class="btn btn-primary" data-close-android-dialog>
+          Got it
+        </button>
+      </div>
+    </dialog>
+    <script src="../js/site.js"></script>
+  </body>
+</html>

--- a/docs/site/articles/million-chord-annotations.html
+++ b/docs/site/articles/million-chord-annotations.html
@@ -43,9 +43,7 @@
         </a>
         <div class="nav-spacer"></div>
         <ul class="nav-links">
-          <li><a href="why-chord-naming-is-hard.html">For Musicians</a></li>
-          <li><a href="under-the-hood.html">Under the Hood</a></li>
-          <li><a href="choco-chord-coverage.html">Chord Data</a></li>
+          <li><a href="./">Articles</a></li>
         </ul>
         <a
           class="btn btn-ghost"
@@ -436,7 +434,7 @@
             </a>
             <a
               class="article-card article-card-following"
-              href="under-the-hood.html"
+              href="chord-recognition-algorithm.html"
             >
               <div class="article-tag">Technical deep-dive</div>
               <h3>Under the Hood: Building a Real-Time Chord Recognizer</h3>

--- a/docs/site/articles/why-chord-naming-is-hard.html
+++ b/docs/site/articles/why-chord-naming-is-hard.html
@@ -64,9 +64,7 @@
         </a>
         <div class="nav-spacer"></div>
         <ul class="nav-links">
-          <li><a href="why-chord-naming-is-hard.html">For Musicians</a></li>
-          <li><a href="under-the-hood.html">Under the Hood</a></li>
-          <li><a href="choco-chord-coverage.html">Chord Data</a></li>
+          <li><a href="./">Articles</a></li>
         </ul>
         <a
           class="btn btn-ghost"
@@ -399,7 +397,7 @@
           <p>
             If you want to see how that musical judgment is represented in code,
             the underlying algorithm is described in more technical depth in the
-            <a href="under-the-hood.html">companion article</a>.
+            <a href="chord-recognition-algorithm.html">companion article</a>.
           </p>
 
           <div class="article-cta">
@@ -436,7 +434,7 @@
             <h4>Also on this site</h4>
             <a
               class="article-card article-card-first"
-              href="under-the-hood.html"
+              href="chord-recognition-algorithm.html"
             >
               <div class="article-tag">Technical deep-dive</div>
               <h3>Under the Hood: Building a Real-Time Chord Recognizer</h3>

--- a/docs/site/css/style.css
+++ b/docs/site/css/style.css
@@ -852,6 +852,32 @@ section {
   color: var(--accent-light);
 }
 
+/* ─── Articles index ─────────────────────────────────────────── */
+
+.article-group h2 {
+  padding-top: 34px;
+  margin: 34px 0 24px;
+  font-size: 1.55rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--text);
+  letter-spacing: -0.022em;
+  scroll-margin-top: var(--sticky-anchor-offset);
+  border-top: 1px solid var(--border);
+}
+
+.article-group-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 360px));
+  gap: 20px;
+}
+
+@media (width <= 520px) {
+  .article-group-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* ─── Android beta dialog ────────────────────────────────────── */
 
 dialog {
@@ -1074,7 +1100,7 @@ footer {
 
 /* GitHub-style section anchors, injected by site.js and revealed on hover or
    keyboard focus so readers can link to a specific heading. */
-.article-body a.heading-anchor {
+a.heading-anchor {
   margin-left: 0.4em;
   font-weight: 400;
   color: var(--text-3);
@@ -1085,16 +1111,16 @@ footer {
     color 0.15s;
 }
 
-.article-body h2:hover a.heading-anchor,
-.article-body a.heading-anchor:focus {
+h2:hover a.heading-anchor,
+a.heading-anchor:focus {
   opacity: 1;
 }
 
-.article-body a.heading-anchor:hover {
+a.heading-anchor:hover {
   color: var(--accent-light);
 }
 
-.article-body a.heading-anchor svg {
+a.heading-anchor svg {
   width: 0.8em;
   height: 0.8em;
   vertical-align: middle;
@@ -1507,10 +1533,6 @@ footer {
 /* ─── Responsive ─────────────────────────────────────────────── */
 
 @media (width <= 860px) {
-  .nav-links {
-    display: none;
-  }
-
   .hero {
     padding: 56px 0 40px;
   }

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -43,13 +43,7 @@
         </a>
         <div class="nav-spacer"></div>
         <ul class="nav-links">
-          <li>
-            <a href="articles/why-chord-naming-is-hard.html">For Musicians</a>
-          </li>
-          <li><a href="articles/under-the-hood.html">Under the Hood</a></li>
-          <li>
-            <a href="articles/choco-chord-coverage.html">Chord Data</a>
-          </li>
+          <li><a href="articles/">Articles</a></li>
         </ul>
         <a
           class="btn btn-ghost"
@@ -400,7 +394,10 @@
               </p>
               <span class="read-more">Read the article →</span>
             </a>
-            <a class="article-card" href="articles/under-the-hood.html">
+            <a
+              class="article-card"
+              href="articles/chord-recognition-algorithm.html"
+            >
               <div class="article-tag">Technical deep-dive</div>
               <h3>Under the Hood: Building a Real-Time Chord Recognizer</h3>
               <p>
@@ -410,7 +407,10 @@
               </p>
               <span class="read-more">Read the article →</span>
             </a>
-            <a class="article-card" href="articles/choco-chord-coverage.html">
+            <a
+              class="article-card"
+              href="articles/million-chord-annotations.html"
+            >
               <div class="article-tag">Chord data</div>
               <h3>What We Learned From 1 Million Chord Annotations</h3>
               <p>

--- a/docs/site/js/site.js
+++ b/docs/site/js/site.js
@@ -31,39 +31,41 @@
     }
   }
 
-  // Give article section headings GitHub-style anchor links, generating ids
-  // from the heading text so no article has to hand-author them.
-  var articleBody = document.querySelector(".article-body");
-  if (articleBody) {
-    var usedIds = {};
-    articleBody.querySelectorAll("h2").forEach(function (heading) {
-      // Leave the call-to-action and related-articles headings alone.
-      if (heading.closest(".article-cta, .article-related")) return;
+  // Give section headings GitHub-style anchor links, generating ids from the
+  // heading text so no page has to hand-author them. Covers long-form articles
+  // and the articles index.
+  document
+    .querySelectorAll(".article-body, .articles-index")
+    .forEach(function (scope) {
+      var usedIds = {};
+      scope.querySelectorAll("h2").forEach(function (heading) {
+        // Leave the call-to-action and related-articles headings alone.
+        if (heading.closest(".article-cta, .article-related")) return;
 
-      var slug = heading.textContent
-        .trim()
-        .toLowerCase()
-        .replace(/[^\w\s-]/g, "")
-        .replace(/\s+/g, "-")
-        .replace(/-+/g, "-");
-      if (!slug) return;
+        var slug = heading.textContent
+          .trim()
+          .toLowerCase()
+          .replace(/[^\w\s-]/g, "")
+          .replace(/\s+/g, "-")
+          .replace(/-+/g, "-");
+        if (!slug) return;
 
-      usedIds[slug] = (usedIds[slug] || 0) + 1;
-      if (usedIds[slug] > 1) slug = slug + "-" + usedIds[slug];
-      if (!heading.id) heading.id = slug;
+        usedIds[slug] = (usedIds[slug] || 0) + 1;
+        if (usedIds[slug] > 1) slug = slug + "-" + usedIds[slug];
+        if (!heading.id) heading.id = slug;
 
-      var anchor = document.createElement("a");
-      anchor.className = "heading-anchor";
-      anchor.href = "#" + heading.id;
-      anchor.setAttribute("aria-label", "Link to this section");
-      anchor.innerHTML =
-        '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">' +
-        '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1" d="M10.6 13.4a4 4 0 0 1 0-5.7l2.8-2.8a4 4 0 0 1 5.7 5.7l-1.5 1.5"/>' +
-        '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1" d="M13.4 10.6a4 4 0 0 1 0 5.7l-2.8 2.8a4 4 0 0 1-5.7-5.7l1.5-1.5"/>' +
-        "</svg>";
-      heading.appendChild(anchor);
+        var anchor = document.createElement("a");
+        anchor.className = "heading-anchor";
+        anchor.href = "#" + heading.id;
+        anchor.setAttribute("aria-label", "Link to this section");
+        anchor.innerHTML =
+          '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">' +
+          '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1" d="M10.6 13.4a4 4 0 0 1 0-5.7l2.8-2.8a4 4 0 0 1 5.7 5.7l-1.5 1.5"/>' +
+          '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1" d="M13.4 10.6a4 4 0 0 1 0 5.7l-2.8 2.8a4 4 0 0 1-5.7-5.7l1.5-1.5"/>' +
+          "</svg>";
+        heading.appendChild(anchor);
+      });
     });
-  }
 
   if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
     return;

--- a/docs/site/sitemap.xml
+++ b/docs/site/sitemap.xml
@@ -7,6 +7,9 @@
     <loc>https://whatchord.earthmanmuons.com/try</loc>
   </url>
   <url>
+    <loc>https://whatchord.earthmanmuons.com/articles/</loc>
+  </url>
+  <url>
     <loc>https://whatchord.earthmanmuons.com/articles/chord-naming.html</loc>
   </url>
   <url>
@@ -16,9 +19,9 @@
     <loc>https://whatchord.earthmanmuons.com/articles/chord-symbols.html</loc>
   </url>
   <url>
-    <loc>https://whatchord.earthmanmuons.com/articles/under-the-hood.html</loc>
+    <loc>https://whatchord.earthmanmuons.com/articles/chord-recognition-algorithm.html</loc>
   </url>
   <url>
-    <loc>https://whatchord.earthmanmuons.com/articles/choco-chord-coverage.html</loc>
+    <loc>https://whatchord.earthmanmuons.com/articles/million-chord-annotations.html</loc>
   </url>
 </urlset>

--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -61,11 +61,7 @@
         </a>
         <div class="nav-spacer"></div>
         <ul class="nav-links">
-          <li>
-            <a href="articles/why-chord-naming-is-hard.html">For Musicians</a>
-          </li>
-          <li><a href="articles/under-the-hood.html">Under the Hood</a></li>
-          <li><a href="articles/choco-chord-coverage.html">Chord Data</a></li>
+          <li><a href="articles/">Articles</a></li>
         </ul>
         <a
           class="btn btn-ghost"


### PR DESCRIPTION
Replace the three hard-coded header links with a single "Articles" link pointing to a new categorized index at /articles/, so the header no longer needs editing across every file as articles are added. The index groups the writing under For Musicians and Technical Deep-Dives, omits the redundant category pills, and gets anchored section headings by extending the heading-anchor injection in site.js to cover it.

Serve /articles/ as a clean, extensionless URL via a new _redirects file, and rename two articles for clearer, more searchable slugs with 301s: under-the-hood.html to chord-recognition-algorithm.html, and choco-chord-coverage.html to million-chord-annotations.html.

Also keep the nav links visible on mobile, update the sitemap, refine the index copy, and ignore wrangler's local dev state.