### PR TITLE
Clean up benchmark report output

### DIFF
--- a/benchmark/analyze_benchmark.dart
+++ b/benchmark/analyze_benchmark.dart
@@ -92,7 +92,6 @@ Future<void> main(List<String> args) async {
   final verdict = printComparison
       ? _maybePrintComparison(outPath, result, check: check)
       : _CheckVerdict.pass();
-  if (printSummary || printComparison) stdout.writeln('Wrote $outPath');
   if (check && !verdict.passed) exitCode = 1;
 }
 
@@ -459,13 +458,14 @@ void _printCheckVerdict(_CheckVerdict verdict, _NoiseModel? noise) {
     '${_formatMagnitudePercent(_memoryRegressionThreshold)}'
     ' and above absolute/noise thresholds',
   );
+  stdout.writeln('');
   if (verdict.passed) {
     stdout.writeln('  result: PASS');
   } else {
-    stdout.writeln('  result: FAIL');
     for (final failure in verdict.failures) {
-      stdout.writeln('    - $failure');
+      stdout.writeln('  - $failure');
     }
+    stdout.writeln('  result: FAIL');
   }
 }
 


### PR DESCRIPTION
Drop the "Wrote <path>" line from benchmark runs; the last_run.json output is rarely used and the notice just adds noise to the report.

Reorder the --check verdict so failures are listed first and the PASS/FAIL line prints last, making the result obvious at the end of a report.