### PR TITLE
Spell color-tone slash basses for readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,11 +51,16 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 - When nothing structural separates two close readings, the chord with the
   cleaner spelling now wins instead of an arbitrary root-order fallback, so
   C♯m(maj7,♭9) is chosen over C♯maj7♭9 and its E♯ spelling.
+- Slash bass notes now favor a readable sounding-pitch spelling when the bass is
+  a color or altered tone, so a sharp-nine in the bass shows as A7♯9/C rather
+  than A7♯9/B♯, and double accidentals such as F♯7(♯9,♯11,♭13)/G𝄪 become
+  F♯7(♯9,♯11,♭13)/A. Genuine chord-tone inversions keep their conventional
+  spelling, so A/C♯, F♯7/A♯, and C♯maj7/B♯ are unchanged.
 
 ### Fixed
 
 - Improved altered sharp-five dominant recognition, so voicings such as C7♯5♭9,
-  A7♯5♯9/B♯, and D9♭5/C are less likely to be displaced by remote minor-major,
+  A7♯5♯9/C, and D9♭5/C are less likely to be displaced by remote minor-major,
   altered-major, sus add-color, or less idiomatic altered-fifth-bass
   reinterpretations.
 - Improved Lydian major-ninth recognition when the alternative is a close

--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -564,6 +564,18 @@
             <span class="chord">C7 / B♭</span>.
           </p>
 
+          <p>
+            The slash note names the pitch a player sounds, so it favors a
+            readable spelling. When the bass is a genuine chord tone, its
+            conventional inversion spelling is kept, even where that means a
+            less common letter, as with <span class="chord">C♯maj7 / B♯</span>.
+            But when the bass is a color or altered tone, the sounding spelling
+            wins, so a sharp ninth in the bass is
+            <span class="chord">A7(♯9) / C</span>, not
+            <span class="chord not-used">A7(♯9) / B♯</span>, and double
+            accidentals are avoided.
+          </p>
+
           <h2>References</h2>
 
           <p>

--- a/docs/site/js/chord-id.js
+++ b/docs/site/js/chord-id.js
@@ -22,7 +22,7 @@ a[c]=function(){if(a[b]===t){a[b]=d()}a[c]=function(){return this[b]}
 return a[b]}}function lazyFinal(a,b,c,d){var t=a
 a[b]=t
 a[c]=function(){if(a[b]===t){var s=d()
-if(a[b]!==t){A.m8(b)}a[b]=s}var r=a[b]
+if(a[b]!==t){A.mb(b)}a[b]=s}var r=a[b]
 a[c]=function(){return r}
 return r}}function makeConstList(a,b){if(b!=null)A.i(a,b)
 a.$flags=7
@@ -80,46 +80,46 @@ if(a==null)return J.bd.prototype
 if(typeof a=="boolean")return J.c4.prototype
 if(Array.isArray(a))return J.l.prototype
 if(typeof a=="function")return J.be.prototype
-if(typeof a=="object"){if(a instanceof A.r){return a}else{return J.aJ.prototype}}if(!(a instanceof A.r))return J.ac.prototype
+if(typeof a=="object"){if(a instanceof A.r){return a}else{return J.aK.prototype}}if(!(a instanceof A.r))return J.ad.prototype
 return a},
 ex(a){if(a==null)return a
 if(Array.isArray(a))return J.l.prototype
-if(!(a instanceof A.r))return J.ac.prototype
+if(!(a instanceof A.r))return J.ad.prototype
 return a},
-l4(a){if(typeof a=="string")return J.ai.prototype
+l6(a){if(typeof a=="string")return J.ai.prototype
 if(a==null)return a
 if(Array.isArray(a))return J.l.prototype
-if(!(a instanceof A.r))return J.ac.prototype
+if(!(a instanceof A.r))return J.ad.prototype
 return a},
-l5(a){if(typeof a=="number")return J.aG.prototype
+l7(a){if(typeof a=="number")return J.aH.prototype
 if(typeof a=="string")return J.ai.prototype
 if(a==null)return a
-if(!(a instanceof A.r))return J.ac.prototype
+if(!(a instanceof A.r))return J.ad.prototype
 return a},
 fT(a){if(typeof a=="string")return J.ai.prototype
 if(a==null)return a
-if(!(a instanceof A.r))return J.ac.prototype
+if(!(a instanceof A.r))return J.ad.prototype
 return a},
 L(a,b){if(a==null)return b==null
 if(typeof a!="object")return b!=null&&a===b
 return J.az(a).B(a,b)},
 b1(a,b){return J.ex(a).l(a,b)},
 eE(a,b){return J.fT(a).aB(a,b)},
-he(a,b){return J.l5(a).A(a,b)},
+he(a,b){return J.l7(a).A(a,b)},
 hf(a,b){return J.ex(a).L(a,b)},
 v(a){return J.az(a).gv(a)},
 cs(a){return J.ex(a).gq(a)},
-bK(a){return J.l4(a).gu(a)},
+bK(a){return J.l6(a).gu(a)},
 hg(a){return J.az(a).gP(a)},
-hh(a,b,c){return J.fT(a).D(a,b,c)},
+hh(a,b,c){return J.fT(a).E(a,b,c)},
 bL(a){return J.az(a).j(a)},
 c2:function c2(){},
 c4:function c4(){},
 bd:function bd(){},
-aJ:function aJ(){},
+aK:function aK(){},
 aj:function aj(){},
 d2:function d2(){},
-ac:function ac(){},
+ad:function ad(){},
 be:function be(){},
 l:function l(a){this.$ti=a},
 c3:function c3(){},
@@ -130,7 +130,7 @@ _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-aG:function aG(){},
+aH:function aH(){},
 bc:function bc(){},
 c5:function c5(){},
 ai:function ai(){}},A={e4:function e4(){},
@@ -167,7 +167,7 @@ _.$ti=c},
 N:function N(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-ad:function ad(a,b,c){this.a=a
+ae:function ae(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
 bz:function bz(a,b,c){this.a=a
@@ -229,16 +229,16 @@ if(!A.fC(b))return new A.Z(!0,b,s,null)
 t=J.bK(a)
 if(b<0||b>=t)return A.e3(b,t,a,s)
 return A.f_(b,s)},
-kV(a){return new A.Z(!0,a,null,null)},
+kX(a){return new A.Z(!0,a,null,null)},
 d(a){return A.G(a,new Error())},
 G(a,b){var t
 if(a==null)a=new A.bx()
 b.dartException=a
-t=A.m9
+t=A.mc
 if("defineProperty" in Object){Object.defineProperty(b,"message",{get:t})
 b.name=""}else b.toString=t
 return b},
-m9(){return J.bL(this.dartException)},
+mc(){return J.bL(this.dartException)},
 b_(a,b){throw A.G(a,b==null?new Error():b)},
 cr(a,b,c){var t
 if(b==null)b=0
@@ -260,7 +260,7 @@ else if((n&2)!==0){l="unmodifiable "
 m="an "}else l=(n&1)!==0?"fixed-length ":""
 return new A.by("'"+t+"': Cannot "+p+" "+m+l+o)},
 Q(a){throw A.d(A.T(a))},
-ab(a){var t,s,r,q,p,o
+ac(a){var t,s,r,q,p,o
 a=A.fW(a.replace(String({}),"$receiver$"))
 t=a.match(/\\\$[a-zA-Z]+\\\$/g)
 if(t==null)t=A.i([],u.s)
@@ -277,18 +277,18 @@ e5(a,b){var t=b==null,s=t?null:b.method
 return new A.c6(a,s,t?null:b.receiver)},
 eA(a){if(a==null)return new A.d0(a)
 if(typeof a!=="object")return a
-if("dartException" in a)return A.aB(a,a.dartException)
-return A.kU(a)},
-aB(a,b){if(u.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
+if("dartException" in a)return A.aC(a,a.dartException)
+return A.kW(a)},
+aC(a,b){if(u.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
 return b},
-kU(a){var t,s,r,q,p,o,n,m,l,k,j,i,h
+kW(a){var t,s,r,q,p,o,n,m,l,k,j,i,h
 if(!("message" in a))return a
 t=a.message
 if("number" in a&&typeof a.number=="number"){s=a.number
 r=s&65535
-if((B.b.aw(s,16)&8191)===10)switch(r){case 438:return A.aB(a,A.e5(A.p(t)+" (Error "+r+")",null))
+if((B.b.aw(s,16)&8191)===10)switch(r){case 438:return A.aC(a,A.e5(A.p(t)+" (Error "+r+")",null))
 case 445:case 5007:A.p(t)
-return A.aB(a,new A.bm())}}if(a instanceof TypeError){q=$.h1()
+return A.aC(a,new A.bm())}}if(a instanceof TypeError){q=$.h1()
 p=$.h2()
 o=$.h3()
 n=$.h4()
@@ -299,22 +299,22 @@ $.h5()
 j=$.ha()
 i=$.h9()
 h=q.H(t)
-if(h!=null)return A.aB(a,A.e5(A.a3(t),h))
+if(h!=null)return A.aC(a,A.e5(A.a3(t),h))
 else{h=p.H(t)
 if(h!=null){h.method="call"
-return A.aB(a,A.e5(A.a3(t),h))}else if(o.H(t)!=null||n.H(t)!=null||m.H(t)!=null||l.H(t)!=null||k.H(t)!=null||n.H(t)!=null||j.H(t)!=null||i.H(t)!=null){A.a3(t)
-return A.aB(a,new A.bm())}}return A.aB(a,new A.cg(typeof t=="string"?t:""))}if(a instanceof RangeError){if(typeof t=="string"&&t.indexOf("call stack")!==-1)return new A.bt()
+return A.aC(a,A.e5(A.a3(t),h))}else if(o.H(t)!=null||n.H(t)!=null||m.H(t)!=null||l.H(t)!=null||k.H(t)!=null||n.H(t)!=null||j.H(t)!=null||i.H(t)!=null){A.a3(t)
+return A.aC(a,new A.bm())}}return A.aC(a,new A.cg(typeof t=="string"?t:""))}if(a instanceof RangeError){if(typeof t=="string"&&t.indexOf("call stack")!==-1)return new A.bt()
 t=function(b){try{return String(b)}catch(g){}return null}(a)
-return A.aB(a,new A.Z(!1,null,null,typeof t=="string"?t.replace(/^RangeError:\s*/,""):t))}if(typeof InternalError=="function"&&a instanceof InternalError)if(typeof t=="string"&&t==="too much recursion")return new A.bt()
+return A.aC(a,new A.Z(!1,null,null,typeof t=="string"?t.replace(/^RangeError:\s*/,""):t))}if(typeof InternalError=="function"&&a instanceof InternalError)if(typeof t=="string"&&t==="too much recursion")return new A.bt()
 return a},
 ez(a){if(a==null)return J.v(a)
 if(typeof a=="object")return A.bo(a)
 return J.v(a)},
-kX(a){if(typeof a=="number")return B.Y.gv(a)
+kZ(a){if(typeof a=="number")return B.Y.gv(a)
 if(a instanceof A.cp)return A.bo(a)
 if(a instanceof A.U)return a.gv(a)
 return A.ez(a)},
-l3(a,b){var t,s,r,q=a.length
+l5(a,b){var t,s,r,q=a.length
 for(t=0;t<q;t=r){s=t+1
 r=s+1
 b.t(0,a[t],a[s])}return b},
@@ -324,12 +324,12 @@ case 1:return a.$1(c)
 case 2:return a.$2(c,d)
 case 3:return a.$3(c,d,e)
 case 4:return a.$4(c,d,e,f)}throw A.d(new A.da("Unsupported number of arguments for wrapped closure"))},
-kY(a,b){var t=a.$identity
+l_(a,b){var t=a.$identity
 if(!!t)return t
-t=A.kZ(a,b)
+t=A.l0(a,b)
 a.$identity=t
 return t},
-kZ(a,b){var t
+l0(a,b){var t
 switch(b){case 0:t=a.$0
 break
 case 1:t=a.$1
@@ -344,7 +344,7 @@ default:t=null}if(t!=null)return t.bind(a)
 return function(c,d,e){return function(f,g,h,i){return e(c,d,f,g,h,i)}}(a,b,A.jF)},
 im(a1){var t,s,r,q,p,o,n,m,l,k,j=a1.co,i=a1.iS,h=a1.iI,g=a1.nDA,f=a1.aI,e=a1.fs,d=a1.cs,c=e[0],b=d[0],a=j[c],a0=a1.fT
 a0.toString
-t=i?Object.create(new A.cc().constructor.prototype):Object.create(new A.aC(null,null).constructor.prototype)
+t=i?Object.create(new A.cc().constructor.prototype):Object.create(new A.aD(null,null).constructor.prototype)
 t.$initialize=t.constructor
 s=i?function static_tear_off(){this.$initialize()}:function tear_off(a2,a3){this.$initialize(a2,a3)}
 t.constructor=s
@@ -400,7 +400,7 @@ ew(a){return A.im(a)},
 hi(a,b){return A.bH(v.typeUniverse,A.cq(a.a),b)},
 eI(a){return a.a},
 hj(a){return a.b},
-eF(a){var t,s,r,q=new A.aC("receiver","interceptor"),p=Object.getOwnPropertyNames(q)
+eF(a){var t,s,r,q=new A.aD("receiver","interceptor"),p=Object.getOwnPropertyNames(q)
 p.$flags=1
 t=p
 for(p=t.length,s=0;s<p;++s){r=t[s]
@@ -410,7 +410,7 @@ j3(a,b){var t,s
 for(t=0;t<a.length;++t){s=a[t]
 if(!(t<b.length))return A.c(b,t)
 if(!J.L(s,b[t]))return!1}return!0},
-l0(a,b){var t=b.length,s=v.rttc[""+t+";"+a]
+l2(a,b){var t=b.length,s=v.rttc[""+t+";"+a]
 if(s==null)return null
 if(t===0)return s
 if(t===s.length)return s.apply(null,b)
@@ -418,41 +418,41 @@ return s(b)},
 eW(a,b,c,d,e,f){var t=b?"m":"",s=c?"":"i",r=d?"u":"",q=e?"s":"",p=function(g,h){try{return new RegExp(g,h)}catch(o){return o}}(a,t+s+r+q+f)
 if(p instanceof RegExp)return p
 throw A.d(A.eR("Illegal RegExp pattern ("+String(p)+")",a))},
-m3(a,b,c){var t=a.indexOf(b,c)
+m6(a,b,c){var t=a.indexOf(b,c)
 return t>=0},
 fS(a){if(a.indexOf("$",0)>=0)return a.replace(/\$/g,"$$$$")
 return a},
 fW(a){if(/[[\]{}()*+?.\\^$|]/.test(a))return a.replace(/[[\]{}()*+?.\\^$|]/g,"\\$&")
 return a},
 Y(a,b,c){var t
-if(typeof b=="string")return A.m5(a,b,c)
-if(b instanceof A.aI){t=b.gau()
+if(typeof b=="string")return A.m8(a,b,c)
+if(b instanceof A.aJ){t=b.gau()
 t.lastIndex=0
-return a.replace(t,A.fS(c))}return A.m4(a,b,c)},
-m4(a,b,c){var t,s,r,q
+return a.replace(t,A.fS(c))}return A.m7(a,b,c)},
+m7(a,b,c){var t,s,r,q
 for(t=J.eE(b,a),t=t.gq(t),s=0,r="";t.k();){q=t.gp()
 r=r+a.substring(s,q.ga7())+c
 s=q.ga2()}t=r+a.substring(s)
 return t.charCodeAt(0)==0?t:t},
-m5(a,b,c){var t,s,r
+m8(a,b,c){var t,s,r
 if(b===""){if(a==="")return c
 t=a.length
 for(s=c,r=0;r<t;++r)s=s+a[r]+c
 return s.charCodeAt(0)==0?s:s}if(a.indexOf(b,0)<0)return a
 if(a.length<500||c.indexOf("$",0)>=0)return a.split(b).join(c)
 return a.replace(new RegExp(A.fW(b),"g"),A.fS(c))},
-m6(a,b,c,d){var t=a.indexOf(b,d)
+m9(a,b,c,d){var t=a.indexOf(b,d)
 if(t<0)return a
-return A.m7(a,t,t+b.length,c)},
-m7(a,b,c,d){return a.substring(0,b)+d+a.substring(c)},
+return A.ma(a,t,t+b.length,c)},
+ma(a,b,c,d){return a.substring(0,b)+d+a.substring(c)},
 bA:function bA(a,b){this.a=a
 this.b=b},
-aU:function aU(a,b,c){this.a=a
+aV:function aV(a,b,c){this.a=a
 this.b=b
 this.c=c},
 bB:function bB(a){this.a=a},
 b9:function b9(){},
-aF:function aF(a,b,c){this.a=a
+aG:function aG(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
 at:function at(a,b,c){var _=this
@@ -461,7 +461,7 @@ _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-aE:function aE(){},
+aF:function aF(){},
 ap:function ap(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
@@ -486,7 +486,7 @@ bW:function bW(){},
 bX:function bX(){},
 ce:function ce(){},
 cc:function cc(){},
-aC:function aC(a,b){this.a=a
+aD:function aD(a,b){this.a=a
 this.b=b},
 cb:function cb(a){this.a=a},
 a_:function a_(a){var _=this
@@ -531,10 +531,10 @@ _.f=_.e=_.d=_.c=_.b=null
 _.r=0
 _.$ti=a},
 U:function U(){},
-aR:function aR(){},
 aS:function aS(){},
 aT:function aT(){},
-aI:function aI(a,b){var _=this
+aU:function aU(){},
+aJ:function aJ(a,b){var _=this
 _.a=a
 _.b=b
 _.e=_.d=_.c=null},
@@ -563,7 +563,7 @@ f1(a){var t=a.w
 if(t===6||t===7)return A.f1(a.x)
 return t===11||t===12},
 iF(a){return a.as},
-le(a,b){var t,s=b.length
+lg(a,b){var t,s=b.length
 for(t=0;t<s;++t)if(!a[t].b(b[t]))return!1
 return!0},
 F(a){return A.di(v.typeUniverse,a,!1)},
@@ -578,29 +578,29 @@ s=A.ax(a0,t,a2,a3)
 if(s===t)return a1
 return A.fg(a0,s,!0)
 case 8:r=a1.y
-q=A.aW(a0,r,a2,a3)
+q=A.aX(a0,r,a2,a3)
 if(q===r)return a1
 return A.bF(a0,a1.x,q)
 case 9:p=a1.x
 o=A.ax(a0,p,a2,a3)
 n=a1.y
-m=A.aW(a0,n,a2,a3)
+m=A.aX(a0,n,a2,a3)
 if(o===p&&m===n)return a1
 return A.eh(a0,o,m)
 case 10:l=a1.x
 k=a1.y
-j=A.aW(a0,k,a2,a3)
+j=A.aX(a0,k,a2,a3)
 if(j===k)return a1
 return A.fi(a0,l,j)
 case 11:i=a1.x
 h=A.ax(a0,i,a2,a3)
 g=a1.y
-f=A.kR(a0,g,a2,a3)
+f=A.kT(a0,g,a2,a3)
 if(h===i&&f===g)return a1
 return A.ff(a0,h,f)
 case 12:e=a1.y
 a3+=e.length
-d=A.aW(a0,e,a2,a3)
+d=A.aX(a0,e,a2,a3)
 p=a1.x
 o=A.ax(a0,p,a2,a3)
 if(d===e&&o===p)return a1
@@ -611,19 +611,19 @@ b=a2[c-a3]
 if(b==null)return a1
 return b
 default:throw A.d(A.bP("Attempted to substitute unexpected RTI kind "+a))}},
-aW(a,b,c,d){var t,s,r,q,p=b.length,o=A.dj(p)
+aX(a,b,c,d){var t,s,r,q,p=b.length,o=A.dj(p)
 for(t=!1,s=0;s<p;++s){r=b[s]
 q=A.ax(a,r,c,d)
 if(q!==r)t=!0
 o[s]=q}return t?o:b},
-kS(a,b,c,d){var t,s,r,q,p,o,n=b.length,m=A.dj(n)
+kU(a,b,c,d){var t,s,r,q,p,o,n=b.length,m=A.dj(n)
 for(t=!1,s=0;s<n;s+=3){r=b[s]
 q=b[s+1]
 p=b[s+2]
 o=A.ax(a,p,c,d)
 if(o!==p)t=!0
 m.splice(s,3,r,q,o)}return t?m:b},
-kR(a,b,c,d){var t,s=b.a,r=A.aW(a,s,c,d),q=b.b,p=A.aW(a,q,c,d),o=b.c,n=A.kS(a,o,c,d)
+kT(a,b,c,d){var t,s=b.a,r=A.aX(a,s,c,d),q=b.b,p=A.aX(a,q,c,d),o=b.c,n=A.kU(a,o,c,d)
 if(r===s&&p===q&&n===o)return b
 t=new A.ck()
 t.a=r
@@ -633,9 +633,9 @@ return t},
 i(a,b){a[v.arrayRti]=b
 return a},
 fP(a){var t=a.$S
-if(t!=null){if(typeof t=="number")return A.l7(t)
+if(t!=null){if(typeof t=="number")return A.l9(t)
 return a.$S()}return null},
-la(a,b){var t
+lc(a,b){var t
 if(A.f1(b))if(a instanceof A.ah){t=A.fP(a)
 if(t!=null)return t}return A.cq(a)},
 cq(a){if(a instanceof A.r)return A.a(a)
@@ -653,13 +653,13 @@ return A.jD(a,t)},
 jD(a,b){var t=a instanceof A.ah?Object.getPrototypeOf(Object.getPrototypeOf(a)).constructor:b,s=A.jb(v.typeUniverse,t.name)
 b.$ccache=s
 return s},
-l7(a){var t,s=v.types,r=s[a]
+l9(a){var t,s=v.types,r=s[a]
 if(typeof r=="string"){t=A.di(v.typeUniverse,r,!1)
 s[a]=t
 return t}return r},
-l6(a){return A.ay(A.a(a))},
+l8(a){return A.ay(A.a(a))},
 ev(a){var t
-if(a instanceof A.U)return A.l1(a.$r,a.a1())
+if(a instanceof A.U)return A.l3(a.$r,a.a1())
 t=a instanceof A.ah?A.fP(a):null
 if(t!=null)return t
 if(u.R.b(a))return J.hg(a).a
@@ -667,40 +667,40 @@ if(Array.isArray(a))return A.H(a)
 return A.cq(a)},
 ay(a){var t=a.r
 return t==null?a.r=new A.cp(a):t},
-l1(a,b){var t,s,r=b,q=r.length
+l3(a,b){var t,s,r=b,q=r.length
 if(q===0)return u.F
 if(0>=q)return A.c(r,0)
 t=A.bH(v.typeUniverse,A.ev(r[0]),"@<0>")
 for(s=1;s<q;++s){if(!(s<r.length))return A.c(r,s)
 t=A.fj(v.typeUniverse,t,A.ev(r[s]))}return A.bH(v.typeUniverse,t,a)},
-ma(a){return A.ay(A.di(v.typeUniverse,a,!1))},
+md(a){return A.ay(A.di(v.typeUniverse,a,!1))},
 jC(a){var t=this
-t.b=A.kN(t)
+t.b=A.kP(t)
 return t.b(a)},
-kN(a){var t,s,r,q,p
-if(a===u.K)return A.jO
-if(A.aA(a))return A.jX
+kP(a){var t,s,r,q,p
+if(a===u.K)return A.jP
+if(A.aA(a))return A.jZ
 t=a.w
 if(t===6)return A.jz
 if(t===1)return A.fG
-if(t===7)return A.jJ
-s=A.kM(a)
+if(t===7)return A.jK
+s=A.kO(a)
 if(s!=null)return s
 if(t===8){r=a.x
 if(a.y.every(A.aA)){a.f="$i"+r
-if(r==="ak")return A.jM
-if(a===u.o)return A.jL
-return A.jW}}else if(t===10){q=A.l0(a.x,a.y)
+if(r==="ak")return A.jN
+if(a===u.o)return A.jM
+return A.jY}}else if(t===10){q=A.l2(a.x,a.y)
 p=q==null?A.fG:q
 return p==null?A.ej(p):p}return A.jx},
-kM(a){if(a.w===8){if(a===u.S)return A.fC
-if(a===u.i||a===u.H)return A.jN
-if(a===u.N)return A.jV
+kO(a){if(a.w===8){if(a===u.S)return A.fC
+if(a===u.i||a===u.H)return A.jO
+if(a===u.N)return A.jX
 if(a===u.y)return A.en}return null},
 jB(a){var t=this,s=A.jw
 if(A.aA(t))s=A.jm
 else if(t===u.K)s=A.ej
-else if(A.aX(t)){s=A.jy
+else if(A.aY(t)){s=A.jy
 if(t===u.E)s=A.ji
 else if(t===u.w)s=A.jl
 else if(t===u.x)s=A.jf
@@ -715,23 +715,23 @@ else if(t===u.o)s=A.jj
 t.a=s
 return t.a(a)},
 jx(a){var t=this
-if(a==null)return A.aX(t)
-return A.lb(v.typeUniverse,A.la(a,t),t)},
+if(a==null)return A.aY(t)
+return A.ld(v.typeUniverse,A.lc(a,t),t)},
 jz(a){if(a==null)return!0
 return this.x.b(a)},
-jW(a){var t,s=this
-if(a==null)return A.aX(s)
+jY(a){var t,s=this
+if(a==null)return A.aY(s)
 t=s.f
 if(a instanceof A.r)return!!a[t]
 return!!J.az(a)[t]},
-jM(a){var t,s=this
-if(a==null)return A.aX(s)
+jN(a){var t,s=this
+if(a==null)return A.aY(s)
 if(typeof a!="object")return!1
 if(Array.isArray(a))return!0
 t=s.f
 if(a instanceof A.r)return!!a[t]
 return!!J.az(a)[t]},
-jL(a){var t=this
+jM(a){var t=this
 if(a==null)return!1
 if(typeof a=="object"){if(a instanceof A.r)return!!a[t.f]
 return!0}if(typeof a=="function")return!0
@@ -740,7 +740,7 @@ fD(a){if(typeof a=="object"){if(a instanceof A.r)return u.o.b(a)
 return!0}if(typeof a=="function")return!0
 return!1},
 jw(a){var t=this
-if(a==null){if(A.aX(t))return a}else if(t.b(a))return a
+if(a==null){if(A.aY(t))return a}else if(t.b(a))return a
 throw A.G(A.fs(a,t),new Error())},
 jy(a){var t=this
 if(a==null||t.b(a))return a
@@ -748,12 +748,12 @@ throw A.G(A.fs(a,t),new Error())},
 fs(a,b){return new A.bD("TypeError: "+A.f8(a,A.O(b,null)))},
 f8(a,b){return A.c0(a)+": type '"+A.O(A.ev(a),null)+"' is not a subtype of type '"+b+"'"},
 V(a,b){return new A.bD("TypeError: "+A.f8(a,b))},
-jJ(a){var t=this
+jK(a){var t=this
 return t.x.b(a)||A.ee(v.typeUniverse,t).b(a)},
-jO(a){return a!=null},
+jP(a){return a!=null},
 ej(a){if(a!=null)return a
 throw A.G(A.V(a,"Object"),new Error())},
-jX(a){return!0},
+jZ(a){return!0},
 jm(a){return a},
 fG(a){return!1},
 en(a){return!0===a||!1===a},
@@ -775,13 +775,13 @@ throw A.G(A.V(a,"int"),new Error())},
 ji(a){if(typeof a=="number"&&Math.floor(a)===a)return a
 if(a==null)return a
 throw A.G(A.V(a,"int?"),new Error())},
-jN(a){return typeof a=="number"},
+jO(a){return typeof a=="number"},
 fn(a){if(typeof a=="number")return a
 throw A.G(A.V(a,"num"),new Error())},
 fo(a){if(typeof a=="number")return a
 if(a==null)return a
 throw A.G(A.V(a,"num?"),new Error())},
-jV(a){return typeof a=="string"},
+jX(a){return typeof a=="string"},
 a3(a){if(typeof a=="string")return a
 throw A.G(A.V(a,"String"),new Error())},
 jl(a){if(typeof a=="string")return a
@@ -795,7 +795,7 @@ throw A.G(A.V(a,"JSObject?"),new Error())},
 fN(a,b){var t,s,r
 for(t="",s="",r=0;r<a.length;++r,s=", ")t+=s+A.O(a[r],b)
 return t},
-kJ(a,b){var t,s,r,q,p,o,n=a.x,m=a.y
+kL(a,b){var t,s,r,q,p,o,n=a.x,m=a.y
 if(""===n)return"("+A.fN(m,b)+")"
 t=m.length
 s=n.split(",")
@@ -844,9 +844,9 @@ if(m===6){t=a.x
 s=A.O(t,b)
 r=t.w
 return(r===11||r===12?"("+s+")":s)+"?"}if(m===7)return"FutureOr<"+A.O(a.x,b)+">"
-if(m===8){q=A.kT(a.x)
+if(m===8){q=A.kV(a.x)
 p=a.y
-return p.length>0?q+("<"+A.fN(p,b)+">"):q}if(m===10)return A.kJ(a,b)
+return p.length>0?q+("<"+A.fN(p,b)+">"):q}if(m===10)return A.kL(a,b)
 if(m===11)return A.fu(a,b,null)
 if(m===12)return A.fu(a.x,b,a.y)
 if(m===13){o=a.x
@@ -854,7 +854,7 @@ n=b.length
 o=n-1-o
 if(!(o>=0&&o<n))return A.c(b,o)
 return b[o]}return"?"},
-kT(a){var t=v.mangledGlobalNames[a]
+kV(a){var t=v.mangledGlobalNames[a]
 if(t!=null)return t
 return"minified:"+a},
 jc(a,b){var t=a.tR[b]
@@ -910,7 +910,7 @@ return t},
 j7(a,b,c,d){var t,s,r
 if(d){t=b.w
 s=!0
-if(!A.aA(b))if(!(b===u.P||b===u.T))if(t!==6)s=t===7&&A.aX(b.x)
+if(!A.aA(b))if(!(b===u.P||b===u.T))if(t!==6)s=t===7&&A.aY(b.x)
 if(s)return b
 else if(t===1)return u.P}r=new A.a1(null,null)
 r.w=6
@@ -1008,7 +1008,7 @@ if(e){t=c.length
 s=A.dj(t)
 for(r=0,q=0;q<t;++q){p=c[q]
 if(p.w===1){s[q]=p;++r}}if(r>0){o=A.ax(a,b,s,0)
-n=A.aW(a,c,s,0)
+n=A.aX(a,c,s,0)
 return A.ei(a,o,n,c!==n)}}m=new A.a1(null,null)
 m.w=12
 m.x=b
@@ -1157,7 +1157,7 @@ if(r!==8)throw A.d(A.bP("Indexed base must be an interface type"))
 t=b.y
 if(c<=t.length)return t[c-1]
 throw A.d(A.bP("Bad index "+c+" for "+b.j(0)))},
-lb(a,b,c){var t,s=b.d
+ld(a,b,c){var t,s=b.d
 if(s==null)s=b.d=new Map()
 t=s.get(c)
 if(t==null){t=A.C(a,b,null,c,null)
@@ -1197,7 +1197,7 @@ j=n[l]
 if(!A.C(a,k,c,j,e)||!A.C(a,j,e,k,c))return!1}return A.fA(a,b.x,c,d.x,e)}if(r===11){if(b===u.L)return!0
 if(q)return!1
 return A.fA(a,b,c,d,e)}if(t===8){if(r!==8)return!1
-return A.jK(a,b,c,d,e)}if(p&&r===10)return A.jR(a,b,c,d,e)
+return A.jL(a,b,c,d,e)}if(p&&r===10)return A.jT(a,b,c,d,e)
 return!1},
 fA(a2,a3,a4,a5,a6){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1
 if(!A.C(a2,a3.x,a4,a5.x,a6))return!1
@@ -1234,7 +1234,7 @@ h=g[c-1]
 if(!A.C(a2,f[b+2],a6,h,a4))return!1
 break}}while(c<e){if(g[c+1])return!1
 c+=3}return!0},
-jK(a,b,c,d,e){var t,s,r,q,p,o=b.x,n=d.x
+jL(a,b,c,d,e){var t,s,r,q,p,o=b.x,n=d.x
 while(o!==n){t=a.tR[o]
 if(t==null)return!1
 if(typeof t=="string"){o=t
@@ -1247,13 +1247,13 @@ return A.fm(a,q,null,c,d.y,e)}return A.fm(a,b.y,null,c,d.y,e)},
 fm(a,b,c,d,e,f){var t,s=b.length
 for(t=0;t<s;++t)if(!A.C(a,b[t],d,e[t],f))return!1
 return!0},
-jR(a,b,c,d,e){var t,s=b.y,r=d.y,q=s.length
+jT(a,b,c,d,e){var t,s=b.y,r=d.y,q=s.length
 if(q!==r.length)return!1
 if(b.x!==d.x)return!1
 for(t=0;t<q;++t)if(!A.C(a,s[t],c,r[t],e))return!1
 return!0},
-aX(a){var t=a.w,s=!0
-if(!(a===u.P||a===u.T))if(!A.aA(a))if(t!==6)s=t===7&&A.aX(a.x)
+aY(a){var t=a.w,s=!0
+if(!(a===u.P||a===u.T))if(!A.aA(a))if(t!==6)s=t===7&&A.aY(a.x)
 return s},
 aA(a){var t=a.w
 return t===2||t===3||t===4||t===5||a===u.X},
@@ -1272,15 +1272,15 @@ cp:function cp(a){this.a=a},
 cj:function cj(){},
 bD:function bD(a){this.a=a},
 iv(a,b){return new A.a_(a.i("@<0>").U(b).i("a_<1,2>"))},
-e8(a,b,c){return b.i("@<0>").U(c).i("e7<1,2>").a(A.l3(a,new A.a_(b.i("@<0>").U(c).i("a_<1,2>"))))},
-aK(a,b){return new A.a_(a.i("@<0>").U(b).i("a_<1,2>"))},
+e8(a,b,c){return b.i("@<0>").U(c).i("e7<1,2>").a(A.l5(a,new A.a_(b.i("@<0>").U(c).i("a_<1,2>"))))},
+aL(a,b){return new A.a_(a.i("@<0>").U(b).i("a_<1,2>"))},
 iw(a){return new A.au(a.i("au<0>"))},
 cV(a){return new A.au(a.i("au<0>"))},
 eg(){var t=Object.create(null)
 t["<non-identifier-key>"]=t
 delete t["<non-identifier-key>"]
 return t},
-ae(a,b,c){var t=new A.av(a,b,c.i("av<0>"))
+af(a,b,c){var t=new A.av(a,b,c.i("av<0>"))
 t.c=a.e
 return t},
 e9(a,b){var t=A.iw(b)
@@ -1288,7 +1288,7 @@ t.N(0,a)
 return t},
 eb(a){var t,s
 if(A.ey(a))return"{...}"
-t=new A.aQ("")
+t=new A.aR("")
 try{s={}
 B.a.l($.P,a)
 t.a+="{"
@@ -1309,15 +1309,15 @@ _.a=a
 _.b=b
 _.d=_.c=null
 _.$ti=c},
-aL:function aL(){},
+aM:function aM(){},
 cX:function cX(a,b){this.a=a
 this.b=b},
-a9:function a9(){},
+aa:function aa(){},
 bC:function bC(){},
 eX(a,b,c){return new A.bg(a,b)},
 js(a){return a.a5()},
-iW(a,b){return new A.db(a,[],A.l_())},
-iX(a,b,c){var t,s=new A.aQ(""),r=A.iW(s,b)
+iW(a,b){return new A.db(a,[],A.l1())},
+iX(a,b,c){var t,s=new A.aR(""),r=A.iW(s,b)
 r.a6(a)
 t=s.a
 return t.charCodeAt(0)==0?t:t},
@@ -1356,7 +1356,7 @@ return s},
 ea(a,b){var t=A.ix(a,!1,b)
 t.$flags=3
 return t},
-f0(a){return new A.aI(a,A.eW(a,!1,!0,!1,!1,""))},
+f0(a){return new A.aJ(a,A.eW(a,!1,!0,!1,!1,""))},
 f4(a,b,c){var t=J.cs(b)
 if(!t.k())return a
 if(c.length===0){do a+=A.p(t.gp())
@@ -1383,19 +1383,19 @@ ip(a,b,c){var t,s
 if(A.ey(a)){if(b==="("&&c===")")return"(...)"
 return b+"..."+c}t=A.i([],u.s)
 B.a.l($.P,a)
-try{A.jZ(a,t)}finally{if(0>=$.P.length)return A.c($.P,-1)
+try{A.k0(a,t)}finally{if(0>=$.P.length)return A.c($.P,-1)
 $.P.pop()}s=A.f4(b,u.W.a(t),", ")+c
 return s.charCodeAt(0)==0?s:s},
 eT(a,b,c){var t,s
 if(A.ey(a))return b+"..."+c
-t=new A.aQ(b)
+t=new A.aR(b)
 B.a.l($.P,a)
 try{s=t
 s.a=A.f4(s.a,a,", ")}finally{if(0>=$.P.length)return A.c($.P,-1)
 $.P.pop()}t.a+=c
 s=t.a
 return s.charCodeAt(0)==0?s:s},
-jZ(a,b){var t,s,r,q,p,o,n,m=a.gq(a),l=0,k=0
+k0(a,b){var t,s,r,q,p,o,n,m=a.gq(a),l=0,k=0
 for(;;){if(!(l<80||k<3))break
 if(!m.k())return
 t=A.p(m.gp())
@@ -1487,16 +1487,16 @@ this.b=b
 this.$ti=c},
 bl:function bl(){},
 r:function r(){},
-aO:function aO(a){var _=this
+aP:function aP(a){var _=this
 _.a=a
 _.c=_.b=0
 _.d=-1},
-aQ:function aQ(a){this.a=a},
+aR:function aR(a){this.a=a},
 eJ(a,b,c,d,e,f){var t,s,r,q
 if(a.c!==f)return!1
 t=a.d
 if(!t.h(0,c))return!1
-for(t=A.ae(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){r=t.d
+for(t=A.af(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){r=t.d
 if(r==null)r=s.a(r)
 if(r!==c&&!b.h(0,r))return!1}t=a.e
 q=new A.b(t,A.a(t).i("b<2>"))
@@ -1545,9 +1545,9 @@ t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.f)&&s.h(0,B.e)&&s.h(0,B.d)},
 hy(a,b){if(b===B.t&&a===B.D)return!0
-return a===B.w||a===B.N||a===B.R||a===B.q||a===B.I},
+return a===B.w||a===B.N||a===B.R||a===B.r||a===B.I},
 ht(a,b){var t
-if(!A.aD(a.c))return!1
+if(!A.aE(a.c))return!1
 if(b)return!1
 t=a.e
 return!new A.b(t,A.a(t).i("b<2>")).h(0,B.d)},
@@ -1562,7 +1562,7 @@ if(A.X(s,t)!==2)return!1
 t=a.e
 q=new A.b(t,A.a(t).i("b<2>"))
 p=q.h(0,B.e)||q.h(0,B.k)||q.h(0,B.G)||q.h(0,B.C)
-o=q.h(0,B.h)||q.h(0,B.r)
+o=q.h(0,B.h)||q.h(0,B.q)
 return q.h(0,B.f)&&p&&q.h(0,B.d)&&o},
 hv(a,b){var t,s,r,q
 if(!b)return!1
@@ -1573,7 +1573,7 @@ r=a.e
 q=new A.b(r,A.a(r).i("b<2>"))
 return(s?q.h(0,B.G):q.h(0,B.C))&&q.h(0,B.h)},
 hx(a,b){var t,s,r=a.c
-if(r===B.af||r===B.ap)return!0
+if(r===B.ag||r===B.ap)return!0
 if(A.S(r)===B.z&&!b&&!a.d.h(0,B.n)){t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 if(!(s.h(0,B.d)||s.h(0,B.p)||s.h(0,B.v)))return!0}return!1},
@@ -1588,33 +1588,33 @@ t=a.a
 s=a.b
 if(t===s)return!1
 r=A.hn(a.e.n(0,A.X(s,t)))
-for(t=a.d,t=A.ae(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){q=t.d
+for(t=a.d,t=A.af(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){q=t.d
 if(q==null)q=s.a(q)
 if(q===r)continue
-if(q===B.w||q===B.N||q===B.q||q===B.I)return!0}return!1},
+if(q===B.w||q===B.N||q===B.r||q===B.I)return!0}return!1},
 hn(a){var t
 A:{if(B.H===a){t=B.w
 break A}if(B.X===a){t=B.N
-break A}if(B.M===a){t=B.q
+break A}if(B.M===a){t=B.r
 break A}if(B.a6===a){t=B.I
-break A}if(B.ag===a){t=B.n
+break A}if(B.ah===a){t=B.n
 break A}if(B.a_===a){t=B.o
 break A}if(B.a7===a){t=B.l
 break A}if(B.ac===a){t=B.J
 break A}if(B.av===a){t=B.R
-break A}if(B.ah===a){t=B.R
+break A}if(B.ad===a){t=B.R
 break A}if(B.a4===a){t=B.D
 break A}if(B.aq===a){t=B.a1
 break A}t=null
 break A}return t},
 hl(a){var t=a.e.n(0,A.X(a.b,a.a))
 if(t==null)return!1
-return!(t===B.f||t===B.e||t===B.k||t===B.d||t===B.p||t===B.v||t===B.a5||t===B.h||t===B.r||t===B.W)},
+return!(t===B.f||t===B.e||t===B.k||t===B.d||t===B.p||t===B.v||t===B.a5||t===B.h||t===B.q||t===B.W)},
 dY(a){var t=a.e.n(0,A.X(a.b,a.a))
 if(t===B.f)return 0
 if(t===B.k||t===B.e)return 1
 if(t===B.d)return 2
-if(t===B.W||t===B.h||t===B.r)return 3
+if(t===B.W||t===B.h||t===B.q)return 3
 return 4},
 R:function R(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6){var _=this
 _.a=a
@@ -1710,10 +1710,10 @@ k=l!==B.t
 if((!k||l===B.E)&&(m&512)!==0&&b1!==9)return a9
 j=A.S(l)===B.z
 i=A.cV(u.G)
-if((m&2)!==0)i.l(0,j||A.aD(l)?B.w:B.as)
+if((m&2)!==0)i.l(0,j||A.aE(l)?B.w:B.as)
 if((m&8)!==0){if(!j)h=!(!k||l===B.O||l===B.V)
 else h=!0
-i.l(0,h?B.N:B.R)}if((m&64)!==0)i.l(0,B.q)
+i.l(0,h?B.N:B.R)}if((m&64)!==0)i.l(0,B.r)
 if((m&256)!==0)i.l(0,B.I)
 if((m&4)!==0)i.l(0,j?B.n:B.J)
 if((m&32)!==0)i.l(0,j?B.o:B.D)
@@ -1740,7 +1740,7 @@ if(a5===0)continue
 a0+=a5
 a1=(a1|j)>>>0
 if(!k)B.a.l(a,a4.b+"="+B.Y.Z(a5,2))}if(a0!==0){e+=a0
-b0.$4$detail$intervals("color tones",a0,k?a9:B.a.G(a," "),a1)}if(A.aD(l)&&(b4&128)===0&&A.aZ(b4)===3){e+=0.45
+b0.$4$detail$intervals("color tones",a0,k?a9:B.a.G(a," "),a1)}if(A.aE(l)&&(b4&128)===0&&A.aZ(b4)===3){e+=0.45
 b0.$2("fifthless sixth",0.45)}k=a2!==0
 if(k&&l===B.ao)return a9
 if(k){a6=A.aZ(a2)*2
@@ -1751,7 +1751,7 @@ b0.$4$detail$intervals("missing required",a7,"count="+n,r)}a8=d?0:A.hA(g.n(0,b1)
 if(a8!==0){e+=a8
 b0.$3$detail("bass fit",a8,"interval="+b1)}return new A.df(e,i,g)},
 hN(a){var t
-A:{if(B.af===a||B.a3===a||B.B===a||B.V===a||B.L===a||B.F===a||B.A===a||B.S===a){t=0.1
+A:{if(B.ag===a||B.a3===a||B.B===a||B.V===a||B.L===a||B.F===a||B.A===a||B.S===a){t=0.1
 break A}if(B.y===a||B.x===a||B.aa===a||B.Z===a){t=0.4
 break A}t=A.eO(a)
 if(t){t=1
@@ -1761,7 +1761,7 @@ eL(a){var t
 A:{t=B.u===a||B.a9===a||B.S===a||B.y===a||B.x===a
 break A}return t},
 hE(a){var t
-if(!A.eL(a))A:{t=B.t===a||B.O===a||B.K===a||B.E===a||B.ae===a||B.U===a||B.A===a||B.ap===a||B.aa===a||B.a3===a
+if(!A.eL(a))A:{t=B.t===a||B.O===a||B.K===a||B.E===a||B.af===a||B.U===a||B.A===a||B.ap===a||B.aa===a||B.a3===a
 break A}else t=!0
 return t},
 hM(a,b,c,d,e,f,g){var t,s,r=(e&4)===0,q=g.n(0,4)===B.e
@@ -1796,7 +1796,7 @@ o=f.n(0,6)===B.p&&f.n(0,3)===B.k
 if(e===B.a6&&!l.$1(7)&&!o&&c!==B.A)q+=0.5
 t=e===B.H
 r=!t
-if(!r||e===B.X)n=f.S(B.G)||f.S(B.ag)||f.S(B.ac)
+if(!r||e===B.X)n=f.S(B.G)||f.S(B.ah)||f.S(B.ac)
 else n=!1
 if(n)q+=0.4
 n=!1
@@ -1804,14 +1804,14 @@ if(t)if(b)C:{t=B.O===c||B.K===c||B.T===c||B.Z===c
 break C}else t=n
 else t=n
 if(t)q+=0.3
-if(a)t=!r||e===B.ah
+if(a)t=!r||e===B.ad
 else t=!1
 if(t)q+=0.15
 if(!(A.eL(c)&&l.$1(10)))m=!(s&&A.hE(c))
 else m=!1
 return m?q*2:q},
 b4(a){var t
-A:{t=B.B===a||B.V===a||B.L===a||B.F===a||B.A===a||B.an===a||B.ab===a||B.a2===a||B.T===a||B.Z===a||B.am===a||B.af===a||B.a3===a||B.a9===a
+A:{t=B.B===a||B.V===a||B.L===a||B.F===a||B.A===a||B.an===a||B.ab===a||B.a2===a||B.T===a||B.Z===a||B.am===a||B.ag===a||B.a3===a||B.a9===a
 break A}return t},
 hG(a,b,c){if(A.S(c.a)!==B.z)return!1
 if((b&3584)===0)return!1
@@ -1829,10 +1829,10 @@ break A}if(a==null)return 1
 B:{if(B.f===a){t=0
 break B}if(B.G===a||B.C===a){t=0.7
 break B}if(B.p===a||B.v===a){t=t?0.15:0.3
-break B}if(B.k===a||B.e===a||B.d===a||B.a5===a||B.W===a||B.h===a||B.r===a){t=0.15
-break B}if(B.ag===a||B.a_===a||B.a7===a){t=0.3
+break B}if(B.k===a||B.e===a||B.d===a||B.a5===a||B.W===a||B.h===a||B.q===a){t=0.15
+break B}if(B.ah===a||B.a_===a||B.a7===a){t=0.3
 break B}if(B.ac===a||B.a4===a||B.aq===a){t=0.65
-break B}if(B.H===a||B.X===a||B.M===a||B.a6===a||B.ah===a||B.av===a){t=0.5
+break B}if(B.H===a||B.X===a||B.M===a||B.a6===a||B.ad===a||B.av===a){t=0.5
 break B}t=null}return t},
 hD(a,b,c){var t=c.a
 if(A.hL(a,b)&&A.hF(t,b))return 8
@@ -1881,7 +1881,7 @@ for(q=t.length,p=e8!=null,r=0;r<t.length;t.length===q||(0,A.Q)(t),++r){o=t[r].a
 n=o.c
 m=o.a===o.b
 l=o.d
-k=A.l2(l,A.ic(n))
+k=A.l4(l,A.ic(n))
 j=k.a
 i=j[2]
 h=j[1]
@@ -1905,7 +1905,7 @@ a3=o.e
 a9=new A.b(a3,A.a(a3).i("b<2>")).h(0,B.e)
 b0=l.h(0,B.D)||l.h(0,B.o)
 b1=a9&&b0
-b2=A.aD(n)
+b2=A.aE(n)
 b3=A.S(n)
 b4=A.e1(n)
 b5=A.hw(o,m)
@@ -1916,7 +1916,7 @@ A.ht(o,m)
 b9=A.hq(o)
 A.dY(o)
 c0=A.hv(o,m)
-if(m)c1=(n===B.t||n===B.E||n===B.O||n===B.ae)&&j[1]===0&&j[2]===0
+if(m)c1=(n===B.t||n===B.E||n===B.O||n===B.af)&&j[1]===0&&j[2]===0
 else c1=!1
 c2=A.hx(o,m)
 a=n===B.ab||n===B.a9||n===B.S||!a||n===B.x||n===B.am||n===B.aa||n===B.T||n===B.Z
@@ -2017,10 +2017,10 @@ t=(t&t-1)>>>0
 r=$.eD()
 if(!(s>=0&&s<15))return A.c(r,s)
 q=r[s].b.$5(a,b,c,d,f)
-if(q!=null&&q!==0)return new A.aN(q,!0)}if(Math.abs(o)>0.25)return new A.aN(o>0?1:-1,!1)
+if(q!=null&&q!==0)return new A.aO(q,!0)}if(Math.abs(o)>0.25)return new A.aO(o>0?1:-1,!1)
 for(r=$.hd(),p=0;p<32;++p){q=r[p].b.$5(a,b,c,d,f)
-if(q!=null&&q!==0)return new A.aN(q,!1)}return new A.aN(B.b.A(a.a.a,b.a.a),!1)},
-aN:function aN(a,b){this.a=a
+if(q!=null&&q!==0)return new A.aO(q,!1)}return new A.aO(B.b.A(a.a.a,b.a.a),!1)},
+aO:function aO(a,b){this.a=a
 this.d=b},
 cA:function cA(a){this.a=a},
 cB:function cB(a,b,c){this.a=a
@@ -2034,7 +2034,7 @@ _.b=b
 _.c=c
 _.d=d
 _.e=e},
-lh(a,b,c,d,e){var t,s,r,q,p,o,n,m=null
+lj(a,b,c,d,e){var t,s,r,q,p,o,n,m=null
 if(Math.abs(a.b-b.b)>0.25)return m
 if(c.ry!==d.ry)return m
 if(c.ok!==d.ok)return m
@@ -2062,7 +2062,7 @@ return a.c.b+"|"+new A.N(t,s.i("k(1)").a(new A.dq()),s.i("N<1,k>")).G(0,",")},
 dp:function dp(){},
 dq:function dq(){},
 h(a,b,c){return new A.bk(a,b,c)},
-kh(a,b,c,d,e){var t,s=null,r=a.a,q=A.es(r),p=b.a,o=A.es(p),n=A.eq(r),m=A.eq(p)
+kj(a,b,c,d,e){var t,s=null,r=a.a,q=A.es(r),p=b.a,o=A.es(p),n=A.eq(r),m=A.eq(p)
 if(!(q&&m))t=!(o&&n)
 else t=!1
 if(t)return s
@@ -2078,9 +2078,9 @@ t=t.a===2&&t.h(0,B.w)&&t.h(0,B.n)}else t=!1
 return t},
 eq(a){var t
 if(a.c===B.u){t=a.d
-t=t.a===2&&t.h(0,B.q)&&t.h(0,B.I)}else t=!1
+t=t.a===2&&t.h(0,B.r)&&t.h(0,B.I)}else t=!1
 return t},
-kB(a,b,c,d,e){var t,s,r,q,p=c.r
+kD(a,b,c,d,e){var t,s,r,q,p=c.r
 if(p===d.r)return null
 t=p?b:a
 s=!(p?d:c).a
@@ -2089,10 +2089,10 @@ q=s&&t.a.c===B.a3
 if(!r&&!q)return null
 if((p?a:b).b>t.b+1.3)return null
 return p?-1:1},
-kH(a,b,c,d,e){var t=c.to
+kJ(a,b,c,d,e){var t=c.to
 if(t===d.to)return null
 return t?-1:1},
-k_(a,b,c,d,e){var t,s,r,q=c.b
+k1(a,b,c,d,e){var t,s,r,q=c.b
 if(q===d.b)return null
 t=q?c:d
 s=q?d:c
@@ -2100,7 +2100,7 @@ if(t.a)r=!A.fz((q?a:b).a)&&!s.a&&s.ok===0
 else r=!1
 if(r)return q?-1:1
 return null},
-ke(a,b,c,d,e){var t,s,r=A.fB(a.a),q=A.fB(b.a)
+kg(a,b,c,d,e){var t,s,r=A.fB(a.a),q=A.fB(b.a)
 if(r===q)return null
 t=c.w
 s=d.w
@@ -2108,13 +2108,13 @@ if(r&&s)return 1
 if(q&&t)return-1
 return null},
 fz(a){var t
-if(!A.aD(a.c))return!1
+if(!A.aE(a.c))return!1
 t=a.e
 return!new A.b(t,A.a(t).i("b<2>")).h(0,B.d)},
 fB(a){if(!A.fz(a))return!1
 if(a.a!==a.b)return!0
 return a.d.a===0},
-kt(a,b,c,d,e){var t=A.fE(a.a,d)
+kv(a,b,c,d,e){var t=A.fE(a.a,d)
 if(t===A.fE(b.a,c))return null
 return t?-1:1},
 fE(a,b){var t,s,r
@@ -2126,8 +2126,8 @@ if(a.c!==B.K)return!1
 if(A.X(s,t)!==2)return!1
 t=a.e
 r=new A.b(t,A.a(t).i("b<2>"))
-return r.h(0,B.f)&&r.h(0,B.e)&&r.h(0,B.d)&&r.h(0,B.r)},
-k8(a,b,c,d,e){var t,s,r=A.eo(a.a)
+return r.h(0,B.f)&&r.h(0,B.e)&&r.h(0,B.d)&&r.h(0,B.q)},
+ka(a,b,c,d,e){var t,s,r=A.eo(a.a)
 if(r===A.eo(b.a))return null
 t=r?b:a
 s=r?d:c
@@ -2145,7 +2145,7 @@ if(s.O(0,new A.dt()))return!1
 s=a.e
 r=new A.b(s,A.a(s).i("b<2>"))
 return r.h(0,B.f)&&r.h(0,B.X)&&r.h(0,B.e)&&r.h(0,t)&&r.h(0,B.h)},
-k9(a,b,c,d,e){var t,s=A.fv(a.a)
+kb(a,b,c,d,e){var t,s=A.fv(a.a)
 if(s===A.fv(b.a))return null
 t=s?d:c
 if(t.CW)return null
@@ -2159,25 +2159,25 @@ if(t.O(0,new A.du()))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.f)&&s.h(0,B.H)&&s.h(0,B.e)&&s.h(0,B.d)&&s.h(0,B.a6)&&s.h(0,B.h)},
-jU(a,b){var t,s,r
+jW(a,b){var t,s,r
 if(!b.b||!b.k4)return!1
 t=a.d
 if(!t.h(0,B.w))return!1
 s=t.a
 if(s!==1){r=!1
-if(!(s===2&&t.h(0,B.R)))if(t.a===3)if(t.h(0,B.R))s=t.h(0,B.q)||t.h(0,B.D)
+if(!(s===2&&t.h(0,B.R)))if(t.a===3)if(t.h(0,B.R))s=t.h(0,B.r)||t.h(0,B.D)
 else s=r
 else s=r
 else s=!0}else s=!0
 return s},
 fI(a,b){var t,s,r
-if(A.jU(a,b))return!0
+if(A.jW(a,b))return!0
 if(!b.k4||b.c)return!1
 t=a.d
 s=t.h(0,B.w)||t.h(0,B.as)
-r=t.h(0,B.R)||t.h(0,B.q)||t.h(0,B.D)||t.h(0,B.l)||t.h(0,B.a1)||t.h(0,B.I)
+r=t.h(0,B.R)||t.h(0,B.r)||t.h(0,B.D)||t.h(0,B.l)||t.h(0,B.a1)||t.h(0,B.I)
 return s&&r},
-k7(a,b,c,d,e){var t,s,r,q,p=A.dw(a.a,c)
+k9(a,b,c,d,e){var t,s,r,q,p=A.dw(a.a,c)
 if(p===A.dw(b.a,d))return null
 t=p?b:a
 s=p?d:c
@@ -2191,9 +2191,9 @@ if(a.c!==B.u)return!1
 if(!b.k4)return!1
 t=a.d
 if(!t.h(0,B.w))return!1
-for(t=A.ae(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){r=t.d
+for(t=A.af(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){r=t.d
 if(r==null)r=s.a(r)
-if(r!==B.w&&r!==B.N&&r!==B.q)return!1}t=a.e
+if(r!==B.w&&r!==B.N&&r!==B.r)return!1}t=a.e
 q=new A.b(t,A.a(t).i("b<2>"))
 return q.h(0,B.f)&&q.h(0,B.e)&&q.h(0,B.h)&&q.h(0,B.H)},
 jI(a,b){var t,s
@@ -2202,7 +2202,7 @@ if(b.ok===0)return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.f)&&s.h(0,B.k)&&s.h(0,B.p)},
-ko(a,b,c,d,e){var t,s,r,q=null,p=c.id
+kq(a,b,c,d,e){var t,s,r,q=null,p=c.id
 if(p===d.id)return q
 t=p?b:a
 s=(p?d:c).a&&t.a.c===B.A
@@ -2211,7 +2211,7 @@ if(!s&&r.c!==B.B)return q
 if(e.b===B.m&&s&&r.a===e.a.e)return q
 if((p?a:b).b>t.b+0.35)return q
 return p?-1:1},
-k1(a,b,c,d,e){var t,s,r,q=null,p=c.CW,o=c.e,n=d.e
+k3(a,b,c,d,e){var t,s,r,q=null,p=c.CW,o=c.e,n=d.e
 if(!(p&&n))t=d.CW&&o
 else t=!0
 if(!t)return q
@@ -2223,7 +2223,7 @@ if(!r.k1)return q
 if(!r.k3)return q
 if(!s.RG)return q
 return p?-1:1},
-kG(a,b,c,d,e){var t,s,r,q=null
+kI(a,b,c,d,e){var t,s,r,q=null
 if(!c.CW||!d.CW)return q
 if(c.a===d.a)return q
 t=c.dx
@@ -2233,14 +2233,14 @@ if(!s.dx||!r.db)return q
 if(!s.dy||!r.dy)return q
 if(s.k3&&!s.fr)return t?-1:1
 else return t?1:-1},
-kA(a,b,c,d,e){var t,s=null,r=A.et(a.a,c)
+kC(a,b,c,d,e){var t,s=null,r=A.et(a.a,c)
 if(r===A.et(b.a,d))return s
 t=r?d:c
 if(!t.cx)return s
 if(!t.k1)return s
 if(!t.dy)return s
 return r?-1:1},
-kz(a,b,c,d,e){var t,s,r,q,p,o=c.at
+kB(a,b,c,d,e){var t,s,r,q,p,o=c.at
 if(o===d.at)return null
 t=o?a.a:b.a
 if((o?c:d).p3.a[1]>0){s=!1
@@ -2254,24 +2254,24 @@ if(q===B.t||q===B.E){s=r.p3.a
 p=s[1]===0&&s[2]===0}else p=!1
 if(p)return o?1:-1
 return o?-1:1},
-kb(a,b,c,d,e){var t=A.fw(a.a,c)
+kd(a,b,c,d,e){var t=A.fw(a.a,c)
 if(t===A.fw(b.a,d))return null
-if(!A.jS((t?b:a).a))return null
+if(!A.jU((t?b:a).a))return null
 return t?-1:1},
 fw(a,b){var t,s
 if(!b.y)return!1
 t=a.d
-if(t.a!==1||!t.h(0,B.q))return!1
+if(t.a!==1||!t.h(0,B.r))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.f)&&s.h(0,B.e)&&s.h(0,B.d)&&s.h(0,B.M)},
-jS(a){var t,s
+jU(a){var t,s
 if(a.c!==B.aa)return!1
 if(!a.d.h(0,B.l))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
-return s.h(0,B.f)&&s.h(0,B.C)&&s.h(0,B.r)&&s.h(0,B.a7)&&!s.h(0,B.e)&&!s.h(0,B.d)},
-ka(a,b,c,d,e){var t,s=c.y
+return s.h(0,B.f)&&s.h(0,B.C)&&s.h(0,B.q)&&s.h(0,B.a7)&&!s.h(0,B.e)&&!s.h(0,B.d)},
+kc(a,b,c,d,e){var t,s=c.y
 if(s===d.y)return null
 t=s?d:c
 if(!t.c||!t.k3)return null
@@ -2281,10 +2281,10 @@ if(!b.db&&!b.dx)return!1
 if(!b.dy)return!1
 t=a.d
 if(!t.h(0,B.n))return!1
-if(!t.h(0,B.q))return!1
+if(!t.h(0,B.r))return!1
 s=A.X(a.b,a.a)
 return s===0||s===4||s===7||s===10},
-k6(a,b,c,d,e){var t,s,r=A.fx(a.a)
+k8(a,b,c,d,e){var t,s,r=A.fx(a.a)
 if(r===A.fx(b.a))return null
 t=r?b:a
 s=r?d:c
@@ -2293,25 +2293,25 @@ return r?-1:1},
 fx(a){var t,s
 if(a.c!==B.u)return!1
 t=a.d
-if(t.a!==3||!t.h(0,B.N)||!t.h(0,B.q)||!t.h(0,B.l))return!1
+if(t.a!==3||!t.h(0,B.N)||!t.h(0,B.r)||!t.h(0,B.l))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.f)&&s.h(0,B.X)&&s.h(0,B.e)&&s.h(0,B.M)&&s.h(0,B.d)&&s.h(0,B.a7)&&s.h(0,B.h)},
 jH(a,b){var t,s
 if(a.c!==B.U||!b.k4)return!1
 t=a.d
-if(t.a!==3||!t.h(0,B.w)||!t.h(0,B.q)||!t.h(0,B.l))return!1
+if(t.a!==3||!t.h(0,B.w)||!t.h(0,B.r)||!t.h(0,B.l))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.f)&&s.h(0,B.H)&&s.h(0,B.k)&&s.h(0,B.M)&&s.h(0,B.d)&&s.h(0,B.a7)&&s.h(0,B.h)},
-k5(a,b,c,d,e){var t,s,r,q,p,o,n=null,m=A.em(a.a)
+k7(a,b,c,d,e){var t,s,r,q,p,o,n=null,m=A.em(a.a)
 if(m===A.em(b.a))return n
 t=m?b:a
 s=m?a:b
 r=m?c:d
 q=m?d:c
 p=s.a
-if(!p.d.h(0,B.q)&&!r.a)return n
+if(!p.d.h(0,B.r)&&!r.a)return n
 o=t.a
 if(A.et(o,q)&&A.jd(p,e))return n
 if(!A.fF(o)&&!A.fH(o))return n
@@ -2336,7 +2336,7 @@ if(!a.d.h(0,B.o))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.f)&&s.h(0,B.e)&&s.h(0,B.a_)&&s.h(0,B.v)&&s.h(0,B.h)},
-kj(a,b,c,d,e){var t,s,r=null,q=c.d
+kl(a,b,c,d,e){var t,s,r=null,q=c.d
 if(!q&&!d.d)return r
 if(q&&d.d){q=d.a
 if(c.a===q)return r
@@ -2345,7 +2345,7 @@ s=d.d&&d.a
 if(t===s)return r
 if(!(t?!d.a:!c.a))return r
 return s?1:-1},
-kk(a,b,c,d,e){var t,s,r,q,p,o,n=null,m=c.db&&c.dy
+km(a,b,c,d,e){var t,s,r,q,p,o,n=null,m=c.db&&c.dy
 if(m===(d.db&&d.dy))return n
 t=m?c:d
 s=m?d:c
@@ -2362,7 +2362,7 @@ if(o.h(0,B.e))if(!o.h(0,B.d))p=o.h(0,B.a_)||o.h(0,B.a4)
 if(p)return n
 if(r.b>q.b+0.45)return n
 return m?-1:1},
-ky(a,b,c,d,e){var t,s,r,q,p,o=null
+kA(a,b,c,d,e){var t,s,r,q,p,o=null
 if(!c.cx||!d.cx)return o
 t=c.a
 if(t===d.a)return o
@@ -2372,11 +2372,11 @@ q=t?a:b
 p=t?b:a
 if(!s.dy||!r.dy)return o
 if(!s.R8||r.R8)return o
-if(A.jY(q,p))return o
+if(A.k_(q,p))return o
 if(q.b>p.b+0.3)return o
 return t?-1:1},
-jY(a,b){var t,s,r=a.a.d,q=b.a,p=q.d
-if(r.a===1)t=r.h(0,B.q)||r.h(0,B.I)
+k_(a,b){var t,s,r=a.a.d,q=b.a,p=q.d
+if(r.a===1)t=r.h(0,B.r)||r.h(0,B.I)
 else t=!1
 if(!t)return!1
 s=!1
@@ -2384,7 +2384,7 @@ if(p.a===1)if(p.h(0,B.n)){q=q.c
 q=q===B.x||q===B.y
 s=q}if(!s)return!1
 return b.b<=a.b},
-kv(a,b,c,d,e){var t,s,r,q=null,p=c.Q
+kx(a,b,c,d,e){var t,s,r,q=null,p=c.Q
 if(p===d.Q)return q
 t=p?d:c
 s=p?a:b
@@ -2393,7 +2393,7 @@ if(!t.k1)return q
 if(t.p1===0&&!t.ch)return q
 if(s.b>r.b+0.6)return q
 return p?-1:1},
-kf(a,b,c,d,e){var t,s,r,q,p,o=null,n=c.p2
+kh(a,b,c,d,e){var t,s,r,q,p,o=null,n=c.p2
 if(n===d.p2)return o
 t=n?a:b
 s=n?b:a
@@ -2408,7 +2408,7 @@ if(A.eu(p))return o
 if(q.k2>=r.k2)return o
 if(s.b>t.b+0.7)return o
 return n?1:-1},
-kx(a,b,c,d,e){var t,s,r,q=null,p=c.ax
+kz(a,b,c,d,e){var t,s,r,q=null,p=c.ax
 if(p===d.ax)return q
 t=p?d:c
 if(!t.f||!t.k1)return q
@@ -2418,7 +2418,7 @@ if(!A.jA(s.a))return q
 if(s.b>r.b+1.5)return q
 return p?-1:1},
 jA(a){return a.d.aC(0,new A.ds())},
-kc(a,b,c,d,e){var t,s,r,q,p,o=null
+ke(a,b,c,d,e){var t,s,r,q,p,o=null
 if(c.x){t=c.p3.a
 s=t[1]===0&&t[2]===0}else s=!1
 if(d.x){t=d.p3.a
@@ -2429,15 +2429,15 @@ p=s?b:a
 if(!q.c)return o
 t=q.p3.a
 if(t[1]>0)return o
-if(t[2]>0&&!A.jT(p.a))return o
+if(t[2]>0&&!A.jV(p.a))return o
 return s?-1:1},
-jT(a){var t,s
+jV(a){var t,s
 if(A.S(a.c)!==B.z)return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 if(s.h(0,B.d)||s.h(0,B.p)||s.h(0,B.v))return!1
 return a.d.aC(0,new A.dv())},
-kE(a,b,c,d,e){var t,s,r,q,p=null,o=!c.c&&!c.f&&c.rx
+kG(a,b,c,d,e){var t,s,r,q,p=null,o=!c.c&&!c.f&&c.rx
 if(o===(!d.c&&!d.f&&d.rx))return p
 t=o?d:c
 if(!t.c)return p
@@ -2450,7 +2450,7 @@ r=o?a:b
 q=o?b:a
 if(r.b>q.b+1.5)return p
 return o?-1:1},
-kw(a,b,c,d,e){var t,s,r,q=null,p=a.a,o=A.er(p)||A.fy(p)
+ky(a,b,c,d,e){var t,s,r,q=null,p=a.a,o=A.er(p)||A.fy(p)
 p=b.a
 if(o===(A.er(p)||A.fy(p)))return q
 t=o?a:b
@@ -2458,7 +2458,7 @@ s=o?b:a
 p=t.a
 if(A.er(p)&&p.b===p.a)return q
 r=s.a
-if(!(A.jP(r)||A.jQ(r)))return q
+if(!(A.jQ(r)||A.jR(r)))return q
 if(p.a!==r.a||p.b!==r.b||p.f!==r.f)return q
 if(A.dn(t,s,e,15)!==-1)return q
 if(t.b>s.b+1.5)return q
@@ -2466,37 +2466,37 @@ return o?-1:1},
 er(a){var t,s
 if(a.c!==B.t)return!1
 t=a.d
-if(t.a!==1||!t.h(0,B.q))return!1
+if(t.a!==1||!t.h(0,B.r))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.f)&&s.h(0,B.e)&&s.h(0,B.M)&&!s.h(0,B.d)},
 fy(a){var t,s
 if(a.c!==B.K)return!1
 t=a.d
-if(t.a!==1||!t.h(0,B.q))return!1
+if(t.a!==1||!t.h(0,B.r))return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
-return s.h(0,B.f)&&s.h(0,B.e)&&s.h(0,B.r)&&s.h(0,B.M)&&!s.h(0,B.d)},
-jP(a){var t,s
+return s.h(0,B.f)&&s.h(0,B.e)&&s.h(0,B.q)&&s.h(0,B.M)&&!s.h(0,B.d)},
+jQ(a){var t,s
 if(a.c!==B.a2)return!1
 if(a.d.a!==0)return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return s.h(0,B.f)&&s.h(0,B.e)&&s.h(0,B.p)&&!s.h(0,B.d)},
-jQ(a){var t,s
+jR(a){var t,s
 if(a.c!==B.T)return!1
 if(a.d.a!==0)return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
-return s.h(0,B.f)&&s.h(0,B.e)&&s.h(0,B.p)&&s.h(0,B.r)&&!s.h(0,B.d)},
-kd(a,b,c,d,e){var t,s,r=c.x
+return s.h(0,B.f)&&s.h(0,B.e)&&s.h(0,B.p)&&s.h(0,B.q)&&!s.h(0,B.d)},
+kf(a,b,c,d,e){var t,s,r=c.x
 if(r===d.x)return null
 if(!(r?d:c).ay)return null
 t=r?a:b
 s=r?b:a
 if(t.b>s.b+0.45)return null
 return r?-1:1},
-kl(a,b,c,d,e){var t,s,r=null,q=c.dx
+kn(a,b,c,d,e){var t,s,r=null,q=c.dx
 if(q===d.dx)return r
 t=q?c:d
 s=q?d:c
@@ -2506,15 +2506,15 @@ if(!s.c)return r
 if(s.CW)return r
 if(!s.k1)return r
 return q?-1:1},
-kp(a,b,c,d,e){var t,s,r,q,p=c.ry>0
+kr(a,b,c,d,e){var t,s,r,q,p=c.ry>0
 if(p===d.ry>0)return null
 t=p?b:a
 s=p?a:b
 r=p?d:c
 q=p?c:d
-if(A.aV(t.a,s.a,r,q,e))return null
+if(A.aW(t.a,s.a,r,q,e))return null
 return p?1:-1},
-aV(a,b,c,d,e){if(!c.ch||!A.eu(a))return!1
+aW(a,b,c,d,e){if(!c.ch||!A.eu(a))return!1
 if(!A.ep(b,d))return!1
 return A.dm(a,e)>A.dm(b,e)},
 ep(a,b){var t=a.c
@@ -2525,14 +2525,14 @@ if(A.S(a.c)!==B.z)return!1
 t=a.e
 s=new A.b(t,A.a(t).i("b<2>"))
 return!s.h(0,B.e)&&!s.h(0,B.k)&&!s.h(0,B.G)&&!s.h(0,B.C)},
-kr(a,b,c,d,e){var t,s,r=A.ep(a.a,c)
+kt(a,b,c,d,e){var t,s,r=A.ep(a.a,c)
 if(r===A.ep(b.a,d))return null
 t=r?a:b
 s=r?b:a
 if(!A.eu(s.a))return null
 if(t.b>s.b)return null
 return r?-1:1},
-kq(a,b,c,d,e){var t,s,r,q
+ks(a,b,c,d,e){var t,s,r,q
 if(e.b!==B.m)return null
 t=new A.dx(e)
 s=t.$2(a,c)
@@ -2541,10 +2541,10 @@ r=s?b:a
 q=s?d:c
 if(!new A.dy().$2(r,q))return null
 return s?-1:1},
-km(a,b,c,d,e){var t=B.b.A(c.p1,d.p1)
+ko(a,b,c,d,e){var t=B.b.A(c.p1,d.p1)
 if(t===0)return null
 return t},
-ks(a,b,c,d,e){var t,s=null,r=a.b<b.b,q=r?a:b,p=r?b:a,o=r?c:d,n=r?d:c
+ku(a,b,c,d,e){var t,s=null,r=a.b<b.b,q=r?a:b,p=r?b:a,o=r?c:d,n=r?d:c
 if(q.b===p.b)return s
 if(!o.c||!n.c)return s
 if(!o.k1||!n.k1)return s
@@ -2553,10 +2553,10 @@ if(!n.k3)return s
 t=q.a
 if(A.X(t.b,t.a)!==11)return s
 return r?-1:1},
-ki(a,b,c,d,e){var t=e.a_(a.a),s=e.a_(b.a)!=null
+kk(a,b,c,d,e){var t=e.a_(a.a),s=e.a_(b.a)!=null
 if(t!=null===s)return null
 return s?1:-1},
-kC(a,b,c,d,e){var t,s,r,q,p,o,n,m,l,k=a.a.c===B.U
+kE(a,b,c,d,e){var t,s,r,q,p,o,n,m,l,k=a.a.c===B.U
 if(k===(b.a.c===B.U))return null
 t=k?a:b
 s=k?c:d
@@ -2573,59 +2573,59 @@ if(p===1)l=(o.h(0,B.D)||o.h(0,B.o))&&n.a===1&&n.h(0,B.J)
 else l=!1
 if(!m&&!l)return null
 return k?-1:1},
-kF(a,b,c,d,e){var t,s=e.a_(a.a),r=e.a_(b.a)
+kH(a,b,c,d,e){var t,s=e.a_(a.a),r=e.a_(b.a)
 if(s==null||r==null)return null
-t=r===B.ad
-if(s===B.ad===t)return null
+t=r===B.ae
+if(s===B.ae===t)return null
 return t?1:-1},
-ku(a,b,c,d,e){var t,s,r,q,p,o,n=null,m=d.p3.a,l=c.p3.a,k=B.b.A(m[2],l[2])
+kw(a,b,c,d,e){var t,s,r,q,p,o,n=null,m=d.p3.a,l=c.p3.a,k=B.b.A(m[2],l[2])
 if(k!==0){m=k<0
 t=m?a:b
 s=m?b:a
 r=m?c:d
 q=m?d:c
 if(r.ay&&!r.dy&&!q.ay)return n
-if(A.aV(t.a,s.a,r,q,e))return n
+if(A.aW(t.a,s.a,r,q,e))return n
 return k}p=B.b.A(l[0],m[0])
 if(p!==0){m=p<0
 t=m?a:b
 s=m?b:a
 r=m?c:d
 q=m?d:c
-if(A.aV(t.a,s.a,r,q,e))return n
+if(A.aW(t.a,s.a,r,q,e))return n
 return p}o=B.b.A(l[3],m[3])
 if(o!==0){m=o<0
 t=m?a:b
 s=m?b:a
 r=m?c:d
 q=m?d:c
-if(A.aV(t.a,s.a,r,q,e))return n
+if(A.aW(t.a,s.a,r,q,e))return n
 return o}return n},
-kD(a,b,c,d,e){var t,s,r,q,p=c.a,o=d.a
+kF(a,b,c,d,e){var t,s,r,q,p=c.a,o=d.a
 if(p===o)return null
 t=p?a:b
 s=p?b:a
 r=p?c:d
 q=p?d:c
-if(A.aV(t.a,s.a,r,q,e))return null
+if(A.aW(t.a,s.a,r,q,e))return null
 return o?1:-1},
-kg(a,b,c,d,e){var t,s,r,q,p,o=B.b.A(c.k2,d.k2)
+ki(a,b,c,d,e){var t,s,r,q,p,o=B.b.A(c.k2,d.k2)
 if(o===0)return null
 t=o<0
 s=t?a:b
 r=t?b:a
 q=t?c:d
 p=t?d:c
-if(A.aV(s.a,r.a,q,p,e))return null
+if(A.aW(s.a,r.a,q,p,e))return null
 return o},
-k2(a,b,c,d,e){var t,s=null,r=c.CW||c.cx,q=d.CW||d.cx
+k4(a,b,c,d,e){var t,s=null,r=c.CW||c.cx,q=d.CW||d.cx
 if(!r||!q)return s
 if(!c.p4&&!d.p4)return s
 t=a.a
 if(t.d.h(0,B.l)||b.a.d.h(0,B.l))return s
 if(A.X(t.a,b.a.a)!==6)return s
 return A.dn(a,b,e,10)},
-k4(a,b,c,d,e){var t=a.a,s=b.a
+k6(a,b,c,d,e){var t=a.a,s=b.a
 if(!(t.c===B.y&&s.c===B.y&&t.d.a===0&&s.d.a===0&&A.X(t.a,s.a)===6))return null
 if(Math.abs(a.b-b.b)>0.05)return null
 return A.dn(a,b,e,0)},
@@ -2635,14 +2635,14 @@ return t<s?-1:1},
 dm(a,b){var t,s,r,q=A.bI(a,b),p=A.fM(q)
 for(t=a.e,t=new A.M(t,A.a(t).i("M<1,2>")).gq(0),s=a.a;t.k();){r=t.d
 p+=A.fM(A.bJ(B.b.m(s+r.a,12),q,r.b,b))}return p},
-fM(a){var t,s,r,q,p,o,n=A.af(a)
+fM(a){var t,s,r,q,p,o,n=A.a6(a)
 if(n.length===0)return 1000
-t=B.c.E(n,1)
+t=B.c.D(n,1)
 for(s=t.split(""),r=s.length,q=0,p=0;p<r;++p){o=s[p]
 if(o==="#"||o==="b")q+=10
 if(o==="x")q+=20}if(t.length===2)q+=30
 return n==="B#"||n==="Cb"||n==="E#"||n==="Fb"?q+16:q},
-k0(a,b,c,d,e){var t,s,r,q,p,o,n=null,m=c.c,l=d.c
+k2(a,b,c,d,e){var t,s,r,q,p,o,n=null,m=c.c,l=d.c
 if(m===l)return n
 t=m?a:b
 s=m?b:a
@@ -2651,11 +2651,11 @@ q=m?d:c
 m=t.a
 p=m.e
 o=new A.b(p,A.a(p).i("b<2>"))
-if(!(o.h(0,B.W)||o.h(0,B.h)||o.h(0,B.r)))return n
-if(A.kL(t,s,r,q))return n
-if(A.aV(m,s.a,r,q,e))return n
+if(!(o.h(0,B.W)||o.h(0,B.h)||o.h(0,B.q)))return n
+if(A.kN(t,s,r,q))return n
+if(A.aW(m,s.a,r,q,e))return n
 return l?1:-1},
-kL(a,b,c,d){var t,s
+kN(a,b,c,d){var t,s
 if(!c.f||!c.c||!c.ch||c.a)return!1
 t=a.a.e
 s=new A.b(t,A.a(t).i("b<2>"))
@@ -2664,13 +2664,13 @@ if(!d.b)return!1
 if(d.ry>0)return!1
 if(b.b>a.b+0.25)return!1
 return!0},
-kn(a,b,c,d,e){var t=B.b.A(c.ok,d.ok)
+kp(a,b,c,d,e){var t=B.b.A(c.ok,d.ok)
 if(t===0)return null
 return t},
 jn(a,b,c,d,e){var t=c.f
 if(t===d.f)return null
 return t?1:-1},
-k3(a,b,c,d,e){return A.dn(a,b,e,0)},
+k5(a,b,c,d,e){return A.dn(a,b,e,0)},
 bk:function bk(a,b,c){this.a=a
 this.b=b
 this.c=c},
@@ -2742,11 +2742,11 @@ hW(a){switch(a.a){case 1:case 4:case 7:return!0
 default:return!1}},
 hV(a){switch(a.a){case 0:case 2:case 5:case 6:return!0
 default:return!1}},
-l2(a,b){var t,s,r,q,p,o
-for(t=A.ae(a,a.r,A.a(a).c),s=t.$ti.c,r=0,q=0,p=0;t.k();){o=t.d
+l4(a,b){var t,s,r,q,p,o
+for(t=A.af(a,a.r,A.a(a).c),s=t.$ti.c,r=0,q=0,p=0;t.k();){o=t.d
 if(o==null)o=s.a(o)
 if(A.bQ(o))++p
-else{if(A.hV(o))o=!(b&&o===B.q)
+else{if(A.hV(o))o=!(b&&o===B.r)
 else o=!1
 if(o)++r
 else ++q}}return new A.bB([p,r,q,a.a])},
@@ -2762,10 +2762,10 @@ this.b=b},
 hZ(a,b,c){var t,s,r
 if(a===b)return!0
 if(a.a!==b.a)return!1
-for(t=A.ae(a,a.r,A.a(a).c),s=t.$ti.c;t.k();){r=t.d
+for(t=A.af(a,a.r,A.a(a).c),s=t.$ti.c;t.k();){r=t.d
 if(!b.h(0,r==null?s.a(r):r))return!1}return!0},
 i_(a,b){var t,s,r,q
-for(t=A.ae(a,a.r,A.a(a).c),s=t.$ti.c,r=0;t.k();){q=t.d
+for(t=A.af(a,a.r,A.a(a).c),s=t.$ti.c,r=0;t.k();){q=t.d
 r=(r^J.v(q==null?s.a(q):q))>>>0}return r},
 hX(a,b,c,d){var t,s,r
 if(a===b)return!0
@@ -2779,7 +2779,7 @@ for(t=new A.M(a,A.a(a).i("M<1,2>")).gq(0),s=0;t.k();){r=t.d
 s^=A.am(r.a,r.b,B.i,B.i,B.i,B.i)}return s},
 S(a){switch(a.a){case 12:case 13:case 14:case 15:case 16:case 17:case 18:case 19:case 20:case 21:case 22:case 23:case 24:case 25:case 26:return B.z
 default:return B.bd}},
-aD(a){switch(a.a){case 10:case 11:return!0
+aE(a){switch(a.a){case 10:case 11:return!0
 default:return!1}},
 e1(a){switch(a.a){case 7:case 8:case 9:case 13:case 14:case 18:case 19:return!0
 default:return!1}},
@@ -2804,12 +2804,12 @@ this.c=c},
 ie(a){var t
 A:{if(B.f===a){t=1
 break A}if(B.G===a){t=2
-break A}if(B.k===a||B.ah===a||B.e===a){t=3
+break A}if(B.k===a||B.ad===a||B.e===a){t=3
 break A}if(B.C===a){t=4
 break A}if(B.p===a||B.d===a||B.v===a){t=5
 break A}if(B.a5===a){t=6
-break A}if(B.W===a||B.h===a||B.r===a){t=7
-break A}if(B.H===a||B.ag===a||B.X===a||B.ac===a||B.av===a){t=9
+break A}if(B.W===a||B.h===a||B.q===a){t=7
+break A}if(B.H===a||B.ah===a||B.X===a||B.ac===a||B.av===a){t=9
 break A}if(B.a_===a||B.M===a||B.a4===a){t=11
 break A}if(B.a6===a||B.a7===a||B.aq===a){t=13
 break A}t=null}return t},
@@ -2843,9 +2843,9 @@ for(r=0;r<t;++r){q=a[r]
 if(!(r<s))return A.c(b,r)
 if(q!==b[r])return!1}return!0},
 bn:function bn(a){this.a=a},
-a8:function a8(a,b){this.a=a
+a9:function a9(a,b){this.a=a
 this.b=b},
-aP:function aP(a,b){this.a=a
+aQ:function aQ(a,b){this.a=a
 this.b=b},
 d3:function d3(a,b){this.a=a
 this.b=b},
@@ -2885,7 +2885,7 @@ break A}if(8===b||9===b){t=13
 break A}t=99
 break A}return t},
 cI:function cI(a){this.a=a},
-ih(a,b,c){var t,s,r,q,p,o=A.aK(u.S,u.u),n=new A.cL(c)
+ih(a,b,c){var t,s,r,q,p,o=A.aL(u.S,u.u),n=new A.cL(c)
 if(n.$1(0))o.t(0,0,B.f)
 t=new A.cJ(n,o)
 switch(b.a){case 0:t.$2(4,B.e)
@@ -2948,23 +2948,23 @@ t.$2(10,B.h)
 break
 case 17:t.$2(4,B.e)
 t.$2(7,B.d)
-t.$2(11,B.r)
+t.$2(11,B.q)
 break
 case 18:t.$2(2,B.G)
 t.$2(7,B.d)
-t.$2(11,B.r)
+t.$2(11,B.q)
 break
 case 19:t.$2(5,B.C)
 t.$2(7,B.d)
-t.$2(11,B.r)
+t.$2(11,B.q)
 break
 case 20:t.$2(4,B.e)
 t.$2(6,B.p)
-t.$2(11,B.r)
+t.$2(11,B.q)
 break
 case 21:t.$2(4,B.e)
 t.$2(8,B.v)
-t.$2(11,B.r)
+t.$2(11,B.q)
 break
 case 22:t.$2(3,B.k)
 t.$2(7,B.d)
@@ -2976,7 +2976,7 @@ t.$2(10,B.h)
 break
 case 24:t.$2(3,B.k)
 t.$2(7,B.d)
-t.$2(11,B.r)
+t.$2(11,B.q)
 break
 case 25:t.$2(3,B.k)
 t.$2(6,B.p)
@@ -2986,14 +2986,14 @@ case 26:t.$2(3,B.k)
 t.$2(6,B.p)
 t.$2(9,B.W)
 break}s=new A.cK(n,o)
-for(r=A.ae(a,a.r,A.a(a).c),q=r.$ti.c;r.k();){p=r.d
+for(r=A.af(a,a.r,A.a(a).c),q=r.$ti.c;r.k();){p=r.d
 switch((p==null?q.a(p):p).a){case 0:case 11:s.$2(1,B.H)
 break
-case 1:s.$2(2,B.ag)
+case 1:s.$2(2,B.ah)
 break
 case 2:s.$2(3,B.X)
 break
-case 3:s.$2(3,B.ah)
+case 3:s.$2(3,B.ad)
 break
 case 4:s.$2(5,B.a_)
 break
@@ -3017,20 +3017,32 @@ this.b=b},
 bJ(a,b,c,d){var t,s,r,q,p
 if(c!=null)t=B.c.I(b).length===0
 else t=!0
-if(t)return A.aY(a,d)
-s=A.af(b)
+if(t)return A.aB(a,d)
+s=A.a6(b)
 if(0>=s.length)return A.c(s,0)
 r=B.a.W(B.Q,s[0].toUpperCase())
-if(r===-1)return A.aY(a,d)
+if(r===-1)return A.aB(a,d)
 q=B.Q[B.b.m(r+(A.ig(c)-1),7)]
 t=B.ar.n(0,q)
 t.toString
 p=B.b.m(B.b.m(a,12)-t,12)
 if(p>6)p-=12
-if(p<-2||p>2)return A.aY(a,d)
+if(p<-2||p>2)return A.aB(a,d)
 return q+A.dk(p)},
-bI(a,b){var t,s,r,q,p,o,n,m,l=a.a,k=A.aY(l,b),j=A.fp(A.e6(b).a,b.a.d)
-if(new A.b(j,A.a(j).i("b<2>")).h(0,A.af(k)))return k
+m4(a,b,c,d){var t=A.bJ(a,b,c,d)
+if(c==null||A.jJ(c))return t
+if(A.jS(t))return t
+return A.aB(a,d)},
+jJ(a){var t
+A:{t=B.f===a||B.k===a||B.ad===a||B.e===a||B.d===a||B.h===a||B.q===a
+break A}return t},
+jS(a){var t,s=A.a6(a)
+if(s.length<2)return!0
+t=B.c.D(s,1)
+if(t==="x"||t.length>=2)return!1
+return!(s==="B#"||s==="E#"||s==="Cb"||s==="Fb")},
+bI(a,b){var t,s,r,q,p,o,n,m,l=a.a,k=A.aB(l,b),j=A.fp(A.e6(b).a,b.a.d)
+if(new A.b(j,A.a(j).i("b<2>")).h(0,A.a6(k)))return k
 t=A.jp(l)
 for(l=t.length,s=null,r=0;r<t.length;t.length===l||(0,A.Q)(t),++r){q=t[r]
 p=A.jr(a,q,k,b)
@@ -3039,24 +3051,24 @@ n=!0
 if(s!=null){m=s.b
 if(p>=m)n=p===m&&q===k}if(n)s=o}l=s==null?null:s.a
 return l==null?k:l},
-aY(a,b){var t=B.b.m(a,12),s=A.e6(b).a,r=b.a.d,q=A.fp(s,r),p=q.n(0,t)
+aB(a,b){var t=B.b.m(a,12),s=A.e6(b).a,r=b.a.d,q=A.fp(s,r),p=q.n(0,t)
 if(p!=null)return p
-return A.kQ(t,q,s,r)},
-fl(a){var t,s,r,q=A.aK(u.N,u.S)
+return A.kS(t,q,s,r)},
+fl(a){var t,s,r,q=A.aL(u.N,u.S)
 for(t=0;t<7;++t)q.t(0,B.Q[t],0)
 if(a>0)for(s=0;s<a;++s){if(!(s<7))return A.c(B.aW,s)
 q.t(0,B.aW[s],1)}else if(a<0)for(r=-a,s=0;s<r;++s){if(!(s<7))return A.c(B.aV,s)
 q.t(0,B.aV[s],-1)}return q},
 fp(a,b){var t,s,r,q,p,o,n=B.a.W(B.Q,b),m=n===-1?0:n,l=A.fl(a),k=u.N,j=J.eU(new Array(7),k)
 for(t=0;t<7;++t)j[t]=B.Q[B.b.m(m+t,7)]
-s=A.aK(u.S,k)
+s=A.aL(u.S,k)
 for(k=j.length,r=0;r<k;++r){q=j[r]
 p=B.ar.n(0,q)
 p.toString
 o=l.n(0,q)
 o.toString
 s.t(0,B.b.m(p+o,12),q+A.dk(o))}return s},
-kQ(a,b,c,d){var t,s,r,q,p,o,n,m,l,k,j,i=A.fl(c),h=A.a(b).i("b<2>"),g=new A.dA(A.e9(new A.b(b,h),h.i("f.E")))
+kS(a,b,c,d){var t,s,r,q,p,o,n,m,l,k,j,i=A.fl(c),h=A.a(b).i("b<2>"),g=new A.dA(A.e9(new A.b(b,h),h.i("f.E")))
 for(h=c<0,t=c>0,s=null,r=0;r<7;++r){q=B.Q[r]
 p=i.n(0,q)
 p.toString
@@ -3096,9 +3108,9 @@ jr(a,b,c,d){var t,s,r,q=b!==c?3:0
 q+=A.fK(b)
 for(t=a.e,t=new A.M(t,A.a(t).i("M<1,2>")).gq(0),s=a.a;t.k();){r=t.d
 q+=A.fK(A.bJ(B.b.m(s+r.a,12),b,r.b,d))}return q},
-fK(a){var t,s,r,q,p,o,n=A.af(a)
+fK(a){var t,s,r,q,p,o,n=A.a6(a)
 if(n.length===0)return 1000
-t=B.c.E(n,1)
+t=B.c.D(n,1)
 for(s=t.split(""),r=s.length,q=0,p=0;p<r;++p){o=s[p]
 if(o==="#"||o==="b")q+=10
 if(o==="x")q+=20}if(t.length===2)q+=30
@@ -3128,7 +3140,7 @@ hT(a){var t,s=a.b,r=a.a
 if(s===r)return!1
 t=a.e.n(0,A.X(s,r))
 if(t==null)return!1
-return t===B.e||t===B.k||t===B.d||t===B.p||t===B.v||t===B.a5||t===B.h||t===B.r||t===B.W},
+return t===B.e||t===B.k||t===B.d||t===B.p||t===B.v||t===B.a5||t===B.h||t===B.q||t===B.W},
 eM(a){var t,s,r,q,p
 if(A.hU(a))return B.aY
 t=a.b
@@ -3136,8 +3148,8 @@ s=a.a
 if(t===s)return a.d
 r=a.d
 q=A.a(r)
-p=q.i("ad<1>")
-return A.e9(new A.ad(r,q.i("x(1)").a(new A.cC(B.b.m(t-s,12))),p),p.i("f.E"))},
+p=q.i("ae<1>")
+return A.e9(new A.ae(r,q.i("x(1)").a(new A.cC(B.b.m(t-s,12))),p),p.i("f.E"))},
 cC:function cC(a){this.a=a},
 fq(a,b,c){var t,s,r,q,p,o=A.al(a,A.a(a).c)
 B.a.M(o,new A.dl())
@@ -3154,13 +3166,13 @@ return t},
 jv(a,b,c){var t=A.fq(a,b,c)
 if(t.length===0)return""
 return" with "+A.ju(t)},
-kI(a,b){var t,s,r=A.eN(b,B.au),q=A.ek(a,b)
+kK(a,b){var t,s,r=A.eN(b,B.au),q=A.ek(a,b)
 if(q==null)return r
 A:{if(B.n===q){t="ninth"
 break A}if(B.o===q){t="eleventh"
 break A}if(B.l===q){t="thirteenth"
 break A}t=A.dZ(q)
-break A}s=A.kK(r,t)
+break A}s=A.kM(r,t)
 return s===r?r:s},
 ek(a,b){if(A.S(b)!==B.z||b===B.L)return null
 if(a.h(0,B.l))return B.l
@@ -3172,7 +3184,7 @@ case B.o:return a===B.n||a===B.o
 case B.l:return a===B.n||a===B.o||a===B.l
 case B.J:return a===B.J
 default:return!1}},
-kK(a,b){if(B.c.h(a,"seventh"))return A.m6(a,"seventh",b,0)
+kM(a,b){if(B.c.h(a,"seventh"))return A.m9(a,"seventh",b,0)
 return a},
 fJ(a,b,c){var t
 switch(b.a){case 0:t=new A.a5(c).K(a)
@@ -3192,7 +3204,7 @@ this.b=b},
 dl:function dl(){},
 i6(a0,a1,a2){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=null,d=a1===B.al?B.bF:B.at,c=a2===B.A&&d===B.at,b=c?"m":A.eN(a2,d),a=A.al(a0,A.a(a0).c)
 B.a.M(a,new A.cF())
-if(A.aD(a2)&&a0.h(0,B.J))b+="/9"
+if(A.aE(a2)&&a0.h(0,B.J))b+="/9"
 t=a0.h(0,B.n)
 s=a0.h(0,B.o)
 r=a0.h(0,B.l)
@@ -3203,7 +3215,7 @@ else q=e
 if(q!=null&&!c){p=A.i4(b,A.e_(q))
 if(p!==b)b=p
 else q=e}o=A.i([],u.c)
-n=A.aD(a2)&&B.c.a3(b,"/9")
+n=A.aE(a2)&&B.c.a3(b,"/9")
 for(m=a.length,l=q===B.o,k=q===B.l,j=0;j<a.length;a.length===m||(0,A.Q)(a),++j){i=a[j]
 if(i===q)continue
 if(n&&i===B.J)continue
@@ -3227,11 +3239,11 @@ i1(a,b){if(b===B.L&&A.hW(a))switch(a.a){case 1:return B.J
 case 4:return B.D
 case 7:return B.a1
 default:return a}return a},
-i4(a,b){if(B.c.a0(a,"7sus"))return b+B.c.E(a,1)
-if(B.c.a0(a,"maj7sus"))return"maj"+b+B.c.E(a,4)
-if(B.c.a0(a,"\u03947sus"))return"\u0394"+b+B.c.E(a,2)
+i4(a,b){if(B.c.a0(a,"7sus"))return b+B.c.D(a,1)
+if(B.c.a0(a,"maj7sus"))return"maj"+b+B.c.D(a,4)
+if(B.c.a0(a,"\u03947sus"))return"\u0394"+b+B.c.D(a,2)
 if(a==="7")return b
-if(B.c.a3(a,"7"))return B.c.D(a,0,a.length-1)+b
+if(B.c.a3(a,"7"))return B.c.E(a,0,a.length-1)+b
 return a},
 i3(a){if(a==null)return"maj7"
 return"maj"+A.e_(a)},
@@ -3396,7 +3408,7 @@ if(r===0)return null
 if(0>=r)return A.c(s,0)
 t=s[0].toUpperCase()
 if(!B.c.h("ABCDEFG",t))return null
-return new A.de(t,B.c.E(s,1))},
+return new A.de(t,B.c.D(s,1))},
 a5:function a5(a){this.a=a},
 de:function de(a,b){this.a=a
 this.b=b},
@@ -3408,16 +3420,16 @@ break
 case 2:t="unlikely"
 break
 default:t=null}return t},
-l8(b9,c0,c1){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8=null
+la(b9,c0,c1){var t,s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8=null
 if(b9.length>512)return new A.ag(!1,B.P,"",A.fX(A.fV(c0)),B.ai,B.P,B.c3)
 t=A.fV(c0)
 s=A.e6(t)
 r=A.fX(t)
-q=A.m2(b9)
+q=A.m5(b9)
 p=q.length
 if(p===0)return new A.ag(!1,B.P,"",r,B.ai,B.P,B.c_)
 if(p>128)return new A.ag(!1,B.P,"",r,B.ai,B.P,B.bZ)
-o=A.lf(q)
+o=A.lh(q)
 p=o.b
 if(p.length===0){p=A.i([],u.s)
 n=o.e
@@ -3434,9 +3446,9 @@ i=A.fL(p)
 h=l.length
 p=h!==0?h:p.length
 i=(i&j)>>>0===0?1:0
-g=A.l9(o,t)
+g=A.lb(o,t)
 f=o.c.n(0,k)
-h=f!=null?A.af(f):A.aY(k,t)
+h=f!=null?A.a6(f):A.aB(k,t)
 e=new A.a5(B.a0).K(h)
 d=l.length>=2?A.iz(l):b8
 c=A.hO(new A.bT((m|j)>>>0,k,p+i),new A.bM(t,s,new A.d_(s.a<0)),5,d)
@@ -3452,7 +3464,7 @@ a4=A.bI(p,t)
 m=p.b
 j=p.a
 i=m!==j
-a5=i?A.bJ(m,a4,p.e.n(0,B.b.m(m-j,12)),t):b8
+a5=i?A.m4(m,a4,p.e.n(0,B.b.m(m-j,12)),t):b8
 h=p.c
 a6=A.i6(A.eM(p),c1,h)
 a7=a5==null?b8:B.c.I(a5)
@@ -3469,15 +3481,15 @@ b0=b1==null?b0:b0+"/"+b1
 b2=A.bI(p,t)
 a4=A.fJ(b2,B.aT,B.a0)
 b3=A.eM(p)
-a6=A.kI(b3,h)
+a6=A.kK(b3,h)
 b4=A.jv(b3,A.ek(b3,h),A.e0(h,B.au))
 b5=A.fq(b3,A.ek(b3,h),A.e0(h,B.au)).length
 b6=a4+" "+a6+b4
 if(i){a5=A.fJ(A.bJ(m,b2,p.e.n(0,B.b.m(m-j,12)),t),B.aT,B.a0)
 if(a5!==a4){b7=A.hT(p)?"slash":"over"
 b6=b6+(b5>=2?",":"")+" "+b7+" "+a5}}m=a2.b
-B.a.l(a0,new A.bR(a1,b0,B.c.I(b6),A.kP(p,t),A.kO(p,o,t),m,m-b,a3))}return new A.ag(!0,g,e,r,a0,n,B.P)},
-m2(a){var t=B.c.aM(a,A.f0("[\\s,-]+")),s=A.H(t),r=s.i("N<1,k>")
+B.a.l(a0,new A.bR(a1,b0,B.c.I(b6),A.kR(p,t),A.kQ(p,o,t),m,m-b,a3))}return new A.ag(!0,g,e,r,a0,n,B.P)},
+m5(a){var t=B.c.aM(a,A.f0("[\\s,-]+")),s=A.H(t),r=s.i("N<1,k>")
 r=new A.N(t,s.i("k(1)").a(new A.dV()),r).aO(0,r.i("x(I.E)").a(new A.dW()))
 t=A.al(r,r.$ti.i("f.E"))
 return t},
@@ -3487,8 +3499,8 @@ r=A.f0("\\s+")
 q=A.Y(g,r,"")
 t=null
 p=B.c.W(q,":")
-if(p>=0){t=B.c.D(q,0,p)
-o=B.c.E(q,p+1)}else{t=q
+if(p>=0){t=B.c.E(q,0,p)
+o=B.c.D(q,p+1)}else{t=q
 o=null}if(o!=null){n=o.toLowerCase()
 m=n==="min"||n==="minor"?B.m:B.j}else{l=t.toLowerCase()
 k=0
@@ -3498,16 +3510,16 @@ if(!B.c.a3(l,j))break A
 m=B.c.a0(j,"min")?B.m:B.j
 t=J.hh(t,0,J.bK(t)-j.length)
 break}++k}}s=null
-try{i=A.iT(A.af(t))
+try{i=A.iT(A.a6(t))
 s=i==null?B.ak:i}catch(h){if(A.eA(h) instanceof A.Z)s=B.ak
-else throw h}return A.ld(new A.e(s,m))},
-ld(a){var t,s,r,q,p
+else throw h}return A.lf(new A.e(s,m))},
+lf(a){var t,s,r,q,p
 for(t=a.b===B.j,s=0;s<15;++s){r=B.aw[s]
 if((t?r.b:r.c).B(0,a))return a}q=A.i([],u.Q)
 for(s=0;s<15;++s){r=B.aw[s]
 p=t?r.b:r.c
-q.push(new A.bA(Math.abs(r.a),p))}return new A.ad(q,u.a.a(new A.dS(a)),u.O).ai(0,new A.dT()).b},
-lf(a){var t,s,r,q,p,o,n=u.t,m=A.i([],n),l=A.i([],n),k=A.aK(u.S,u.N),j=A.i([],u.k),i=A.i([],u.s)
+q.push(new A.bA(Math.abs(r.a),p))}return new A.ae(q,u.a.a(new A.dS(a)),u.O).ai(0,new A.dT()).b},
+lh(a){var t,s,r,q,p,o,n=u.t,m=A.i([],n),l=A.i([],n),k=A.aL(u.S,u.N),j=A.i([],u.k),i=A.i([],u.s)
 for(n=a.length,r=0;r<a.length;a.length===n||(0,A.Q)(a),++r){t=B.c.I(a[r])
 if(J.bK(t)===0)continue
 q=A.iC(t,null)
@@ -3515,31 +3527,31 @@ if(q!=null){if(q<0||q>127){J.b1(i,t)
 continue}B.a.l(m,q)
 p=B.b.m(q,12)
 J.b1(l,p)
-J.b1(j,new A.aU(q,null,p))
-continue}try{s=A.lg(t)
+J.b1(j,new A.aV(q,null,p))
+continue}try{s=A.li(t)
 J.b1(l,s)
 k.bi(s,new A.dU(t))
-J.b1(j,new A.aU(null,t,s))}catch(o){if(A.eA(o) instanceof A.Z)J.b1(i,t)
+J.b1(j,new A.aV(null,t,s))}catch(o){if(A.eA(o) instanceof A.Z)J.b1(i,t)
 else throw o}}return new A.cZ(m,l,k,j,i)},
-l9(a,b){var t,s,r,q,p,o=A.cV(u.S),n=A.i([],u.s)
+lb(a,b){var t,s,r,q,p,o=A.cV(u.S),n=A.i([],u.s)
 for(t=a.d,s=t.length,r=0;r<t.length;t.length===s||(0,A.Q)(t),++r){q=t[r]
 p=q.a
 if(p==null||o.l(0,p)){p=q.b
-p=p!=null?A.af(p):A.aY(q.c,b)
+p=p!=null?A.a6(p):A.aB(q.c,b)
 n.push(new A.a5(B.a0).K(p))}}return n},
-kP(a,b){var t,s,r,q,p,o,n=A.bI(a,b),m=A.aK(u.S,u.u)
+kR(a,b){var t,s,r,q,p,o,n=A.bI(a,b),m=A.aL(u.S,u.u)
 m.t(0,0,B.f)
 m.N(0,a.e)
 t=A.id(new A.a0(m,m.$ti.i("a0<1>")),a,m)
 s=A.i([],u.s)
 for(r=t.length,q=a.a,p=0;p<r;++p){o=t[p]
 s.push(new A.a5(B.a0).K(A.bJ(B.b.m(q+o,12),n,m.n(0,o),b)))}return B.a.G(s," ")},
-kO(a,b,c){var t,s,r,q,p,o=a.e,n=u.S,m=new A.a0(o,A.a(o).i("a0<1>")).bb(0,B.b.F(1,a.a),new A.dz(a),n),l=A.cV(n)
+kQ(a,b,c){var t,s,r,q,p,o=a.e,n=u.S,m=new A.a0(o,A.a(o).i("a0<1>")).bb(0,B.b.F(1,a.a),new A.dz(a),n),l=A.cV(n)
 n=A.i([],u.s)
 for(o=b.d,t=o.length,s=0;s<o.length;o.length===t||(0,A.Q)(o),++s){r=o[s]
 q=r.c
 if(l.l(0,q)&&(m&B.b.T(1,q))>>>0===0){p=r.b
-q=p!=null?A.af(p):A.aY(q,c)
+q=p!=null?A.a6(p):A.aB(q,c)
 n.push(new A.a5(B.a0).K(q))}}return B.a.G(n," ")},
 fL(a){var t,s,r
 for(t=a.length,s=0,r=0;r<t;++r)s=(s|B.b.T(1,B.b.m(a[r],12)))>>>0
@@ -3579,14 +3591,14 @@ _.e=e},
 dU:function dU(a){this.a=a},
 dz:function dz(a){this.a=a},
 dr:function dr(){},
-lc(){var t,s=v.G,r=new A.dR()
+le(){var t,s=v.G,r=new A.dR()
 if(typeof r=="function")A.b_(A.ct("Attempting to rewrap a JS function."))
 t=function(a,b){return function(c,d,e){return a(b,c,d,e,arguments.length)}}(A.jo,r)
 t[$.eB()]=r
 s.whatchordIdentify=t
 s.whatchordReady=!0},
 dR:function dR(){},
-m8(a){throw A.G(new A.c8("Field '"+a+"' has been assigned during initialization."),new Error())},
+mb(a){throw A.G(new A.c8("Field '"+a+"' has been assigned during initialization."),new Error())},
 jo(a,b,c,d,e){u.Z.a(a)
 A.W(e)
 if(e>=3)return a.$3(b,c,d)
@@ -3606,7 +3618,7 @@ p=A.e9(new A.b(r,t),t.i("f.E"))
 o=p.h(0,B.f)
 n=p.h(0,B.k)||p.h(0,B.e)||p.h(0,B.G)||p.h(0,B.C)
 m=p.h(0,B.d)||p.h(0,B.p)||p.h(0,B.v)
-l=p.h(0,B.h)||p.h(0,B.r)||p.h(0,B.W)
+l=p.h(0,B.h)||p.h(0,B.q)||p.h(0,B.W)
 t=A.S(a.c)
 s=!1
 if(o)if(n)if(m)t=t!==B.z||l
@@ -3615,7 +3627,7 @@ else t=s
 else t=s
 if(!t)return!1
 k=B.a.gJ(i)
-for(t=A.iU(a),t=A.ae(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){r=t.d
+for(t=A.iU(a),t=A.af(t,t.r,A.a(t).c),s=t.$ti.c;t.k();){r=t.d
 j=b.bh(r==null?s.a(r):r)
 if(j==null||j<=k)return!1}t=i[1]
 i=i[0]
@@ -3624,23 +3636,23 @@ iU(a){var t,s,r,q=A.cV(u.S)
 for(t=a.e,t=new A.M(t,A.a(t).i("M<1,2>")).gq(0),s=a.a;t.k();){r=t.d
 if(A.f7(r.b))q.l(0,B.b.m(s+r.a,12))}return q},
 f7(a){var t
-A:{t=B.f===a||B.G===a||B.C===a||B.k===a||B.e===a||B.p===a||B.d===a||B.v===a||B.a5===a||B.W===a||B.h===a||B.r===a
+A:{t=B.f===a||B.G===a||B.C===a||B.k===a||B.e===a||B.p===a||B.d===a||B.v===a||B.a5===a||B.W===a||B.h===a||B.q===a
 break A}return t},
-af(a){var t,s,r,q,p="name",o=B.c.I(a),n=o.length
+a6(a){var t,s,r,q,p="name",o=B.c.I(a),n=o.length
 if(n===0)throw A.d(A.bN(a,p,"Empty note name"))
 if(0>=n)return A.c(o,0)
 t=o[0].toUpperCase()
 if(!B.ce.h(0,t))throw A.d(A.bN(a,p,"Invalid note letter"))
-n=B.c.E(o,1)
+n=B.c.D(o,1)
 n=A.Y(n,"\ud834\udd2a","x")
 n=A.Y(n,"\ud834\udd2b","bb")
 n=A.Y(n,"\u266f","#")
 s=A.Y(n,"\u266d","b")
 if(s.length===0)return t
 if(s==="##")s="x"
-for(n=new A.aO(s);n.k();){r=A.A(n.d)
+for(n=new A.aP(s);n.k();){r=A.A(n.d)
 if(r!=="b"&&r!=="#"&&r!=="x")throw A.d(A.bN(a,p,'Invalid accidental character: "'+r+'"'))}if(B.c.h(s,"x")){if(s!=="x")throw A.d(A.bN(a,p,'Invalid accidental sequence: "'+s+'"'))
-return t+"x"}for(n=new A.aO(s),q=0;n.k();){r=A.A(n.d)
+return t+"x"}for(n=new A.aP(s),q=0;n.k();){r=A.A(n.d)
 if(r==="#")++q
 if(r==="b")--q}if(q<-2||q>2)throw A.d(A.bN(a,p,'Accidentals beyond double-flat/double-sharp not supported: "'+s+'"'))
 A:{n=""
@@ -3652,7 +3664,7 @@ break A}if(2===q){n="x"
 break A}break A}return t+n},
 X(a,b){var t=B.b.m(a-b,12)
 return t},
-lg(a){var t,s,r,q,p,o,n,m=A.af(a)
+li(a){var t,s,r,q,p,o,n,m=A.a6(a)
 if(0>=m.length)return A.c(m,0)
 t=m[0]
 A:{if("C"===t){s=0
@@ -3662,9 +3674,9 @@ break A}if("F"===t){s=5
 break A}if("G"===t){s=7
 break A}if("A"===t){s=9
 break A}if("B"===t){s=11
-break A}s=A.b_(A.d5('Unreachable: invalid note letter "'+t+'"'))}r=B.c.E(m,1)
+break A}s=A.b_(A.d5('Unreachable: invalid note letter "'+t+'"'))}r=B.c.D(m,1)
 if(r==="x")q=2
-else for(p=new A.aO(r),q=0;p.k();){o=A.A(p.d)
+else for(p=new A.aP(r),q=0;p.k();){o=A.A(p.d)
 if(o==="#")++q
 if(o==="b")--q}n=B.b.m(s+q,12)
 return n},
@@ -3692,12 +3704,12 @@ k=A.iL(q)
 if((p&k)!==k)return j
 if(!A.iG(a,i,p&l,f))return j
 if((p&~(l|k))!==0)return j
-A.m1(h.bj(f),t)
+A.m3(h.bj(f),t)
 A.iR(h,f)
 A.iN(h,f)
 return new A.d3(h,f)},
 iK(a,b,c){var t,s=B.b.m(b-a.a.e,12)
-switch(c.a){case 0:A:{if(0===s){t=B.ad
+switch(c.a){case 0:A:{if(0===s){t=B.ae
 break A}if(2===s){t=B.az
 break A}if(4===s){t=B.aA
 break A}if(5===s){t=B.aB
@@ -3706,7 +3718,7 @@ break A}if(9===s){t=B.aD
 break A}if(11===s){t=B.aE
 break A}t=null
 break A}return t
-case 1:B:{if(0===s){t=B.ad
+case 1:B:{if(0===s){t=B.ae
 break B}if(2===s){t=B.az
 break B}if(3===s){t=B.aA
 break B}if(5===s){t=B.aB
@@ -3715,7 +3727,7 @@ break B}if(8===s){t=B.aD
 break B}if(10===s){t=B.aE
 break B}t=null
 break B}return t
-case 2:C:{if(0===s){t=B.ad
+case 2:C:{if(0===s){t=B.ae
 break C}if(2===s){t=B.az
 break C}if(3===s){t=B.aA
 break C}if(5===s){t=B.aB
@@ -3729,14 +3741,14 @@ if(r==null)return!0
 t=B.a.W(B.Q,a.a.d)
 s=t<0?0:t
 return r===B.Q[B.b.m(s+c.a,7)]},
-iO(a){var t,s=A.af(a),r=s.length
+iO(a){var t,s=A.a6(a),r=s.length
 if(r===0)return null
 if(0>=r)return A.c(s,0)
 t=s[0].toUpperCase()
 return B.a.h(B.Q,t)?t:null},
 iJ(a){var t
 A:{if(B.O===a){t=B.t
-break A}if(B.ae===a){t=B.E
+break A}if(B.af===a){t=B.E
 break A}t=null
 break A}return t},
 iG(a,b,c,d){var t,s
@@ -3744,10 +3756,10 @@ for(t=0;t<12;++t){if((c&B.b.F(1,t))===0)continue
 s=B.b.m(b+t,12)
 if(!A.f2(a,s,d))return!1}return!0},
 iL(a){var t,s,r,q
-for(t=A.ae(a,a.r,A.a(a).c),s=t.$ti.c,r=0;t.k();){q=t.d
+for(t=A.af(a,a.r,A.a(a).c),s=t.$ti.c,r=0;t.k();){q=t.d
 r=(r|B.b.F(1,A.cD(q==null?s.a(q):q)))>>>0}return r},
 iM(a,b,c,d){var t,s,r,q
-for(t=A.ae(c,c.r,A.a(c).c),s=t.$ti.c;t.k();){r=t.d
+for(t=A.af(c,c.r,A.a(c).c),s=t.$ti.c;t.k();){r=t.d
 q=B.b.m(b+A.cD(r==null?s.a(r):r),12)
 if(!A.f2(a,q,d))return!1}return!0},
 iH(a,b){var t
@@ -3842,7 +3854,7 @@ break
 case 6:t="leading tone"
 break
 default:t=null}return t},
-m1(a,b){var t
+m3(a,b){var t
 A:{if(B.u===b){t=a+"7"
 break A}if(B.y===b){t=a+"7b5"
 break A}if(B.x===b){t=a+"7#5"
@@ -3853,7 +3865,7 @@ break A}if(B.Z===b){t=a+"maj7#5"
 break A}if(B.U===b){t=a+"7"
 break A}if(B.ab===b){t=a+"7#5"
 break A}if(B.A===b){t=a+"(maj7)"
-break A}if(B.F===b){t=(B.c.a3(a,"\xb0")?B.c.D(a,0,a.length-1):a)+"\xf87"
+break A}if(B.F===b){t=(B.c.a3(a,"\xb0")?B.c.E(a,0,a.length-1):a)+"\xf87"
 break A}if(B.L===b){t=a+"7"
 break A}t=a
 break A}return t}},B={}
@@ -3869,19 +3881,19 @@ J.c4.prototype={
 j(a){return String(a)},
 gv(a){return a?519018:218159},
 gP(a){return A.ay(u.y)},
-$iaa:1,
+$iab:1,
 $ix:1}
 J.bd.prototype={
 B(a,b){return null==b},
 j(a){return"null"},
 gv(a){return 0},
-$iaa:1}
-J.aJ.prototype={$iaH:1}
+$iab:1}
+J.aK.prototype={$iaI:1}
 J.aj.prototype={
 gv(a){return 0},
 j(a){return String(a)}}
 J.d2.prototype={}
-J.ac.prototype={}
+J.ad.prototype={}
 J.be.prototype={
 j(a){var t=a[$.h_()]
 if(t==null)t=a[$.eB()]
@@ -3948,7 +3960,7 @@ o=b.$2(s,r)
 if(typeof o!=="number")return o.bq()
 if(o>0){a[0]=r
 a[1]=s}return}q=0
-if(o.c.b(null))for(p=0;p<a.length;++p)if(a[p]===void 0){a[p]=null;++q}a.sort(A.kY(b,2))
+if(o.c.b(null))for(p=0;p<a.length;++p)if(a[p]===void 0){a[p]=null;++q}a.sort(A.l_(b,2))
 if(q>0)this.b3(a,q)},
 aL(a){return this.M(a,null)},
 b3(a,b){var t,s=a.length
@@ -3993,7 +4005,7 @@ return!1}s.d=r[t]
 s.c=t+1
 return!0},
 $iz:1}
-J.aG.prototype={
+J.aH.prototype={
 A(a,b){var t
 A.fn(b)
 if(a<b)return-1
@@ -4044,7 +4056,7 @@ b7(a,b){var t=a/b
 if(t>=-2147483648&&t<=2147483647)return t|0
 if(t>0){if(t!==1/0)return Math.floor(t)}else if(t>-1/0)return Math.ceil(t)
 throw A.d(A.ef("Result of truncating division is "+A.p(t)+": "+A.p(a)+" ~/ "+b))},
-T(a,b){if(b<0)throw A.d(A.kV(b))
+T(a,b){if(b<0)throw A.d(A.kX(b))
 return b>31?0:a<<b>>>0},
 F(a,b){return b>31?0:a<<b>>>0},
 aw(a,b){var t
@@ -4053,7 +4065,7 @@ else{t=b>31?31:b
 t=a>>t>>>0}return t},
 b4(a,b){return b>31?0:a>>>b},
 gP(a){return A.ay(u.H)},
-$ia6:1,
+$ia7:1,
 $iao:1,
 $iK:1}
 J.bc.prototype={
@@ -4061,11 +4073,11 @@ gb8(a){var t,s=a<0?-a-1:a,r=s
 for(t=32;r>=4294967296;){r=this.b6(r,4294967296)
 t+=32}return t-Math.clz32(r)},
 gP(a){return A.ay(u.S)},
-$iaa:1,
+$iab:1,
 $ij:1}
 J.c5.prototype={
 gP(a){return A.ay(u.i)},
-$iaa:1}
+$iab:1}
 J.ai.prototype={
 af(a,b,c){var t=b.length
 if(c>t)throw A.d(A.a4(c,0,t,null,null))
@@ -4073,10 +4085,10 @@ return new A.cn(b,a,c)},
 aB(a,b){return this.af(a,b,0)},
 a3(a,b){var t=b.length,s=a.length
 if(t>s)return!1
-return b===this.E(a,s-t)},
+return b===this.D(a,s-t)},
 aM(a,b){var t
 if(typeof b=="string")return A.i(a.split(b),u.s)
-else{if(b instanceof A.aI){t=b.e
+else{if(b instanceof A.aJ){t=b.e
 t=!(t==null?b.e=b.aT():t)}else t=!1
 if(t)return A.i(a.split(b.b),u.s)
 else return this.aV(a,b)}},
@@ -4086,14 +4098,14 @@ p=q.ga7()
 o=q.ga2()
 r=o-p
 if(r===0&&s===p)continue
-B.a.l(n,this.D(a,s,p))
-s=o}if(s<a.length||r>0)B.a.l(n,this.E(a,s))
+B.a.l(n,this.E(a,s,p))
+s=o}if(s<a.length||r>0)B.a.l(n,this.D(a,s))
 return n},
 a0(a,b){var t=b.length
 if(t>a.length)return!1
 return b===a.substring(0,t)},
-D(a,b,c){return a.substring(b,A.iD(b,c,a.length))},
-E(a,b){return this.D(a,b,null)},
+E(a,b,c){return a.substring(b,A.iD(b,c,a.length))},
+D(a,b){return this.E(a,b,null)},
 I(a){var t,s,r,q=a.trim(),p=q.length
 if(p===0)return q
 if(0>=p)return A.c(q,0)
@@ -4114,7 +4126,7 @@ if(b===0)break
 t+=t}return s},
 W(a,b){var t=a.indexOf(b,0)
 return t},
-h(a,b){return A.m3(a,b,0)},
+h(a,b){return A.m6(a,b,0)},
 A(a,b){var t
 A.a3(b)
 if(a===b)t=0
@@ -4129,8 +4141,8 @@ s^=s>>11
 return s+((s&16383)<<15)&536870911},
 gP(a){return A.ay(u.N)},
 gu(a){return a.length},
-$iaa:1,
-$ia6:1,
+$iab:1,
+$ia7:1,
 $id1:1,
 $ik:1}
 A.c8.prototype={
@@ -4177,7 +4189,7 @@ $iz:1}
 A.N.prototype={
 gu(a){return J.bK(this.a)},
 L(a,b){return this.b.$1(J.hf(this.a,b))}}
-A.ad.prototype={
+A.ae.prototype={
 gq(a){return new A.bz(J.cs(this.a),this.b,this.$ti.i("bz<1>"))}}
 A.bz.prototype={
 k(){var t,s
@@ -4186,13 +4198,13 @@ return!1},
 gp(){return this.a.gp()},
 $iz:1}
 A.bA.prototype={$r:"+accidentalDistance,tonality(1,2)",$s:1}
-A.aU.prototype={$r:"+midi,name,pc(1,2,3)",$s:2}
+A.aV.prototype={$r:"+midi,name,pc(1,2,3)",$s:2}
 A.bB.prototype={$r:"+addCount,alterationCount,naturalCount,totalCount(1,2,3,4)",$s:3}
 A.b9.prototype={
 gah(a){return this.gu(this)===0},
 j(a){return A.eb(this)},
-$ia7:1}
-A.aF.prototype={
+$ia8:1}
+A.aG.prototype={
 gu(a){return this.b.length},
 gb1(){var t=this.$keys
 if(t==null){t=Object.keys(this.a)
@@ -4216,7 +4228,7 @@ return!1}t.d=t.a[s]
 t.c=s+1
 return!0},
 $iz:1}
-A.aE.prototype={
+A.aF.prototype={
 l(a,b){A.a(this).c.a(b)
 A.io()}}
 A.ap.prototype={
@@ -4281,10 +4293,10 @@ A.cc.prototype={
 j(a){var t=this.$static_name
 if(t==null)return"Closure of unknown static method"
 return"Closure '"+A.fY(t)+"'"}}
-A.aC.prototype={
+A.aD.prototype={
 B(a,b){if(b==null)return!1
 if(this===b)return!0
-if(!(b instanceof A.aC))return!1
+if(!(b instanceof A.aD))return!1
 return this.$_target===b.$_target&&this.a===b.a},
 gv(a){return(A.ez(this.a)^A.bo(this.$_target))>>>0},
 j(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.ca(this.a)+"'")}}
@@ -4303,7 +4315,7 @@ bc(a){var t=this.d
 if(t==null)return!1
 return this.Y(t[this.X(a)],a)>=0},
 S(a){return new A.a0(this,A.a(this).i("a0<1>")).O(0,new A.cR(this,a))},
-N(a,b){A.a(this).i("a7<1,2>").a(b).V(0,new A.cQ(this))},
+N(a,b){A.a(this).i("a8<1,2>").a(b).V(0,new A.cQ(this))},
 n(a,b){var t,s,r,q,p=null
 if(typeof b=="string"){t=this.b
 if(t==null)return p
@@ -4457,7 +4469,7 @@ s.c=t.c
 return!0}},
 $iz:1}
 A.bf.prototype={
-X(a){return A.kX(a)&1073741823},
+X(a){return A.kZ(a)&1073741823},
 Y(a,b){var t,s
 if(a==null)return-1
 t=a.length
@@ -4484,24 +4496,24 @@ if(o!==""){s=o.split(",")
 t=s.length
 for(r=m;t>0;){--r;--t
 B.a.t(k,r,s[t])}}return A.ea(k,l)}}
-A.aR.prototype={
+A.aS.prototype={
 a1(){return[this.a,this.b]},
 B(a,b){if(b==null)return!1
-return b instanceof A.aR&&this.$s===b.$s&&J.L(this.a,b.a)&&J.L(this.b,b.b)},
+return b instanceof A.aS&&this.$s===b.$s&&J.L(this.a,b.a)&&J.L(this.b,b.b)},
 gv(a){return A.am(this.$s,this.a,this.b,B.i,B.i,B.i)}}
-A.aS.prototype={
+A.aT.prototype={
 a1(){return[this.a,this.b,this.c]},
 B(a,b){var t=this
 if(b==null)return!1
-return b instanceof A.aS&&t.$s===b.$s&&J.L(t.a,b.a)&&J.L(t.b,b.b)&&J.L(t.c,b.c)},
+return b instanceof A.aT&&t.$s===b.$s&&J.L(t.a,b.a)&&J.L(t.b,b.b)&&J.L(t.c,b.c)},
 gv(a){var t=this
 return A.am(t.$s,t.a,t.b,t.c,B.i,B.i)}}
-A.aT.prototype={
+A.aU.prototype={
 a1(){return this.a},
 B(a,b){if(b==null)return!1
-return b instanceof A.aT&&this.$s===b.$s&&A.j3(this.a,b.a)},
+return b instanceof A.aU&&this.$s===b.$s&&A.j3(this.a,b.a)},
 gv(a){return A.am(this.$s,A.ec(this.a),B.i,B.i,B.i,B.i)}}
-A.aI.prototype={
+A.aJ.prototype={
 j(a){return"RegExp/"+this.a+"/"+this.b.flags},
 gau(){var t=this,s=t.c
 if(s!=null)return s
@@ -4527,7 +4539,7 @@ A.cm.prototype={
 ga7(){return this.b.index},
 ga2(){var t=this.b
 return t.index+t[0].length},
-$iaM:1,
+$iaN:1,
 $ibq:1}
 A.ch.prototype={
 gq(a){return new A.ci(this.a,this.b,this.c)}}
@@ -4555,7 +4567,7 @@ return!1},
 $iz:1}
 A.cd.prototype={
 ga2(){return this.a+this.c.length},
-$iaM:1,
+$iaN:1,
 ga7(){return this.a}}
 A.cn.prototype={
 gq(a){return new A.co(this.a,this.b,this.c)}}
@@ -4639,7 +4651,7 @@ return!1}else{t.d=t.$ti.i("1?").a(s.a)
 t.c=s.b
 return!0}},
 $iz:1}
-A.aL.prototype={
+A.aM.prototype={
 V(a,b){var t,s,r,q=this,p=A.a(q)
 p.i("~(1,2)").a(b)
 for(t=new A.ar(q,q.r,q.e,p.i("ar<1>")),p=p.y[1];t.k();){s=t.d
@@ -4648,7 +4660,7 @@ b.$2(s,r==null?p.a(r):r)}},
 gu(a){return this.a},
 gah(a){return this.a===0},
 j(a){return A.eb(this)},
-$ia7:1}
+$ia8:1}
 A.cX.prototype={
 $2(a,b){var t,s=this.a
 if(!s.a)this.b.a+=", "
@@ -4659,7 +4671,7 @@ s.a=(s.a+=t)+": "
 t=A.p(b)
 s.a+=t},
 $S:5}
-A.a9.prototype={
+A.aa.prototype={
 N(a,b){var t
 A.a(this).i("f<1>").a(b)
 for(t=b.gq(b);t.k();)this.l(0,t.gp())},
@@ -4696,7 +4708,7 @@ o=!(o<n&&(a.charCodeAt(o)&64512)===56320)}else o=!1
 if(!o)if(p===56320){p=r-1
 p=!(p>=0&&(a.charCodeAt(p)&64512)===55296)}else p=!1
 else p=!0
-if(p){if(r>s)t.a+=B.c.D(a,s,r)
+if(p){if(r>s)t.a+=B.c.E(a,s,r)
 s=r+1
 p=A.A(92)
 t.a+=p
@@ -4712,7 +4724,7 @@ p=A.A(p<10?48+p:87+p)
 t.a+=p
 p=q&15
 p=A.A(p<10?48+p:87+p)
-t.a+=p}}continue}if(q<32){if(r>s)t.a+=B.c.D(a,s,r)
+t.a+=p}}continue}if(q<32){if(r>s)t.a+=B.c.E(a,s,r)
 s=r+1
 p=A.A(92)
 t.a+=p
@@ -4741,13 +4753,13 @@ t.a+=p
 p=q&15
 p=A.A(p<10?48+p:87+p)
 t.a+=p
-break}}else if(q===34||q===92){if(r>s)t.a+=B.c.D(a,s,r)
+break}}else if(q===34||q===92){if(r>s)t.a+=B.c.E(a,s,r)
 s=r+1
 p=A.A(92)
 t.a+=p
 p=A.A(q)
 t.a+=p}}if(s===0)t.a+=a
-else if(s<n)t.a+=B.c.D(a,s,n)},
+else if(s<n)t.a+=B.c.E(a,s,n)},
 a8(a){var t,s,r,q
 for(t=this.a,s=t.length,r=0;r<s;++r){q=t[r]
 if(a==null?q==null:a===q)throw A.d(new A.c7(a,null))}B.a.l(t,a)},
@@ -4867,11 +4879,11 @@ A.da.prototype={
 j(a){return"Exception: "+this.a}}
 A.cN.prototype={
 j(a){var t=this.a,s=""!==t?"FormatException: "+t:"FormatException",r=this.b
-if(r.length>78)r=B.c.D(r,0,75)+"..."
+if(r.length>78)r=B.c.E(r,0,75)+"..."
 return s+"\n"+r}}
 A.f.prototype={
 bm(a,b){var t=A.a(this)
-return new A.ad(this,t.i("x(f.E)").a(b),t.i("ad<f.E>"))},
+return new A.ae(this,t.i("x(f.E)").a(b),t.i("ae<f.E>"))},
 h(a,b){var t
 for(t=this.gq(this);t.k();)if(J.L(t.gp(),b))return!0
 return!1},
@@ -4911,9 +4923,9 @@ A.r.prototype={$ir:1,
 B(a,b){return this===b},
 gv(a){return A.bo(this)},
 j(a){return"Instance of '"+A.ca(this)+"'"},
-gP(a){return A.l6(this)},
+gP(a){return A.l8(this)},
 toString(){return this.j(this)}}
-A.aO.prototype={
+A.aP.prototype={
 gp(){return this.d},
 k(){var t,s,r,q=this,p=q.b=q.c,o=q.a,n=o.length
 if(p===n){q.d=-1
@@ -4928,7 +4940,7 @@ return!0}}q.c=s
 q.d=t
 return!0},
 $iz:1}
-A.aQ.prototype={
+A.aR.prototype={
 gu(a){return this.a.length},
 j(a){var t=this.a
 return t.charCodeAt(0)==0?t:t},
@@ -4963,7 +4975,7 @@ $1(a){return(this.a&B.b.F(1,a))>>>0!==0},
 $S:7}
 A.a2.prototype={}
 A.df.prototype={}
-A.aN.prototype={}
+A.aO.prototype={}
 A.cA.prototype={
 $2(a,b){var t,s,r,q
 A.W(a)
@@ -5072,7 +5084,7 @@ return t===B.t||t===B.K||t===B.T||t===B.a2},
 $S:1}
 A.dt.prototype={
 $1(a){u.G.a(a)
-return a!==B.N&&a!==B.q&&a!==B.l&&a!==B.I},
+return a!==B.N&&a!==B.r&&a!==B.l&&a!==B.I},
 $S:2}
 A.du.prototype={
 $1(a){u.G.a(a)
@@ -5094,7 +5106,7 @@ r=r.a!==1||!r.h(0,B.I)}}if(r)return!1
 r=a.a
 s=A.f3(this.a,r,r.f,!0,null,!0)
 r=s==null
-if((r?null:s.a)===B.ad){t=(r?null:s.b)===B.aX
+if((r?null:s.a)===B.ae){t=(r?null:s.b)===B.aX
 r=t}else r=!1
 return r},
 $S:9}
@@ -5152,7 +5164,7 @@ if(this!==b)t=b instanceof A.bn&&A.iA(b.a,this.a)
 else t=!0
 return t},
 gv(a){return A.ec(this.a)}}
-A.a8.prototype={
+A.a9.prototype={
 C(){return"ScaleDegree."+this.b},
 aG(a){var t
 if(a===B.j){switch(this.a){case 0:t="I"
@@ -5249,7 +5261,7 @@ break
 case 6:t=a===B.j?"leading tone":"subtonic"
 break
 default:t=null}return t}}
-A.aP.prototype={
+A.aQ.prototype={
 C(){return"ScaleDegreeSource."+this.b}}
 A.d3.prototype={}
 A.cf.prototype={
@@ -5440,88 +5452,88 @@ $2(a,b){return(A.W(a)|B.b.T(1,B.b.m(this.a.a+A.W(b),12)))>>>0},
 $S:3}
 A.dr.prototype={
 $1(a){A.a3(a)
-return'"'+(a.length<=32?a:B.c.D(a,0,32)+"...")+'"'},
+return'"'+(a.length<=32?a:B.c.E(a,0,32)+"...")+'"'},
 $S:12}
 A.dR.prototype={
 $3(a,b,c){A.a3(a)
 A.a3(b)
-return B.b7.b9(A.l8(a,b,A.a3(c)==="symbolic"?B.al:B.aU).a5(),null)},
+return B.b7.b9(A.la(a,b,A.a3(c)==="symbolic"?B.al:B.aU).a5(),null)},
 $S:19};(function aliases(){var t=J.aj.prototype
 t.aP=t.j
 t=A.f.prototype
 t.aO=t.bm})();(function installTearOffs(){var t=hunkHelpers._static_2,s=hunkHelpers._static_1,r=hunkHelpers.installStaticTearOff
 t(J,"jE","is",20)
-s(A,"l_","js",21)
-r(A,"kW",5,null,["$5"],["lh"],0,0)
-r(A,"lB",5,null,["$5"],["kh"],0,0)
-r(A,"lV",5,null,["$5"],["kB"],0,0)
-r(A,"m0",5,null,["$5"],["kH"],0,0)
-r(A,"lj",5,null,["$5"],["k_"],0,0)
-r(A,"ly",5,null,["$5"],["ke"],0,0)
-r(A,"lN",5,null,["$5"],["kt"],0,0)
-r(A,"ls",5,null,["$5"],["k8"],0,0)
-r(A,"lt",5,null,["$5"],["k9"],0,0)
-r(A,"lr",5,null,["$5"],["k7"],0,0)
-r(A,"lI",5,null,["$5"],["ko"],0,0)
-r(A,"ll",5,null,["$5"],["k1"],0,0)
-r(A,"m_",5,null,["$5"],["kG"],0,0)
-r(A,"lU",5,null,["$5"],["kA"],0,0)
-r(A,"lT",5,null,["$5"],["kz"],0,0)
-r(A,"lv",5,null,["$5"],["kb"],0,0)
-r(A,"lu",5,null,["$5"],["ka"],0,0)
-r(A,"lq",5,null,["$5"],["k6"],0,0)
-r(A,"lp",5,null,["$5"],["k5"],0,0)
+s(A,"l1","js",21)
+r(A,"kY",5,null,["$5"],["lj"],0,0)
 r(A,"lD",5,null,["$5"],["kj"],0,0)
-r(A,"lE",5,null,["$5"],["kk"],0,0)
-r(A,"lS",5,null,["$5"],["ky"],0,0)
-r(A,"lP",5,null,["$5"],["kv"],0,0)
-r(A,"lz",5,null,["$5"],["kf"],0,0)
-r(A,"lR",5,null,["$5"],["kx"],0,0)
-r(A,"lw",5,null,["$5"],["kc"],0,0)
-r(A,"lY",5,null,["$5"],["kE"],0,0)
-r(A,"lQ",5,null,["$5"],["kw"],0,0)
-r(A,"lx",5,null,["$5"],["kd"],0,0)
-r(A,"lF",5,null,["$5"],["kl"],0,0)
-r(A,"lJ",5,null,["$5"],["kp"],0,0)
-r(A,"lL",5,null,["$5"],["kr"],0,0)
-r(A,"lK",5,null,["$5"],["kq"],0,0)
-r(A,"lG",5,null,["$5"],["km"],0,0)
-r(A,"lM",5,null,["$5"],["ks"],0,0)
-r(A,"lC",5,null,["$5"],["ki"],0,0)
-r(A,"lW",5,null,["$5"],["kC"],0,0)
-r(A,"lZ",5,null,["$5"],["kF"],0,0)
-r(A,"lO",5,null,["$5"],["ku"],0,0)
 r(A,"lX",5,null,["$5"],["kD"],0,0)
+r(A,"m2",5,null,["$5"],["kJ"],0,0)
+r(A,"ll",5,null,["$5"],["k1"],0,0)
 r(A,"lA",5,null,["$5"],["kg"],0,0)
-r(A,"lm",5,null,["$5"],["k2"],0,0)
-r(A,"lo",5,null,["$5"],["k4"],0,0)
-r(A,"lk",5,null,["$5"],["k0"],0,0)
+r(A,"lP",5,null,["$5"],["kv"],0,0)
+r(A,"lu",5,null,["$5"],["ka"],0,0)
+r(A,"lv",5,null,["$5"],["kb"],0,0)
+r(A,"lt",5,null,["$5"],["k9"],0,0)
+r(A,"lK",5,null,["$5"],["kq"],0,0)
+r(A,"ln",5,null,["$5"],["k3"],0,0)
+r(A,"m1",5,null,["$5"],["kI"],0,0)
+r(A,"lW",5,null,["$5"],["kC"],0,0)
+r(A,"lV",5,null,["$5"],["kB"],0,0)
+r(A,"lx",5,null,["$5"],["kd"],0,0)
+r(A,"lw",5,null,["$5"],["kc"],0,0)
+r(A,"ls",5,null,["$5"],["k8"],0,0)
+r(A,"lr",5,null,["$5"],["k7"],0,0)
+r(A,"lF",5,null,["$5"],["kl"],0,0)
+r(A,"lG",5,null,["$5"],["km"],0,0)
+r(A,"lU",5,null,["$5"],["kA"],0,0)
+r(A,"lR",5,null,["$5"],["kx"],0,0)
+r(A,"lB",5,null,["$5"],["kh"],0,0)
+r(A,"lT",5,null,["$5"],["kz"],0,0)
+r(A,"ly",5,null,["$5"],["ke"],0,0)
+r(A,"m_",5,null,["$5"],["kG"],0,0)
+r(A,"lS",5,null,["$5"],["ky"],0,0)
+r(A,"lz",5,null,["$5"],["kf"],0,0)
 r(A,"lH",5,null,["$5"],["kn"],0,0)
-r(A,"li",5,null,["$5"],["jn"],0,0)
-r(A,"ln",5,null,["$5"],["k3"],0,0)})();(function inheritance(){var t=hunkHelpers.inherit,s=hunkHelpers.inheritMany
+r(A,"lL",5,null,["$5"],["kr"],0,0)
+r(A,"lN",5,null,["$5"],["kt"],0,0)
+r(A,"lM",5,null,["$5"],["ks"],0,0)
+r(A,"lI",5,null,["$5"],["ko"],0,0)
+r(A,"lO",5,null,["$5"],["ku"],0,0)
+r(A,"lE",5,null,["$5"],["kk"],0,0)
+r(A,"lY",5,null,["$5"],["kE"],0,0)
+r(A,"m0",5,null,["$5"],["kH"],0,0)
+r(A,"lQ",5,null,["$5"],["kw"],0,0)
+r(A,"lZ",5,null,["$5"],["kF"],0,0)
+r(A,"lC",5,null,["$5"],["ki"],0,0)
+r(A,"lo",5,null,["$5"],["k4"],0,0)
+r(A,"lq",5,null,["$5"],["k6"],0,0)
+r(A,"lm",5,null,["$5"],["k2"],0,0)
+r(A,"lJ",5,null,["$5"],["kp"],0,0)
+r(A,"lk",5,null,["$5"],["jn"],0,0)
+r(A,"lp",5,null,["$5"],["k5"],0,0)})();(function inheritance(){var t=hunkHelpers.inherit,s=hunkHelpers.inheritMany
 t(A.r,null)
-s(A.r,[A.e4,J.c2,A.br,J.b2,A.w,A.d4,A.f,A.bj,A.bz,A.U,A.b9,A.at,A.a9,A.d6,A.d0,A.ah,A.aL,A.cU,A.ar,A.bi,A.bh,A.aI,A.cm,A.ci,A.cd,A.co,A.a1,A.ck,A.cp,A.cl,A.av,A.bY,A.c_,A.dc,A.d9,A.c9,A.bt,A.da,A.cN,A.as,A.bl,A.aO,A.aQ,A.R,A.cM,A.a2,A.df,A.aN,A.b8,A.bk,A.bM,A.E,A.bS,A.bT,A.D,A.d_,A.bn,A.d3,A.e,A.n,A.d8,A.dh,A.e2,A.a5,A.de,A.bR,A.ag,A.cZ])
-s(J.c2,[J.c4,J.bd,J.aJ,J.aG,J.ai])
-s(J.aJ,[J.aj,J.l])
-s(J.aj,[J.d2,J.ac,J.be])
+s(A.r,[A.e4,J.c2,A.br,J.b2,A.w,A.d4,A.f,A.bj,A.bz,A.U,A.b9,A.at,A.aa,A.d6,A.d0,A.ah,A.aM,A.cU,A.ar,A.bi,A.bh,A.aJ,A.cm,A.ci,A.cd,A.co,A.a1,A.ck,A.cp,A.cl,A.av,A.bY,A.c_,A.dc,A.d9,A.c9,A.bt,A.da,A.cN,A.as,A.bl,A.aP,A.aR,A.R,A.cM,A.a2,A.df,A.aO,A.b8,A.bk,A.bM,A.E,A.bS,A.bT,A.D,A.d_,A.bn,A.d3,A.e,A.n,A.d8,A.dh,A.e2,A.a5,A.de,A.bR,A.ag,A.cZ])
+s(J.c2,[J.c4,J.bd,J.aK,J.aH,J.ai])
+s(J.aK,[J.aj,J.l])
+s(J.aj,[J.d2,J.ad,J.be])
 t(J.c3,A.br)
 t(J.cP,J.l)
-s(J.aG,[J.bc,J.c5])
+s(J.aH,[J.bc,J.c5])
 s(A.w,[A.c8,A.bx,A.c6,A.cg,A.cb,A.cj,A.bg,A.bO,A.Z,A.by,A.bu,A.bZ])
-s(A.f,[A.ba,A.ad,A.ch,A.cn])
+s(A.f,[A.ba,A.ae,A.ch,A.cn])
 s(A.ba,[A.I,A.a0,A.b,A.M])
 s(A.I,[A.bv,A.N])
-s(A.U,[A.aR,A.aS,A.aT])
-t(A.bA,A.aR)
-t(A.aU,A.aS)
-t(A.bB,A.aT)
-t(A.aF,A.b9)
-s(A.a9,[A.aE,A.bC])
-s(A.aE,[A.ap,A.J])
+s(A.U,[A.aS,A.aT,A.aU])
+t(A.bA,A.aS)
+t(A.aV,A.aT)
+t(A.bB,A.aU)
+t(A.aG,A.b9)
+s(A.aa,[A.aF,A.bC])
+s(A.aF,[A.ap,A.J])
 t(A.bm,A.bx)
 s(A.ah,[A.bW,A.bX,A.ce,A.cR,A.cu,A.cz,A.cw,A.cx,A.cv,A.cB,A.dq,A.dB,A.dC,A.dD,A.dI,A.dJ,A.dK,A.dL,A.dM,A.dN,A.dO,A.dP,A.dE,A.dF,A.dG,A.dH,A.dt,A.du,A.ds,A.dv,A.cL,A.dA,A.cC,A.cG,A.cH,A.dV,A.dW,A.dS,A.dr,A.dR])
-s(A.ce,[A.cc,A.aC])
-t(A.a_,A.aL)
+s(A.ce,[A.cc,A.aD])
+t(A.a_,A.aM)
 s(A.bX,[A.cQ,A.cX,A.dd,A.cy,A.cA,A.dp,A.dx,A.dy,A.cI,A.cJ,A.cK,A.dl,A.cF,A.dQ,A.dT,A.dz])
 t(A.bf,A.a_)
 t(A.bD,A.cj)
@@ -5531,19 +5543,19 @@ t(A.cS,A.bY)
 t(A.cT,A.c_)
 t(A.db,A.dc)
 s(A.Z,[A.bp,A.c1])
-s(A.d9,[A.q,A.m,A.bV,A.o,A.a8,A.aP,A.cf,A.y,A.bU,A.cY,A.cE,A.b7,A.b6,A.b3])
+s(A.d9,[A.q,A.m,A.bV,A.o,A.a9,A.aQ,A.cf,A.y,A.bU,A.cY,A.cE,A.b7,A.b6,A.b3])
 t(A.dU,A.bW)})()
-var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{j:"int",ao:"double",K:"num",k:"String",x:"bool",bl:"Null",ak:"List",r:"Object",a7:"Map",aH:"JSObject"},mangledNames:{},types:["j?(E,E,R,R,e)","x(E,R,e)","x(q)","j(j,j)","j(q,q)","~(r?,r?)","E(a2)","x(j)","k(q)","x(E,R)","~(j,o)","x(k)","k(k)","j(a2,a2)","~(k,ao{detail:k?,intervals:j?})","j(j)","x(+accidentalDistance,tonality(j,e))","+accidentalDistance,tonality(j,e)(+accidentalDistance,tonality(j,e),+accidentalDistance,tonality(j,e))","k()","k(k,k,k)","j(@,@)","@(@)"],arrayRti:Symbol("$ti"),rttc:{"2;accidentalDistance,tonality":(a,b)=>c=>c instanceof A.bA&&a.b(c.a)&&b.b(c.b),"3;midi,name,pc":(a,b,c)=>d=>d instanceof A.aU&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"4;addCount,alterationCount,naturalCount,totalCount":a=>b=>b instanceof A.bB&&A.le(a,b.a)}}
-A.ja(v.typeUniverse,JSON.parse('{"be":"aj","d2":"aj","ac":"aj","c4":{"x":[],"aa":[]},"bd":{"aa":[]},"aJ":{"aH":[]},"aj":{"aH":[]},"l":{"ak":["1"],"aH":[],"f":["1"]},"c3":{"br":[]},"cP":{"l":["1"],"ak":["1"],"aH":[],"f":["1"]},"b2":{"z":["1"]},"aG":{"ao":[],"K":[],"a6":["K"]},"bc":{"ao":[],"j":[],"K":[],"a6":["K"],"aa":[]},"c5":{"ao":[],"K":[],"a6":["K"],"aa":[]},"ai":{"k":[],"a6":["k"],"d1":[],"aa":[]},"c8":{"w":[]},"ba":{"f":["1"]},"I":{"f":["1"]},"bv":{"I":["1"],"f":["1"],"f.E":"1","I.E":"1"},"bj":{"z":["1"]},"N":{"I":["2"],"f":["2"],"f.E":"2","I.E":"2"},"ad":{"f":["1"],"f.E":"1"},"bz":{"z":["1"]},"bA":{"aR":[],"U":[]},"aU":{"aS":[],"U":[]},"bB":{"aT":[],"U":[]},"b9":{"a7":["1","2"]},"aF":{"b9":["1","2"],"a7":["1","2"]},"at":{"z":["1"]},"aE":{"a9":["1"],"bs":["1"],"f":["1"]},"ap":{"aE":["1"],"a9":["1"],"bs":["1"],"f":["1"]},"J":{"aE":["1"],"a9":["1"],"bs":["1"],"f":["1"]},"bm":{"w":[]},"c6":{"w":[]},"cg":{"w":[]},"ah":{"aq":[]},"bW":{"aq":[]},"bX":{"aq":[]},"ce":{"aq":[]},"cc":{"aq":[]},"aC":{"aq":[]},"cb":{"w":[]},"a_":{"aL":["1","2"],"e7":["1","2"],"a7":["1","2"]},"a0":{"f":["1"],"f.E":"1"},"ar":{"z":["1"]},"b":{"f":["1"],"f.E":"1"},"bi":{"z":["1"]},"M":{"f":["as<1,2>"],"f.E":"as<1,2>"},"bh":{"z":["as<1,2>"]},"bf":{"a_":["1","2"],"aL":["1","2"],"e7":["1","2"],"a7":["1","2"]},"aR":{"U":[]},"aS":{"U":[]},"aT":{"U":[]},"aI":{"iE":[],"d1":[]},"cm":{"bq":[],"aM":[]},"ch":{"f":["bq"],"f.E":"bq"},"ci":{"z":["bq"]},"cd":{"aM":[]},"cn":{"f":["aM"],"f.E":"aM"},"co":{"z":["aM"]},"cj":{"w":[]},"bD":{"w":[]},"au":{"a9":["1"],"bs":["1"],"f":["1"]},"av":{"z":["1"]},"aL":{"a7":["1","2"]},"a9":{"bs":["1"],"f":["1"]},"bC":{"a9":["1"],"bs":["1"],"f":["1"]},"bg":{"w":[]},"c7":{"w":[]},"ao":{"K":[],"a6":["K"]},"j":{"K":[],"a6":["K"]},"ak":{"f":["1"]},"K":{"a6":["K"]},"bq":{"aM":[]},"k":{"a6":["k"],"d1":[]},"bO":{"w":[]},"bx":{"w":[]},"Z":{"w":[]},"bp":{"w":[]},"c1":{"w":[]},"by":{"w":[]},"bu":{"w":[]},"bZ":{"w":[]},"c9":{"w":[]},"bt":{"w":[]},"aO":{"z":["j"]},"aQ":{"iS":[]}}'))
+var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{j:"int",ao:"double",K:"num",k:"String",x:"bool",bl:"Null",ak:"List",r:"Object",a8:"Map",aI:"JSObject"},mangledNames:{},types:["j?(E,E,R,R,e)","x(E,R,e)","x(q)","j(j,j)","j(q,q)","~(r?,r?)","E(a2)","x(j)","k(q)","x(E,R)","~(j,o)","x(k)","k(k)","j(a2,a2)","~(k,ao{detail:k?,intervals:j?})","j(j)","x(+accidentalDistance,tonality(j,e))","+accidentalDistance,tonality(j,e)(+accidentalDistance,tonality(j,e),+accidentalDistance,tonality(j,e))","k()","k(k,k,k)","j(@,@)","@(@)"],arrayRti:Symbol("$ti"),rttc:{"2;accidentalDistance,tonality":(a,b)=>c=>c instanceof A.bA&&a.b(c.a)&&b.b(c.b),"3;midi,name,pc":(a,b,c)=>d=>d instanceof A.aV&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"4;addCount,alterationCount,naturalCount,totalCount":a=>b=>b instanceof A.bB&&A.lg(a,b.a)}}
+A.ja(v.typeUniverse,JSON.parse('{"be":"aj","d2":"aj","ad":"aj","c4":{"x":[],"ab":[]},"bd":{"ab":[]},"aK":{"aI":[]},"aj":{"aI":[]},"l":{"ak":["1"],"aI":[],"f":["1"]},"c3":{"br":[]},"cP":{"l":["1"],"ak":["1"],"aI":[],"f":["1"]},"b2":{"z":["1"]},"aH":{"ao":[],"K":[],"a7":["K"]},"bc":{"ao":[],"j":[],"K":[],"a7":["K"],"ab":[]},"c5":{"ao":[],"K":[],"a7":["K"],"ab":[]},"ai":{"k":[],"a7":["k"],"d1":[],"ab":[]},"c8":{"w":[]},"ba":{"f":["1"]},"I":{"f":["1"]},"bv":{"I":["1"],"f":["1"],"f.E":"1","I.E":"1"},"bj":{"z":["1"]},"N":{"I":["2"],"f":["2"],"f.E":"2","I.E":"2"},"ae":{"f":["1"],"f.E":"1"},"bz":{"z":["1"]},"bA":{"aS":[],"U":[]},"aV":{"aT":[],"U":[]},"bB":{"aU":[],"U":[]},"b9":{"a8":["1","2"]},"aG":{"b9":["1","2"],"a8":["1","2"]},"at":{"z":["1"]},"aF":{"aa":["1"],"bs":["1"],"f":["1"]},"ap":{"aF":["1"],"aa":["1"],"bs":["1"],"f":["1"]},"J":{"aF":["1"],"aa":["1"],"bs":["1"],"f":["1"]},"bm":{"w":[]},"c6":{"w":[]},"cg":{"w":[]},"ah":{"aq":[]},"bW":{"aq":[]},"bX":{"aq":[]},"ce":{"aq":[]},"cc":{"aq":[]},"aD":{"aq":[]},"cb":{"w":[]},"a_":{"aM":["1","2"],"e7":["1","2"],"a8":["1","2"]},"a0":{"f":["1"],"f.E":"1"},"ar":{"z":["1"]},"b":{"f":["1"],"f.E":"1"},"bi":{"z":["1"]},"M":{"f":["as<1,2>"],"f.E":"as<1,2>"},"bh":{"z":["as<1,2>"]},"bf":{"a_":["1","2"],"aM":["1","2"],"e7":["1","2"],"a8":["1","2"]},"aS":{"U":[]},"aT":{"U":[]},"aU":{"U":[]},"aJ":{"iE":[],"d1":[]},"cm":{"bq":[],"aN":[]},"ch":{"f":["bq"],"f.E":"bq"},"ci":{"z":["bq"]},"cd":{"aN":[]},"cn":{"f":["aN"],"f.E":"aN"},"co":{"z":["aN"]},"cj":{"w":[]},"bD":{"w":[]},"au":{"aa":["1"],"bs":["1"],"f":["1"]},"av":{"z":["1"]},"aM":{"a8":["1","2"]},"aa":{"bs":["1"],"f":["1"]},"bC":{"aa":["1"],"bs":["1"],"f":["1"]},"bg":{"w":[]},"c7":{"w":[]},"ao":{"K":[],"a7":["K"]},"j":{"K":[],"a7":["K"]},"ak":{"f":["1"]},"K":{"a7":["K"]},"bq":{"aN":[]},"k":{"a7":["k"],"d1":[]},"bO":{"w":[]},"bx":{"w":[]},"Z":{"w":[]},"bp":{"w":[]},"c1":{"w":[]},"by":{"w":[]},"bu":{"w":[]},"bZ":{"w":[]},"c9":{"w":[]},"bt":{"w":[]},"aP":{"z":["j"]},"aR":{"iS":[]}}'))
 A.j9(v.typeUniverse,JSON.parse('{"ba":1,"bC":1,"bY":2,"c_":2}'))
 var u=(function rtii(){var t=A.F
-return{G:t("q"),u:t("o"),V:t("a6<@>"),I:t("aF<k,j>"),C:t("w"),Z:t("aq"),h:t("J<m>"),W:t("f<@>"),p:t("l<R>"),B:t("l<E>"),c:t("l<q>"),U:t("l<bR>"),d:t("l<a7<k,r?>>"),Q:t("l<+accidentalDistance,tonality(j,e)>"),k:t("l<+midi,name,pc(j?,k?,j)>"),f:t("l<aP>"),s:t("l<k>"),r:t("l<a2>"),b:t("l<@>"),t:t("l<j>"),T:t("bd"),o:t("aH"),L:t("be"),v:t("ak<x>"),j:t("ak<@>"),J:t("a7<@,@>"),Y:t("N<q,k>"),P:t("bl"),K:t("r"),M:t("me"),F:t("+()"),_:t("+accidentalDistance,tonality(j,e)"),e:t("bq"),N:t("k"),q:t("k(q)"),R:t("aa"),A:t("ac"),O:t("ad<+accidentalDistance,tonality(j,e)>"),m:t("a2"),y:t("x"),a:t("x(+accidentalDistance,tonality(j,e))"),i:t("ao"),S:t("j"),l:t("eS<bl>?"),z:t("aH?"),X:t("r?"),w:t("k?"),g:t("cl?"),x:t("x?"),D:t("ao?"),E:t("j?"),n:t("K?"),H:t("K")}})();(function constants(){var t=hunkHelpers.makeConstList
+return{G:t("q"),u:t("o"),V:t("a7<@>"),I:t("aG<k,j>"),C:t("w"),Z:t("aq"),h:t("J<m>"),W:t("f<@>"),p:t("l<R>"),B:t("l<E>"),c:t("l<q>"),U:t("l<bR>"),d:t("l<a8<k,r?>>"),Q:t("l<+accidentalDistance,tonality(j,e)>"),k:t("l<+midi,name,pc(j?,k?,j)>"),f:t("l<aQ>"),s:t("l<k>"),r:t("l<a2>"),b:t("l<@>"),t:t("l<j>"),T:t("bd"),o:t("aI"),L:t("be"),v:t("ak<x>"),j:t("ak<@>"),J:t("a8<@,@>"),Y:t("N<q,k>"),P:t("bl"),K:t("r"),M:t("mh"),F:t("+()"),_:t("+accidentalDistance,tonality(j,e)"),e:t("bq"),N:t("k"),q:t("k(q)"),R:t("ab"),A:t("ad"),O:t("ae<+accidentalDistance,tonality(j,e)>"),m:t("a2"),y:t("x"),a:t("x(+accidentalDistance,tonality(j,e))"),i:t("ao"),S:t("j"),l:t("eS<bl>?"),z:t("aI?"),X:t("r?"),w:t("k?"),g:t("cl?"),x:t("x?"),D:t("ao?"),E:t("j?"),n:t("K?"),H:t("K")}})();(function constants(){var t=hunkHelpers.makeConstList
 B.bG=J.c2.prototype
 B.a=J.l.prototype
 B.b=J.bc.prototype
-B.Y=J.aG.prototype
+B.Y=J.aH.prototype
 B.c=J.ai.prototype
-B.bH=J.aJ.prototype
+B.bH=J.aK.prototype
 B.b6=function getTagFallback(o) {
   var s = Object.prototype.toString.call(o);
   return s.substring(8, s.length - 1);
@@ -5561,7 +5573,7 @@ B.as=new A.q(11,"addFlat9")
 B.N=new A.q(2,"sharp9")
 B.R=new A.q(3,"addSharp9")
 B.o=new A.q(4,"eleven")
-B.q=new A.q(5,"sharp11")
+B.r=new A.q(5,"sharp11")
 B.I=new A.q(6,"flat13")
 B.l=new A.q(7,"thirteen")
 B.J=new A.q(8,"add9")
@@ -5580,7 +5592,7 @@ B.au=new A.b7(2,"academic")
 B.t=new A.m(0,"major")
 B.a2=new A.m(1,"majorFlat5")
 B.O=new A.m(10,"major6")
-B.ae=new A.m(11,"minor6")
+B.af=new A.m(11,"minor6")
 B.u=new A.m(12,"dominant7")
 B.a9=new A.m(13,"dominant7sus2")
 B.S=new A.m(14,"dominant7sus4")
@@ -5601,7 +5613,7 @@ B.an=new A.m(3,"minorSharp5")
 B.B=new A.m(4,"diminished")
 B.V=new A.m(5,"augmented")
 B.ao=new A.m(6,"power")
-B.af=new A.m(7,"sus2")
+B.ag=new A.m(7,"sus2")
 B.ap=new A.m(8,"sus4")
 B.a3=new A.m(9,"sus2sus4")
 B.f=new A.o(0,"root")
@@ -5620,17 +5632,17 @@ B.H=new A.o(2,"flat9")
 B.aq=new A.o(20,"add13")
 B.W=new A.o(21,"dim7")
 B.h=new A.o(22,"flat7")
-B.r=new A.o(23,"major7")
-B.ag=new A.o(3,"nine")
+B.q=new A.o(23,"major7")
+B.ah=new A.o(3,"nine")
 B.X=new A.o(4,"sharp9")
 B.ac=new A.o(5,"add9")
 B.av=new A.o(6,"addSharp9")
 B.k=new A.o(7,"minor3")
-B.ah=new A.o(8,"splitMinor3")
+B.ad=new A.o(8,"splitMinor3")
 B.e=new A.o(9,"major3")
 B.bI=new A.cT(null)
-B.ay=new A.aP(1,"naturalMinor")
-B.aX=new A.aP(2,"harmonicMinor")
+B.ay=new A.aQ(1,"naturalMinor")
+B.aX=new A.aQ(2,"harmonicMinor")
 B.bY=t([B.ay,B.aX],u.f)
 B.bZ=t(["Too many notes. Enter no more than 128 note names or MIDI numbers."],u.s)
 B.c_=t(["Type some notes, e.g. C E G or 60 64 67."],u.s)
@@ -5713,11 +5725,11 @@ B.by=new A.n(B.an,265,0)
 B.bz=new A.n(B.B,73,0)
 B.bA=new A.n(B.V,273,0)
 B.bB=new A.n(B.ao,129,0)
-B.bC=new A.n(B.af,133,0)
+B.bC=new A.n(B.ag,133,0)
 B.bD=new A.n(B.ap,161,0)
 B.bE=new A.n(B.a3,165,0)
 B.bf=new A.n(B.O,657,128)
-B.bg=new A.n(B.ae,649,128)
+B.bg=new A.n(B.af,649,128)
 B.bh=new A.n(B.u,1169,128)
 B.bi=new A.n(B.a9,1157,128)
 B.bj=new A.n(B.S,1185,128)
@@ -5734,7 +5746,7 @@ B.bu=new A.n(B.A,2185,128)
 B.bv=new A.n(B.F,1097,0)
 B.bw=new A.n(B.L,585,0)
 B.c1=t([B.be,B.bp,B.bx,B.by,B.bz,B.bA,B.bB,B.bC,B.bD,B.bE,B.bf,B.bg,B.bh,B.bi,B.bj,B.bk,B.bl,B.bm,B.bn,B.bo,B.bq,B.br,B.bs,B.bt,B.bu,B.bv,B.bw],A.F("l<n>"))
-B.ax=new A.aP(0,"major")
+B.ax=new A.aQ(0,"major")
 B.c2=t([B.ax],u.f)
 B.c3=t(["Input is too long. Enter no more than 512 characters."],u.s)
 B.ai=t([],u.U)
@@ -5744,25 +5756,25 @@ B.c6=t(["minor","major","min","maj"],u.s)
 B.Q=t(["C","D","E","F","G","A","B"],u.s)
 B.c7=t(["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"],u.s)
 B.c9={C:0,D:1,E:2,F:3,G:4,A:5,B:6}
-B.ar=new A.aF(B.c9,[0,2,4,5,7,9,11],u.I)
+B.ar=new A.aG(B.c9,[0,2,4,5,7,9,11],u.I)
 B.cb={major:0,dominant7:1,minor:2,minor7:3,major7:4,"dominant7|nine":5,diminished:6,major6:7,halfDiminished7:8,"dominant7|flat9":9,minor6:10,"dominant7|nine,eleven,thirteen":11,diminished7:12,dominant7Sharp5:13,"minor7|nine":14,augmented:15,dominant7sus4:16,"major7|nine":17,sus4:18,"major6|add9":19,"dominant7|sharp9":20,"dominant7sus4|nine":21,dominant7Flat5:22,"minor7|nine,eleven":23,sus2:24,minorMajor7:25,"dominant7|nine,sharp11":26,major7sus4:27,"dominant7Sharp5|flat9":28,"dominant7Sharp5|sharp9":29,"dominant7|flat9,add11,add13":30,"dominant7Sharp5|nine":31,"dominant7|sharp11":32,minorSharp5:33,"dominant7Flat5|flat9":34,"major|add9":35,"dominant7sus4|nine,eleven,thirteen":36,"dominant7|nine,eleven":37,"major7|nine,sharp11":38,"dominant7|nine,sharp11,thirteen":39,"dominant7Flat5|nine":40,"major7sus4|nine":41,"major7|nine,eleven,thirteen":42,"dominant7|sharp9,sharp11,flat13":43,"minor6|add9":44,minor7Sharp5:45,"dominant7Flat5|flat9,flat13":46,major7Sharp5:47,"dominant7Flat5|nine,eleven,thirteen":48,"dominant7sus4|flat9":49,"dominant7|flat9,nine,eleven,thirteen":50,"dominant7|flat13":51,"dominant7Flat5|nine,thirteen":52,"dominant7Flat5|sharp9":53,"dominant7|flat9,sharp11":54,"minor|add9":55,"major7|sharp11":56,"minor7|nine,eleven,thirteen":57,"dominant7|flat9,sharp11,add13":58,"major|add11":59,"dominant7sus4|sharp9":60,"minor|addFlat9":61,"major7sus4|add13":62,"dominant7|sharp9,flat13":63,"major7|nine,sharp11,thirteen":64,"dominant7|sharp9,add11,add13":65,"dominant7Sharp5|sharp9,sharp11":66,"major7Sharp5|nine":67,"dominant7|nine,eleven,sharp11,thirteen":68,"major7sus4|nine,eleven,thirteen":69,"minor7|add11":70,major7Flat5:71,"major|sharp11":72,"dominant7|flat9,flat13,add11":73,"minor|addSharp9":74,"dominant7|flat9,sharp9,sharp11,flat13":75,"dominant7Flat5|flat9,add11,add13":76,"dominant7|sharp9,sharp11,add13":77,"dominant7|flat9,flat13":78,"dominant7|nine,eleven,flat13":79,"major|addFlat9":80,"major7|sharp9":81,"dominant7Flat5|flat9,add13":82,"minor|add11":83,"dominant7Sharp5|sharp11":84,"major7sus4|flat9":85,"minor7|flat9":86,"dominant7Sharp5|nine,eleven,thirteen":87,"dominant7|sharp9,sharp11":88,"minorMajor7|nine":89,"minorMajor7|nine,eleven,thirteen":90,"minorMajor7|nine,sharp11":91,"dominant7Sharp5|flat9,add11,add13":92,"dominant7|add11":93,"halfDiminished7|nine":94,"major6|sharp11,add9":95,"major|sharp9":96,"dominant7Sharp5|nine,sharp11":97,"dominant7sus4|flat9,add11,add13":98,"halfDiminished7|nine,eleven":99,"major|add9,add11":100,"minor|addFlat9,add9":101,"minor|sharp11":102,"sus4|addFlat9":103,"minor6|flat9":104,"dominant7Sharp5|add11":105,"dominant7Sharp5|nine,thirteen":106,"dominant7|sharp11,flat13":107,"major7Flat5|nine":108,"sus4|add9":109,"augmented|add9":110,"diminished|add11":111,"diminished|addFlat9":112,"dominant7Sharp5|flat9,sharp11":113,"dominant7|nine,flat13":114,"halfDiminished7|flat9":115,"major7Sharp5|sharp9":116,"major7|add11":117,"major7|sharp9,sharp11":118}
-B.c8=new A.aF(B.cb,[377568,235374,126463,116677,40596,29941,24716,23897,14746,11213,10366,8947,8083,7470,5800,4760,4179,3440,2958,2943,2710,2530,2426,2193,1423,1365,1285,1127,1098,900,896,750,563,531,509,498,459,388,346,314,292,277,274,263,236,207,135,135,107,103,102,85,65,57,56,55,53,50,43,43,39,35,33,30,29,28,27,27,26,25,25,24,21,20,18,17,16,16,15,15,15,13,12,12,10,9,9,8,8,8,8,8,6,6,5,5,5,4,4,4,4,4,4,4,3,2,2,2,2,2,1,1,1,1,1,1,1,1,1],u.I)
+B.c8=new A.aG(B.cb,[377568,235374,126463,116677,40596,29941,24716,23897,14746,11213,10366,8947,8083,7470,5800,4760,4179,3440,2958,2943,2710,2530,2426,2193,1423,1365,1285,1127,1098,900,896,750,563,531,509,498,459,388,346,314,292,277,274,263,236,207,135,135,107,103,102,85,65,57,56,55,53,50,43,43,39,35,33,30,29,28,27,27,26,25,25,24,21,20,18,17,16,16,15,15,15,13,12,12,10,9,9,8,8,8,8,8,6,6,5,5,5,4,4,4,4,4,4,4,3,2,2,2,2,2,1,1,1,1,1,1,1,1,1],u.I)
 B.a0=new A.cY(0,"international")
 B.c5=t([],u.t)
 B.cd=new A.bn(B.c5)
-B.ad=new A.a8(0,"one")
-B.az=new A.a8(1,"two")
-B.aA=new A.a8(2,"three")
-B.aB=new A.a8(3,"four")
-B.aC=new A.a8(4,"five")
-B.aD=new A.a8(5,"six")
-B.aE=new A.a8(6,"seven")
+B.ae=new A.a9(0,"one")
+B.az=new A.a9(1,"two")
+B.aA=new A.a9(2,"three")
+B.aB=new A.a9(3,"four")
+B.aC=new A.a9(4,"five")
+B.aD=new A.a9(5,"six")
+B.aE=new A.a9(6,"seven")
 B.a8=new A.J([B.E,B.U],u.h)
 B.cc={A:0,B:1,C:2,D:3,E:4,F:5,G:6}
 B.ce=new A.ap(B.cc,7,A.F("ap<k>"))
 B.aF=new A.J([B.B,B.F],u.h)
 B.cf=new A.J([B.t,B.u,B.x],u.h)
-B.cg=new A.J([B.N,B.q],A.F("J<q>"))
+B.cg=new A.J([B.N,B.r],A.F("J<q>"))
 B.ca={}
 B.aY=new A.ap(B.ca,0,A.F("ap<q>"))
 B.ch=new A.J([B.E,B.A],u.h)
@@ -5770,38 +5782,38 @@ B.ci=new A.J([B.B,B.L],u.h)
 B.aj=new A.J([B.t,B.K],u.h)
 B.cj=new A.J([B.V,B.Z],u.h)
 B.aZ=new A.J([B.t,B.u],u.h)
-B.cQ=A.ma("r")})();(function staticFields(){$.P=A.i([],A.F("l<r>"))
+B.cQ=A.md("r")})();(function staticFields(){$.P=A.i([],A.F("l<r>"))
 $.eY=null
 $.eH=null
 $.eG=null
 $.dg=A.i([],A.F("l<ak<r>?>"))})();(function lazyInitializers(){var t=hunkHelpers.lazyFinal
-t($,"md","h_",()=>A.fU("_$dart_dartClosure"))
-t($,"mc","eB",()=>A.fU("_$dart_dartClosure_dartJSInterop"))
-t($,"mr","hb",()=>A.i([new J.c3()],A.F("l<br>")))
-t($,"mg","h1",()=>A.ab(A.d7({
+t($,"mg","h_",()=>A.fU("_$dart_dartClosure"))
+t($,"mf","eB",()=>A.fU("_$dart_dartClosure_dartJSInterop"))
+t($,"mu","hb",()=>A.i([new J.c3()],A.F("l<br>")))
+t($,"mj","h1",()=>A.ac(A.d7({
 toString:function(){return"$receiver$"}})))
-t($,"mh","h2",()=>A.ab(A.d7({$method$:null,
+t($,"mk","h2",()=>A.ac(A.d7({$method$:null,
 toString:function(){return"$receiver$"}})))
-t($,"mi","h3",()=>A.ab(A.d7(null)))
-t($,"mj","h4",()=>A.ab(function(){var $argumentsExpr$="$arguments$"
+t($,"ml","h3",()=>A.ac(A.d7(null)))
+t($,"mm","h4",()=>A.ac(function(){var $argumentsExpr$="$arguments$"
 try{null.$method$($argumentsExpr$)}catch(s){return s.message}}()))
-t($,"mm","h7",()=>A.ab(A.d7(void 0)))
-t($,"mn","h8",()=>A.ab(function(){var $argumentsExpr$="$arguments$"
+t($,"mp","h7",()=>A.ac(A.d7(void 0)))
+t($,"mq","h8",()=>A.ac(function(){var $argumentsExpr$="$arguments$"
 try{(void 0).$method$($argumentsExpr$)}catch(s){return s.message}}()))
-t($,"ml","h6",()=>A.ab(A.f6(null)))
-t($,"mk","h5",()=>A.ab(function(){try{null.$method$}catch(s){return s.message}}()))
-t($,"mp","ha",()=>A.ab(A.f6(void 0)))
-t($,"mo","h9",()=>A.ab(function(){try{(void 0).$method$}catch(s){return s.message}}()))
-t($,"mq","b0",()=>A.ez(B.cQ))
-t($,"mb","fZ",()=>A.iv(u.S,A.F("ak<E>")))
-t($,"mt","eC",()=>A.i([A.u(A.t(B.t),3080,!1),A.u(A.t(B.a2),3208,!1),A.u(A.t(B.E),3088,!1),A.u(A.t(B.an),3216,!1),A.u(A.t(B.B),144,!1),A.u(A.t(B.V),136,!1),A.u(A.t(B.ao),3928,!1),A.u(A.t(B.af),3096,!1),A.u(A.t(B.ap),3096,!1),A.u(A.t(B.a3),0,!0),A.u(A.t(B.O),3080,!1),A.u(A.t(B.ae),3088,!1),A.u(A.t(B.u),2056,!1),A.u(A.t(B.a9),2104,!1),A.u(A.t(B.S),2072,!1),A.u(A.t(B.y),2184,!1),A.u(A.t(B.x),2184,!1),A.u(A.t(B.K),1032,!1),A.u(A.t(B.am),1080,!1),A.u(A.t(B.aa),1048,!1),A.u(A.t(B.T),1160,!1),A.u(A.t(B.Z),1160,!1),A.u(A.t(B.U),2064,!1),A.u(A.t(B.ab),2192,!1),A.u(A.t(B.A),1040,!1),A.u(A.t(B.F),2192,!1),A.u(A.t(B.L),3216,!1)],A.F("l<b8>")))
-t($,"mu","eD",()=>A.i([A.h("prefer dominant flat-nine shell over colored diminished",A.lr(),new A.dB()),A.h("prefer flat-nine-bass dominant over remote reinterpretation",A.lI(),new A.dC()),A.h("prefer complete dominant sharp-nine over non-seventh color",A.ls(),new A.dD()),A.h("prefer complete altered sharp-five dominant over remote spellings",A.lp(),new A.dI()),A.h("prefer conventional inversion in split-nine tritone dominant ambiguity",A.lB(),new A.dJ()),A.h("prefer altered dominant7 over dim7 slash",A.ll(),new A.dK()),A.h("prefer conventional altered seventh over add11 slash",A.lz(),new A.dL()),A.h("prefer close root-position dominant7 over non-dominant slash",A.lE(),new A.dM()),A.h("prefer ninth-bass seventh chord over altered slash",A.lP(),new A.dN()),A.h("prefer root-position altered-fifth dominant over slash",A.lS(),new A.dO()),A.h("prefer root-position add-chord over sus slash",A.lR(),new A.dP()),A.h("prefer complete triad over structurally deficient reading",A.lx(),new A.dE()),A.h("prefer root-position minor-eleventh shell over sus slash",A.lV(),new A.dF()),A.h("prefer simple triad add-tone over seventh-family unusual quality",A.lY(),new A.dG()),A.h("prefer readable sharp-eleven major over flat-five spelling",A.lQ(),new A.dH())],A.F("l<bk>")))
-t($,"mv","hd",()=>{var s=null
-return A.i([A.h("prefer voicing-supported upper-structure slash",A.m0(),s),A.h("prefer root-position 6th over inverted 7th",A.lj(),s),A.h("prefer complete triad over incomplete 6th",A.ly(),s),A.h("prefer upper-structure dominant7 slash",A.m_(),s),A.h("prefer major-seventh upper-structure sus slash",A.lN(),s),A.h("prefer root-position dominant sus over slash",A.lT(),s),A.h("prefer cleaner-spelled tritone-twin extended dominant",A.lm(),s),A.h("prefer stable extended dominant over altered-fifth slash",A.lU(),s),A.h("prefer complete altered thirteenth dominant over altered minor thirteenth",A.lq(),s),A.h("prefer complete flat-nine flat-thirteen dominant over remote spelling",A.lt(),s),A.h("prefer complete major sharp-eleven inversion over major13sus4",A.lv(),s),A.h("prefer complete major inversion over seventh-family color-bass slash",A.lu(),s),A.h("prefer root-position diminished7",A.lD(),s),A.h("prefer dominant7 shell slash over non-dominant seventh-family slash",A.lF(),s),A.h("prefer voicing that names every tone",A.lJ(),s),A.h("prefer lower-cost add chord over missing-third unusual seventh",A.lL(),s),A.h("prefer harmonic-minor tonic over split-third inversion",A.lK(),s),A.h("prefer lower-cost major-seventh-bass inversion over color-bass slash",A.lM(),s),A.h("prefer fewer altered/tension colors",A.lG(),s),A.h("prefer diatonic chords",A.lC(),s),A.h("prefer root-position relative minor7 over major6 slash",A.lW(),s),A.h("prefer tonic chord",A.lZ(),s),A.h("prefer complete triad add-tone over sparse seventh-family color",A.lw(),s),A.h("prefer natural extensions over adds, then fewer total",A.lO(),s),A.h("prefer root position",A.lX(),s),A.h("prefer common naming preference",A.kW(),s),A.h("prefer cleaner tritone flat-five dominant spelling",A.lo(),s),A.h("prefer more conventional inversion",A.lA(),s),A.h("prefer 7th chords over triads",A.lk(),s),A.h("prefer fewer extensions",A.lH(),s),A.h("avoid suspended chords",A.li(),s),A.h("prefer cleaner spelling",A.ln(),s)],A.F("l<bk>"))})
-t($,"ms","hc",()=>{var s,r,q=A.aK(A.F("m"),A.F("n"))
+t($,"mo","h6",()=>A.ac(A.f6(null)))
+t($,"mn","h5",()=>A.ac(function(){try{null.$method$}catch(s){return s.message}}()))
+t($,"ms","ha",()=>A.ac(A.f6(void 0)))
+t($,"mr","h9",()=>A.ac(function(){try{(void 0).$method$}catch(s){return s.message}}()))
+t($,"mt","b0",()=>A.ez(B.cQ))
+t($,"me","fZ",()=>A.iv(u.S,A.F("ak<E>")))
+t($,"mw","eC",()=>A.i([A.u(A.t(B.t),3080,!1),A.u(A.t(B.a2),3208,!1),A.u(A.t(B.E),3088,!1),A.u(A.t(B.an),3216,!1),A.u(A.t(B.B),144,!1),A.u(A.t(B.V),136,!1),A.u(A.t(B.ao),3928,!1),A.u(A.t(B.ag),3096,!1),A.u(A.t(B.ap),3096,!1),A.u(A.t(B.a3),0,!0),A.u(A.t(B.O),3080,!1),A.u(A.t(B.af),3088,!1),A.u(A.t(B.u),2056,!1),A.u(A.t(B.a9),2104,!1),A.u(A.t(B.S),2072,!1),A.u(A.t(B.y),2184,!1),A.u(A.t(B.x),2184,!1),A.u(A.t(B.K),1032,!1),A.u(A.t(B.am),1080,!1),A.u(A.t(B.aa),1048,!1),A.u(A.t(B.T),1160,!1),A.u(A.t(B.Z),1160,!1),A.u(A.t(B.U),2064,!1),A.u(A.t(B.ab),2192,!1),A.u(A.t(B.A),1040,!1),A.u(A.t(B.F),2192,!1),A.u(A.t(B.L),3216,!1)],A.F("l<b8>")))
+t($,"mx","eD",()=>A.i([A.h("prefer dominant flat-nine shell over colored diminished",A.lt(),new A.dB()),A.h("prefer flat-nine-bass dominant over remote reinterpretation",A.lK(),new A.dC()),A.h("prefer complete dominant sharp-nine over non-seventh color",A.lu(),new A.dD()),A.h("prefer complete altered sharp-five dominant over remote spellings",A.lr(),new A.dI()),A.h("prefer conventional inversion in split-nine tritone dominant ambiguity",A.lD(),new A.dJ()),A.h("prefer altered dominant7 over dim7 slash",A.ln(),new A.dK()),A.h("prefer conventional altered seventh over add11 slash",A.lB(),new A.dL()),A.h("prefer close root-position dominant7 over non-dominant slash",A.lG(),new A.dM()),A.h("prefer ninth-bass seventh chord over altered slash",A.lR(),new A.dN()),A.h("prefer root-position altered-fifth dominant over slash",A.lU(),new A.dO()),A.h("prefer root-position add-chord over sus slash",A.lT(),new A.dP()),A.h("prefer complete triad over structurally deficient reading",A.lz(),new A.dE()),A.h("prefer root-position minor-eleventh shell over sus slash",A.lX(),new A.dF()),A.h("prefer simple triad add-tone over seventh-family unusual quality",A.m_(),new A.dG()),A.h("prefer readable sharp-eleven major over flat-five spelling",A.lS(),new A.dH())],A.F("l<bk>")))
+t($,"my","hd",()=>{var s=null
+return A.i([A.h("prefer voicing-supported upper-structure slash",A.m2(),s),A.h("prefer root-position 6th over inverted 7th",A.ll(),s),A.h("prefer complete triad over incomplete 6th",A.lA(),s),A.h("prefer upper-structure dominant7 slash",A.m1(),s),A.h("prefer major-seventh upper-structure sus slash",A.lP(),s),A.h("prefer root-position dominant sus over slash",A.lV(),s),A.h("prefer cleaner-spelled tritone-twin extended dominant",A.lo(),s),A.h("prefer stable extended dominant over altered-fifth slash",A.lW(),s),A.h("prefer complete altered thirteenth dominant over altered minor thirteenth",A.ls(),s),A.h("prefer complete flat-nine flat-thirteen dominant over remote spelling",A.lv(),s),A.h("prefer complete major sharp-eleven inversion over major13sus4",A.lx(),s),A.h("prefer complete major inversion over seventh-family color-bass slash",A.lw(),s),A.h("prefer root-position diminished7",A.lF(),s),A.h("prefer dominant7 shell slash over non-dominant seventh-family slash",A.lH(),s),A.h("prefer voicing that names every tone",A.lL(),s),A.h("prefer lower-cost add chord over missing-third unusual seventh",A.lN(),s),A.h("prefer harmonic-minor tonic over split-third inversion",A.lM(),s),A.h("prefer lower-cost major-seventh-bass inversion over color-bass slash",A.lO(),s),A.h("prefer fewer altered/tension colors",A.lI(),s),A.h("prefer diatonic chords",A.lE(),s),A.h("prefer root-position relative minor7 over major6 slash",A.lY(),s),A.h("prefer tonic chord",A.m0(),s),A.h("prefer complete triad add-tone over sparse seventh-family color",A.ly(),s),A.h("prefer natural extensions over adds, then fewer total",A.lQ(),s),A.h("prefer root position",A.lZ(),s),A.h("prefer common naming preference",A.kY(),s),A.h("prefer cleaner tritone flat-five dominant spelling",A.lq(),s),A.h("prefer more conventional inversion",A.lC(),s),A.h("prefer 7th chords over triads",A.lm(),s),A.h("prefer fewer extensions",A.lJ(),s),A.h("avoid suspended chords",A.lk(),s),A.h("prefer cleaner spelling",A.lp(),s)],A.F("l<bk>"))})
+t($,"mv","hc",()=>{var s,r,q=A.aL(A.F("m"),A.F("n"))
 for(s=0;s<27;++s){r=B.c1[s]
 q.t(0,r.a,r)}return q})
-t($,"mf","h0",()=>{var s,r,q,p=A.aK(A.F("m"),A.F("b8"))
+t($,"mi","h0",()=>{var s,r,q,p=A.aL(A.F("m"),A.F("b8"))
 for(s=$.eC(),r=0;r<27;++r){q=s[r]
 p.t(0,q.a,q)}return p})})();(function nativeSupport(){!function(){var t=function(a){var n={}
 n[a]=1
@@ -5827,5 +5839,5 @@ convertToFastObject($);(function(a){if(typeof document==="undefined"){a(null)
 return}if(typeof document.currentScript!="undefined"){a(document.currentScript)
 return}var t=document.scripts
 function onLoad(b){for(var r=0;r<t.length;++r){t[r].removeEventListener("load",onLoad,false)}a(b.target)}for(var s=0;s<t.length;++s){t[s].addEventListener("load",onLoad,false)}})(function(a){v.currentScript=a
-var t=A.lc
+var t=A.le
 if(typeof dartMainRunner==="function"){dartMainRunner(t,[])}else{t([])}})})()

--- a/lib/features/theory/domain/services/note_spelling.dart
+++ b/lib/features/theory/domain/services/note_spelling.dart
@@ -44,6 +44,66 @@ String spellPitchClass(
   return targetLetter + _accidentalToAscii(delta);
 }
 
+/// Spells a slash-bass pitch class, balancing function against readability.
+///
+/// A slash bass names the sounding note under the chord symbol, so its job is
+/// performer readability rather than restating the chord's interior harmonic
+/// role. Genuine chord-tone inversions (root, 3rd, perfect 5th, 7th) keep their
+/// conventional functional spelling even when that is a wrap letter, so a
+/// C#maj7 with its leading tone in the bass stays C#maj7/B#. For other bass
+/// roles (tensions, altered fifths, added tones), a functional spelling that
+/// forces a double accidental or a wrap enharmonic (B#, E#, Cb, Fb) is replaced
+/// by the plainest sounding-pitch spelling. That keeps A13(#9,#11) over C as
+/// .../C instead of the awkward .../B#, and Db7(b5) over G as .../G instead of
+/// .../Abb, while the chord body still carries the harmonic role.
+String spellSlashBass(
+  int pc, {
+  required Tonality tonality,
+  String? chordRootName,
+  ChordToneRole? role,
+}) {
+  final functional = spellPitchClass(
+    pc,
+    tonality: tonality,
+    chordRootName: chordRootName,
+    role: role,
+  );
+
+  if (role == null || _isConventionalInversionTone(role)) {
+    return functional;
+  }
+
+  if (_isReadableBassSpelling(functional)) return functional;
+
+  return pcToName(pc, tonality: tonality);
+}
+
+/// Roles whose conventional slash spelling should always be preserved, even as
+/// a wrap letter (e.g. C#maj7/B#). These are the true inversion tones.
+bool _isConventionalInversionTone(ChordToneRole role) {
+  return switch (role) {
+    ChordToneRole.root ||
+    ChordToneRole.minor3 ||
+    ChordToneRole.splitMinor3 ||
+    ChordToneRole.major3 ||
+    ChordToneRole.perfect5 ||
+    ChordToneRole.flat7 ||
+    ChordToneRole.major7 => true,
+    _ => false,
+  };
+}
+
+/// A bass spelling reads cleanly unless it needs a double accidental or is a
+/// wrap enharmonic (B#, E#, Cb, Fb).
+bool _isReadableBassSpelling(String name) {
+  final ascii = normalizeNoteNameToAscii(name);
+  if (ascii.length < 2) return true; // natural letter
+
+  final accidental = ascii.substring(1);
+  if (accidental == 'x' || accidental.length >= 2) return false; // double
+  return !(ascii == 'B#' || ascii == 'E#' || ascii == 'Cb' || ascii == 'Fb');
+}
+
 /// Chooses a root spelling that keeps the whole chord readable.
 ///
 /// Tonality still matters, but role-aware member spellings can override a

--- a/lib/features/theory/presentation/services/chord_symbol_builder.dart
+++ b/lib/features/theory/presentation/services/chord_symbol_builder.dart
@@ -16,7 +16,7 @@ class ChordSymbolBuilder {
     if (identity.hasSlashBass) {
       final interval = (identity.bassPc - identity.rootPc) % 12;
       final role = identity.toneRolesByInterval[interval];
-      bass = spellPitchClass(
+      bass = spellSlashBass(
         identity.bassPc,
         tonality: tonality,
         chordRootName: root,

--- a/test/chord_analyzer_ranking_golden_test.dart
+++ b/test/chord_analyzer_ranking_golden_test.dart
@@ -553,7 +553,7 @@ void main() {
     golden(
       description:
           'complete altered dominant sharp-nine bass beats sus add-color',
-      expectedSymbol: 'A7(#5,#9)/B#',
+      expectedSymbol: 'A7(#5,#9)/C',
       pcs: ['C', 'Db', 'F', 'G', 'A'],
       bass: 'C',
       expectedRoot: 'A',
@@ -576,7 +576,7 @@ void main() {
     golden(
       description:
           'complete sharp-nine sharp-eleven dominant beats split-third sixth',
-      expectedSymbol: 'A7(#9,#11)/B#',
+      expectedSymbol: 'A7(#9,#11)/C',
       pcs: ['C', 'Db', 'Eb', 'E', 'G', 'A'],
       bass: 'C',
       expectedRoot: 'A',
@@ -612,7 +612,7 @@ void main() {
     golden(
       description:
           'complete altered dominant thirteenth beats colored split-third sixth',
-      expectedSymbol: 'A13(#9,#11)/B#',
+      expectedSymbol: 'A13(#9,#11)/C',
       expectedAlternatives: ['Eb13(b9,#9,#11)/C'],
       pcs: ['C', 'Db', 'Eb', 'E', 'F#', 'G', 'A'],
       bass: 'C',
@@ -694,7 +694,7 @@ void main() {
     golden(
       description:
           'complete flat-thirteenth altered dominant beats root-position add-eleven split-third sixth',
-      expectedSymbol: 'F#7(#9,#11,b13)/Gx',
+      expectedSymbol: 'F#7(#9,#11,b13)/A',
       pcs: ['C', 'Db', 'D', 'E', 'F#', 'A', 'Bb'],
       bass: 'A',
       expectedRoot: 'F#',
@@ -1175,7 +1175,7 @@ void main() {
       description:
           'seventh-bass flat-five dominant beats altered-fifth bass dominant',
       expectedSymbol: 'D9b5/C',
-      expectedAlternatives: ['E9#5/B#', 'Ab7(#5,#11)/C'],
+      expectedAlternatives: ['E9#5/C', 'Ab7(#5,#11)/C'],
       pcs: ['C', 'D', 'E', 'F#', 'Ab'],
       bass: 'C',
       expectedRoot: 'D',
@@ -1210,8 +1210,8 @@ void main() {
     golden(
       description:
           'complete lydian flat-thirteen dominant beats remote altered fifth dominant',
-      expectedSymbol: 'F#9(#11,b13)/B#',
-      expectedAlternatives: ['E13(#5,#11)/B#'],
+      expectedSymbol: 'F#9(#11,b13)/C',
+      expectedAlternatives: ['E13(#5,#11)/C'],
       pcs: ['C', 'Db', 'D', 'E', 'F#', 'Ab', 'Bb'],
       bass: 'C',
       expectedRoot: 'F#',
@@ -1293,7 +1293,7 @@ void main() {
       description:
           'complete altered flat-nine dominant beats remote minor thirteenth',
       expectedSymbol: 'C9(b9,#11)',
-      expectedAlternatives: ['F#7(b9,#11,b13)/B#'],
+      expectedAlternatives: ['F#7(b9,#11,b13)/C'],
       pcs: ['C', 'Db', 'D', 'E', 'F#', 'G', 'Bb'],
       bass: 'C',
       expectedRoot: 'C',

--- a/test/chord_analyzer_spelling_golden_test.dart
+++ b/test/chord_analyzer_spelling_golden_test.dart
@@ -65,6 +65,69 @@ void main() {
       expectedBass: 'Ab',
       expectedQuality: ChordQualityToken.augmented,
     ),
+
+    // -------------------------------------------------------------------------
+    // Slash bass readability: a color/altered tone in the bass names the
+    // sounding pitch, not its interior role, so it avoids wrap and double
+    // accidental spellings. The chord body still carries the harmonic role.
+    // -------------------------------------------------------------------------
+
+    // A #9 in the bass would functionally spell as B# (a wrap); prefer C.
+    golden(
+      description: 'sharp-nine bass avoids wrap spelling',
+      expectedSymbol: 'A7#9/C',
+      pcs: ['A', 'C#', 'E', 'G', 'C'],
+      bass: 'C',
+      expectedRoot: 'A',
+      expectedBass: 'C',
+      expectedQuality: ChordQualityToken.dominant7,
+    ),
+
+    // A #9 in the bass would functionally spell as Cx (double sharp); prefer D.
+    golden(
+      description: 'sharp-nine bass avoids double-sharp spelling',
+      expectedSymbol: 'B7#9/D',
+      pcs: ['B', 'D#', 'F#', 'A', 'D'],
+      bass: 'D',
+      expectedRoot: 'B',
+      expectedBass: 'D',
+      expectedQuality: ChordQualityToken.dominant7,
+    ),
+
+    // Stacked tensions in the bass stay readable while the body names the roles.
+    golden(
+      description: 'upper-structure tension bass stays readable',
+      expectedSymbol: 'A13(#9,#11)/C',
+      pcs: ['A', 'C#', 'E', 'G', 'C', 'D#', 'F#'],
+      bass: 'C',
+      expectedRoot: 'A',
+      expectedBass: 'C',
+      expectedQuality: ChordQualityToken.dominant7,
+    ),
+
+    // Contrast: a genuine chord-tone inversion keeps its functional spelling
+    // even as a wrap letter. In C# major the major seventh is B#, not C.
+    golden(
+      description: 'major-seventh bass inversion keeps wrap spelling',
+      expectedSymbol: 'C#maj7/B#',
+      pcs: ['C#', 'E#', 'G#', 'B#'],
+      bass: 'B#',
+      tonality: const Tonality(Tonic.cSharp, TonalityMode.major),
+      expectedRoot: 'C#',
+      expectedBass: 'B#',
+      expectedQuality: ChordQualityToken.major7,
+    ),
+
+    // Contrast: the major third in the bass keeps its sharp inversion spelling.
+    golden(
+      description: 'major-third bass inversion keeps sharp spelling',
+      expectedSymbol: 'F#7/A#',
+      pcs: ['F#', 'A#', 'C#', 'E'],
+      bass: 'A#',
+      expectedRoot: 'F#',
+      expectedBass: 'A#',
+      expectedQuality: ChordQualityToken.dominant7,
+    ),
   ];
 
   runChordAnalyzerGoldenCases(cases);


### PR DESCRIPTION
The slash in a chord symbol names the pitch a player sounds, so it should favor a readable spelling rather than restating the bass note's interior harmonic role. Previously the bass was always spelled by functional degree, producing awkward results when a tension sat in the bass: A13(#9,#11)/B# instead of /C, or F#7(#9,#11,b13)/Gx.

Add spellSlashBass, which keeps conventional inversion spellings for the root, 3rd, perfect 5th, and 7th (so C#maj7/B# is preserved) but falls back to the plain sounding-pitch spelling for other bass roles when the functional letter would require a double accidental or a wrap enharmonic (B#, E#, Cb, Fb). The chord body still carries the harmonic role.

Update the affected golden expectations, add cases pinning both the fix and the preserved inversion spellings, and document the rule in the Slash Bass section of the chord symbol guide.