### PR TITLE
Use curly quotes and apostrophes in site prose

### DIFF
--- a/docs/site/articles/chord-naming.html
+++ b/docs/site/articles/chord-naming.html
@@ -618,7 +618,7 @@
           <p>
             The C reading wins because it has the strongest base chord, the bass
             is the root, and the remaining note has a standard name as a ninth.
-            Deciding which reading is "best" can still be tricky, especially in
+            Deciding which reading is “best” can still be tricky, especially in
             real music where context matters, but this is the kind of comparison
             that makes one option much easier to justify than the others.
           </p>
@@ -628,7 +628,7 @@
           <p>
             The spelling is not cosmetic. In this example, B♭ is the seventh
             above C. Spelling the same physical piano key as A♯ would make it
-            look like some kind of altered sixth instead of the chord's seventh.
+            look like some kind of altered sixth instead of the chord’s seventh.
             Both spellings represent the same pitch class, but chord symbols use
             enharmonic spelling to show function, not just keys on the
             instrument.
@@ -747,7 +747,7 @@
             href="mailto:support@earthmanmuons.com?subject=WhatChord%20Android%20Beta"
             >support@earthmanmuons.com</a
           >
-          with your Gmail address and we'll add you to the tester pool.
+          with your Gmail address and we’ll add you to the tester pool.
         </p>
         <button class="btn btn-primary" data-close-android-dialog>
           Got it

--- a/docs/site/articles/chord-ranking-performance.html
+++ b/docs/site/articles/chord-ranking-performance.html
@@ -7,19 +7,19 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <title>
-      Optimizing an Algorithm That's Quadratic by Design | WhatChord
+      Optimizing an Algorithm That’s Quadratic by Design | WhatChord
     </title>
     <meta
       name="description"
-      content="Naming a chord means ranking every plausible name, a step that can't use an ordinary sort. Why WhatChord's ranking is quadratic by design, and how we made it an order of magnitude faster without changing the answer a musician sees."
+      content="Naming a chord means ranking every plausible name, a step that can’t use an ordinary sort. Why WhatChord’s ranking is quadratic by design, and how we made it an order of magnitude faster without changing the answer a musician sees."
     />
     <meta
       property="og:title"
-      content="Optimizing an Algorithm That's Quadratic by Design"
+      content="Optimizing an Algorithm That’s Quadratic by Design"
     />
     <meta
       property="og:description"
-      content="Ranking a chord's possible names can't use an ordinary sort, which makes it quadratic by design. The optimizations that worked, the ones that didn't, and the reframe that cut the cost tenfold."
+      content="Ranking a chord’s possible names can’t use an ordinary sort, which makes it quadratic by design. The optimizations that worked, the ones that didn’t, and the reframe that cut the cost tenfold."
     />
     <meta
       property="og:image"
@@ -40,11 +40,11 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="Optimizing an Algorithm That's Quadratic by Design"
+      content="Optimizing an Algorithm That’s Quadratic by Design"
     />
     <meta
       name="twitter:description"
-      content="Ranking a chord's possible names can't use an ordinary sort, which makes it quadratic by design. The optimizations that worked, the ones that didn't, and the reframe that cut the cost tenfold."
+      content="Ranking a chord’s possible names can’t use an ordinary sort, which makes it quadratic by design. The optimizations that worked, the ones that didn’t, and the reframe that cut the cost tenfold."
     />
     <meta
       name="twitter:image"
@@ -116,11 +116,11 @@
         <header class="article-header">
           <a class="article-back" href="../">← WhatChord</a>
           <div class="article-tag">Technical deep-dive</div>
-          <h1>Optimizing an Algorithm That's Quadratic by Design</h1>
+          <h1>Optimizing an Algorithm That’s Quadratic by Design</h1>
           <p class="article-deck">
             WhatChord names the chord you are playing, in real time. Doing that
             well means generating plausible names and ranking them. That ranking
-            step turned out to eat almost all of the engine's compute because it
+            step turned out to eat almost all of the engine’s compute because it
             cannot use an ordinary sort. In June 2026 we set out to make it
             fast: first by shaving constant factors, then by questioning a
             hidden requirement that had made the larger optimization look
@@ -172,7 +172,7 @@
             already-scored candidates in order.
           </p>
 
-          <h2>Why ranking can't use an ordinary sort</h2>
+          <h2>Why ranking can’t use an ordinary sort</h2>
 
           <p>
             To sort a list, you hand the language a <em>comparator</em>: a
@@ -184,12 +184,12 @@
             <a href="https://en.wikipedia.org/wiki/Transitive_relation"
               >transitive</a
             >: if A belongs before B, and B before C, then A must belong before
-            C. Violate that and the sort's result is undefined. It will not
+            C. Violate that and the sort’s result is undefined. It will not
             usually crash, but it can drop items in nonsensical positions.
           </p>
 
           <p>
-            WhatChord's comparator is deliberately not transitive. Most of the
+            WhatChord’s comparator is deliberately not transitive. Most of the
             time it ranks two candidates by their fit score, but two kinds of
             musical override can outrank the score:
           </p>
@@ -207,7 +207,7 @@
               <strong>Tie-breakers</strong> apply only when two candidates score
               within a small window of each other (0.20 points, a constant the
               code calls <code>nearTieWindow</code>), capturing musical
-              heuristics that a single number can't.
+              heuristics that a single number can’t.
             </li>
           </ul>
 
@@ -216,7 +216,7 @@
             up with a cycle: A beats B, B beats C, and C beats A. No single
             ordering satisfies all three at once, so there is nothing coherent
             for a sort to return. Hand a cyclic comparator to a general sort and
-            the outcome can depend on the candidates' starting order.
+            the outcome can depend on the candidates’ starting order.
           </p>
 
           <p>
@@ -249,7 +249,7 @@
             number of candidates. Second, when a cycle blocks progress, the
             tie-break borrows
             <a href="https://en.wikipedia.org/wiki/Copeland%27s_method"
-              >Copeland's method</a
+              >Copeland’s method</a
             >
             from voting theory: count how many of the others each candidate
             beats, and take the one that beats the most. That count is
@@ -345,7 +345,7 @@
             spelling, a complete triad against a deficient inverted reading, and
             so on), and crucially that condition is
             <strong>candidate-local</strong>: it depends only on a single
-            candidate's quality, extensions, or precomputed features, never on
+            candidate’s quality, extensions, or precomputed features, never on
             the candidate it is being compared against.
           </p>
 
@@ -384,7 +384,7 @@
             done faster. The algorithm is still O(n²).
           </p>
 
-          <h2>What didn't work, part 1: splitting the gate by role</h2>
+          <h2>What didn’t work, part 1: splitting the gate by role</h2>
 
           <p>
             That single combined gate is broad for rules whose “other” side is
@@ -425,7 +425,7 @@
               <strong>Keeping the top N by score</strong> throws away
               lower-scoring candidates before the ranking runs. But the
               tie-break is a global Copeland count, so removing candidates
-              changes everyone else's win total. That can reshuffle the
+              changes everyone else’s win total. That can reshuffle the
               alternatives the app shows the user. This holds for any N and any
               cutoff; the problem is that the dropped candidates were part of
               what the survivors were measured against.
@@ -434,7 +434,7 @@
               <strong>Dropping candidates earlier, at generation time,</strong>
               has the identical problem. You might restrict which roots or chord
               templates are allowed to produce candidates, but any candidate
-              removed before ranking is gone from everyone's win total just the
+              removed before ranking is gone from everyone’s win total just the
               same.
             </li>
             <li>
@@ -452,7 +452,7 @@
             tried to compute the same full ranking faster.
           </p>
 
-          <h2>What didn't work, part 2: the sorted-rank redesign</h2>
+          <h2>What didn’t work, part 2: the sorted-rank redesign</h2>
 
           <p>
             The next redesign kept the exact same output and tried to compute it
@@ -706,7 +706,7 @@
 
           <div class="callout">
             <p>
-              A global Copeland win-count is partly an artifact: a candidate's
+              A global Copeland win-count is partly an artifact: a candidate’s
               total is inflated by every obviously-wrong reading it happens to
               beat. Pruning the unsurfaceable tail removes that padding, so the
               surviving order is decided against a <em>stronger</em> pool.
@@ -964,7 +964,7 @@
               <div class="article-tag">Chord data</div>
               <h3>What We Learned From 1 Million Chord Annotations</h3>
               <p>
-                How real-world chord annotations help keep WhatChord's
+                How real-world chord annotations help keep WhatChord’s
                 recognition roadmap grounded in music people actually write and
                 play.
               </p>
@@ -1020,7 +1020,7 @@
             href="mailto:support@earthmanmuons.com?subject=WhatChord%20Android%20Beta"
             >support@earthmanmuons.com</a
           >
-          with your Gmail address and we'll add you to the tester pool.
+          with your Gmail address and we’ll add you to the tester pool.
         </p>
         <button class="btn btn-primary" data-close-android-dialog>
           Got it

--- a/docs/site/articles/chord-recognition-algorithm.html
+++ b/docs/site/articles/chord-recognition-algorithm.html
@@ -1133,7 +1133,7 @@ notes: F♯ B♭ C E  |  bass: F♯ (pc 6)  |  key: C major
           <ul>
             <li>
               <strong>Polychords.</strong> Two simultaneous independent
-              sonorities (like Stravinsky's Petrushka chord, an F♯ major triad
+              sonorities (like Stravinsky’s Petrushka chord, an F♯ major triad
               over a C major triad) are not modeled. The algorithm will find the
               best single-chord description of the combined note set.
             </li>
@@ -1321,7 +1321,7 @@ notes: F♯ B♭ C E  |  bass: F♯ (pc 6)  |  key: C major
             href="mailto:support@earthmanmuons.com?subject=WhatChord%20Android%20Beta"
             >support@earthmanmuons.com</a
           >
-          with your Gmail address and we'll add you to the tester pool.
+          with your Gmail address and we’ll add you to the tester pool.
         </p>
         <button class="btn btn-primary" data-close-android-dialog>
           Got it

--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -14,7 +14,7 @@
     <meta property="og:title" content="How to Format Chord Symbols" />
     <meta
       property="og:description"
-      content="The conventions behind WhatChord's chord symbols: extensions, added tones, alterations, parentheses, and slash bass, explained for musicians."
+      content="The conventions behind WhatChord’s chord symbols: extensions, added tones, alterations, parentheses, and slash bass, explained for musicians."
     />
     <meta
       property="og:image"
@@ -36,7 +36,7 @@
     <meta name="twitter:title" content="How to Format Chord Symbols" />
     <meta
       name="twitter:description"
-      content="The conventions behind WhatChord's chord symbols: extensions, added tones, alterations, parentheses, and slash bass, explained for musicians."
+      content="The conventions behind WhatChord’s chord symbols: extensions, added tones, alterations, parentheses, and slash bass, explained for musicians."
     />
     <meta
       name="twitter:image"
@@ -112,7 +112,7 @@
           <p class="article-deck">
             A chord symbol is a concise name for a harmonic identity, not an
             exhaustive inventory of the notes being played. It describes a
-            chord's quality, independent of the register, spacing, and doublings
+            chord’s quality, independent of the register, spacing, and doublings
             of any particular voicing.
           </p>
 
@@ -363,7 +363,7 @@
           <h3>Why not add2 or add4?</h3>
 
           <p>
-            Chord symbols say nothing about register, so an added tone's label
+            Chord symbols say nothing about register, so an added tone’s label
             never changes with its voicing: a D added to a C triad is the same
             ninth whether it sits next to the root or an octave above, and an F
             is the same eleventh either way. There is no need to drop to
@@ -523,7 +523,7 @@
 
           <p>
             Commonly omitted tones, especially perfect fifths in extended
-            chords, should be understood as part of that chord's identity rather
+            chords, should be understood as part of that chord’s identity rather
             than turned into a performance instruction. Dropping a structurally
             important tone, like the third, is a different matter: it weakens
             the reading instead of simplifying the symbol.
@@ -598,7 +598,7 @@
           <p>
             Where references or house styles differ, WhatChord favors symbols
             that are concise, widely recognizable, and clear in a real-time app
-            interface. The goal is not to reproduce any one book's house style
+            interface. The goal is not to reproduce any one book’s house style
             exactly, but to apply the same clarity principles consistently
             across every displayed chord.
           </p>
@@ -684,7 +684,7 @@
             href="mailto:support@earthmanmuons.com?subject=WhatChord%20Android%20Beta"
             >support@earthmanmuons.com</a
           >
-          with your Gmail address and we'll add you to the tester pool.
+          with your Gmail address and we’ll add you to the tester pool.
         </p>
         <button class="btn btn-primary" data-close-android-dialog>
           Got it

--- a/docs/site/articles/index.html
+++ b/docs/site/articles/index.html
@@ -164,7 +164,7 @@
                 <span class="read-more">Read the article →</span>
               </a>
               <a class="article-card" href="chord-ranking-performance.html">
-                <h3>Optimizing an Algorithm That's Quadratic by Design</h3>
+                <h3>Optimizing an Algorithm That’s Quadratic by Design</h3>
                 <p>
                   Why the chord comparator is non-transitive, why that forces an
                   O(n²) Copeland linearization, and how we cut its cost by an
@@ -175,7 +175,7 @@
               <a class="article-card" href="million-chord-annotations.html">
                 <h3>What We Learned From 1 Million Chord Annotations</h3>
                 <p>
-                  How a large public chord corpus helped validate WhatChord's
+                  How a large public chord corpus helped validate WhatChord’s
                   chord vocabulary and guide future recognition priorities.
                 </p>
                 <span class="read-more">Read the article →</span>
@@ -245,7 +245,7 @@
             href="mailto:support@earthmanmuons.com?subject=WhatChord%20Android%20Beta"
             >support@earthmanmuons.com</a
           >
-          with your Gmail address and we'll add you to the tester pool.
+          with your Gmail address and we’ll add you to the tester pool.
         </p>
         <button class="btn btn-primary" data-close-android-dialog>
           Got it

--- a/docs/site/articles/million-chord-annotations.html
+++ b/docs/site/articles/million-chord-annotations.html
@@ -9,7 +9,7 @@
     <title>What We Learned From 1 Million Chord Annotations | WhatChord</title>
     <meta
       name="description"
-      content="How a large public chord corpus helped validate WhatChord's chord vocabulary and guide future recognition priorities."
+      content="How a large public chord corpus helped validate WhatChord’s chord vocabulary and guide future recognition priorities."
     />
     <meta
       property="og:title"
@@ -17,7 +17,7 @@
     />
     <meta
       property="og:description"
-      content="A look at how real-world chord annotations help keep WhatChord's recognition roadmap grounded in music people actually write and play."
+      content="A look at how real-world chord annotations help keep WhatChord’s recognition roadmap grounded in music people actually write and play."
     />
     <meta
       property="og:image"
@@ -96,7 +96,7 @@
           <h1>What We Learned From 1 Million Chord Annotations</h1>
           <p class="article-deck">
             WhatChord is built around musical judgment, but judgment still needs
-            evidence. In May 2026, we checked the app's chord vocabulary against
+            evidence. In May 2026, we checked the app’s chord vocabulary against
             a large public corpus of real chord annotations to see what it
             covers, what it misses, and what should matter next.
           </p>
@@ -126,7 +126,7 @@
             That is where engineering discipline helps. A recognition engine can
             still be shaped by musical taste, but the roadmap should not depend
             only on intuition. We wanted external validation: compare
-            WhatChord's current chord vocabulary with a large collection of
+            WhatChord’s current chord vocabulary with a large collection of
             existing chord annotations, then use the result to decide where more
             work would actually help players.
           </p>
@@ -209,7 +209,7 @@
           </table>
 
           <p>
-            Compared with WhatChord's current templates and extension handling,
+            Compared with WhatChord’s current templates and extension handling,
             the result was encouraging:
           </p>
 
@@ -240,7 +240,7 @@
 
           <p>
             In plain English: most of the chord language in this large mixed
-            corpus is already inside WhatChord's recognition vocabulary. The
+            corpus is already inside WhatChord’s recognition vocabulary. The
             current set of supported chord families is broad enough to cover the
             overwhelming majority of real annotated chord material.
           </p>
@@ -373,7 +373,7 @@
           <h2>What this means for WhatChord</h2>
 
           <p>
-            The practical lesson is not "the app is done." It is that the next
+            The practical lesson is not “the app is done.” It is that the next
             highest-impact improvements are probably not a long list of new
             chord templates.
           </p>
@@ -397,7 +397,7 @@
           </ul>
 
           <p>
-            That balance is central to WhatChord's approach. More recognition is
+            That balance is central to WhatChord’s approach. More recognition is
             only better when it improves the answer a musician sees. Sometimes
             the disciplined choice is to say no to a label, or at least not yet.
           </p>
@@ -532,7 +532,7 @@
             href="mailto:support@earthmanmuons.com?subject=WhatChord%20Android%20Beta"
             >support@earthmanmuons.com</a
           >
-          with your Gmail address and we'll add you to the tester pool.
+          with your Gmail address and we’ll add you to the tester pool.
         </p>
         <button class="btn btn-primary" data-close-android-dialog>
           Got it

--- a/docs/site/articles/why-chord-naming-is-hard.html
+++ b/docs/site/articles/why-chord-naming-is-hard.html
@@ -174,7 +174,7 @@
           </div>
 
           <p>
-            So which name is "right"? Without tonal context, none of the four
+            So which name is “right”? Without tonal context, none of the four
             spellings is automatically more correct than the others. They are
             enharmonic descriptions of identical piano keys, and the right
             answer depends on musical context: what key you are in, what chord
@@ -220,7 +220,7 @@
             bass note and scored separately from the upper structure. A chord
             where the bass is the root earns a higher score than the same chord
             with a bass that requires slash notation. Not because root position
-            is "more correct," but because it is the more common interpretation
+            is “more correct,” but because it is the more common interpretation
             and more informative to name explicitly as root position first.
           </p>
 
@@ -281,7 +281,7 @@
           </p>
 
           <p>
-            The "altered scale," the seventh mode of melodic minor, provides a
+            The “altered scale,” the seventh mode of melodic minor, provides a
             vocabulary of alterations that can be stacked on a dominant chord:
             flat 9, sharp 9, sharp 11 or flat 5, and flat 13 or sharp 5. A
             heavily altered dominant might look like
@@ -292,8 +292,8 @@
 
           <p>
             The dominant 7th sharp-nine chord is particularly well-known,
-            nicknamed the "Hendrix chord" for its prominent use in "Purple
-            Haze," where it appears as <span class="chord">E7♯9</span>. Building
+            nicknamed the “Hendrix chord” for its prominent use in “Purple
+            Haze,” where it appears as <span class="chord">E7♯9</span>. Building
             one on G, the notes are G, B, F, and A♯. That A♯ is the same piano
             key as B♭, but the chord role is different: it is the raised 9th
             above G. Without musical context, a naive recognizer might call the
@@ -314,7 +314,7 @@
 
           <p>
             Experienced jazz pianists often build dominant chord voicings using
-            an "upper structure" technique: the left hand plays the shell tones
+            an “upper structure” technique: the left hand plays the shell tones
             (usually the 3rd and flat 7th of the dominant, often with a bass
             root supplied nearby), and the right hand plays what sounds like a
             separate chord, often a simple triad built on another scale degree.
@@ -544,7 +544,7 @@
             href="mailto:support@earthmanmuons.com?subject=WhatChord%20Android%20Beta"
             >support@earthmanmuons.com</a
           >
-          with your Gmail address and we'll add you to the tester pool.
+          with your Gmail address and we’ll add you to the tester pool.
         </p>
         <button class="btn btn-primary" data-close-android-dialog>
           Got it

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -93,7 +93,7 @@
       <section class="hero">
         <div class="wrap">
           <div class="hero-eyebrow">Free · No ads · All analysis on-device</div>
-          <h1>Stop guessing what chord you're playing.</h1>
+          <h1>Stop guessing what chord you’re playing.</h1>
           <div class="hero-screenshot">
             <img
               src="images/theme_modes.webp"
@@ -440,7 +440,7 @@
               <div class="article-tag">Chord data</div>
               <h3>What We Learned From 1 Million Chord Annotations</h3>
               <p>
-                How a large public chord corpus helped validate WhatChord's
+                How a large public chord corpus helped validate WhatChord’s
                 chord vocabulary and guide future recognition priorities with
                 evidence rather than guesswork.
               </p>
@@ -493,7 +493,7 @@
             href="mailto:support@earthmanmuons.com?subject=WhatChord%20Android%20Beta"
             >support@earthmanmuons.com</a
           >
-          with your Gmail address and we'll add you to the tester pool.
+          with your Gmail address and we’ll add you to the tester pool.
         </p>
         <button class="btn btn-primary" data-close-android-dialog>
           Got it

--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -331,7 +331,7 @@
             href="mailto:support@earthmanmuons.com?subject=WhatChord%20Android%20Beta"
             >support@earthmanmuons.com</a
           >
-          with your Gmail address and we'll add you to the tester pool.
+          with your Gmail address and we’ll add you to the tester pool.
         </p>
         <button class="btn btn-primary" data-close-android-dialog>
           Got it


### PR DESCRIPTION
Convert straight quotes to typographic curly quotes and apostrophes across all pages in docs/site: body text, headings, page titles, and meta descriptions (Open Graph and Twitter cards).