### PR TITLE
Use absolute paths on the 404 page

### DIFF
--- a/docs/site/404.html
+++ b/docs/site/404.html
@@ -12,14 +12,14 @@
       content="The requested page could not be found. Return to WhatChord or explore its chord identification tools and articles."
     />
     <meta name="robots" content="noindex" />
-    <link rel="icon" type="image/webp" href="images/whatchord_logo.webp" />
-    <link rel="stylesheet" href="css/style.css" />
+    <link rel="icon" type="image/webp" href="/images/whatchord_logo.webp" />
+    <link rel="stylesheet" href="/css/style.css" />
   </head>
   <body class="not-found-page">
     <nav class="site-nav">
       <div class="nav-inner">
-        <a class="nav-logo" href="./">
-          <img src="images/whatchord_logo.webp" alt="WhatChord logo" />
+        <a class="nav-logo" href="/">
+          <img src="/images/whatchord_logo.webp" alt="WhatChord logo" />
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
       </div>
@@ -34,11 +34,11 @@
           places instead.
         </p>
         <div class="not-found-actions">
-          <a class="btn btn-primary" href="./">Go to the homepage</a>
+          <a class="btn btn-primary" href="/">Go to the homepage</a>
           <a class="btn btn-ghost" href="/try">Try chord identification</a>
         </div>
         <nav class="not-found-links" aria-label="WhatChord articles">
-          <a href="articles/">Browse the articles</a>
+          <a href="/articles/">Browse the articles</a>
         </nav>
       </div>
     </main>


### PR DESCRIPTION
Make the 404 page reference site assets and navigation with root-relative URLs so nested missing routes still load styling and images correctly.