### PR TITLE
Flag unused interval qualities in chord naming guide

### DIFF
--- a/docs/site/articles/chord-naming.html
+++ b/docs/site/articles/chord-naming.html
@@ -208,7 +208,7 @@
                 <td>3rd</td>
                 <td>E, major</td>
                 <td>E♭, minor (<code>m</code>)</td>
-                <td>E♯, augmented</td>
+                <td>E♯, <span class="unused">augmented</span><sup>*</sup></td>
               </tr>
               <tr>
                 <td>5th</td>
@@ -231,17 +231,25 @@
               <tr>
                 <td>11th</td>
                 <td>F, perfect</td>
-                <td>F♭, diminished</td>
+                <td>F♭, <span class="unused">diminished</span><sup>*</sup></td>
                 <td>F♯, augmented (<code>♯11</code>)</td>
               </tr>
               <tr>
                 <td>13th</td>
                 <td>A, major</td>
                 <td>A♭, minor (<code>♭13</code>)</td>
-                <td>A♯, augmented</td>
+                <td>A♯, <span class="unused">augmented</span><sup>*</sup></td>
               </tr>
             </tbody>
           </table>
+
+          <p class="score-table-note">
+            <span class="fn-mark">*</span> Chord symbols never use these three
+            qualities. Each is enharmonically a plainer chord member, so the
+            simpler spelling always wins: a raised 3rd (E♯) is the perfect 11th
+            (F), a lowered 11th (F♭) is the major 3rd (E), and a raised 13th
+            (A♯) is the minor 7th (B♭).
+          </p>
 
           <p>
             The third is major by default, unless <code>m</code> makes it minor.

--- a/docs/site/css/style.css
+++ b/docs/site/css/style.css
@@ -1305,6 +1305,36 @@ a.heading-anchor svg {
   font-size: 0.86em;
 }
 
+.score-table .unused {
+  font-style: italic;
+}
+
+.score-table sup {
+  margin-left: 0.15em;
+  font-size: 1.1em;
+  font-weight: 700;
+  color: var(--accent-light);
+}
+
+.score-table-note {
+  padding: 10px 14px;
+  margin: -8px 0 24px;
+  font-size: 0.85rem;
+  font-style: italic;
+  color: var(--text-2);
+  background: var(--accent-bg);
+  border-left: 2px solid var(--accent-border);
+  border-radius: 0 4px 4px 0;
+}
+
+.score-table-note .fn-mark {
+  font-size: 1.2rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--accent-light);
+}
+
 .article-cta {
   padding: 40px;
   margin-top: 60px;


### PR DESCRIPTION
The default interval quality table named three qualities that no chord symbol ever uses (augmented 3rd, diminished 11th, augmented 13th) without giving them a symbol, which read like an oversight. Mark each with an asterisk and add a footnote explaining that each is enharmonically a plainer chord member, so the simpler spelling wins: E#/F is the 11th, F#/E is the 3rd, A#/Bb is the minor 7th.

Italicize the three unused quality words, color the asterisks to match the table's code chips, and style the footnote as an accent-tinted callout so it stands apart from body prose.