### PR TITLE
Add progression-pattern detection and adopt it in the hybrid

### DIFF
--- a/lib/features/key/domain/detectors/hybrid_key_detector.dart
+++ b/lib/features/key/domain/detectors/hybrid_key_detector.dart
@@ -1,31 +1,42 @@
 import 'package:whatchord/features/history/history_domain.dart';
-import 'package:whatchord/features/theory/domain/theory_domain.dart';
 
 import '../models/key_estimate.dart';
 import 'key_detector.dart';
 import 'key_profiles.dart';
+import 'key_space.dart';
 import 'profile_correlation_key_detector.dart';
+import 'progression_key_detector.dart';
 import 'weighted_evidence_key_detector.dart';
 
 /// Hybrid key detection: profile correlation as the base score with the
-/// weighted evidence model's functional points as an adjustment.
+/// weighted evidence model's functional points, and optionally the
+/// progression detector's transition points, as adjustments.
 ///
-/// The two ingredients fail in complementary places (log entry 2026-07-07-03):
-/// histograms are robust on dense romantic harmony but blind to function, so
-/// they lag modulations; the functional rules track cadences but tie on
-/// purely diatonic or dominant-heavy stretches. Per key, the hybrid score is
+/// The ingredients fail in complementary places (log entries 2026-07-07-03
+/// and -04): histograms are robust on dense romantic harmony but blind to
+/// function, so they lag modulations; the functional rules track cadences but
+/// tie on purely diatonic or dominant-heavy stretches. Per key, the hybrid
+/// score is
 ///
-///   correlation + functionalBlend * functional points per weighted event
+///   correlation
+///     + functionalBlend * functional points per weighted event
+///     + progressionBlend * progression points per weighted event
 ///
 /// so profile shape breaks functional ties and functional evidence moves the
-/// histogram's supertanker at key changes. `functionalBlend: 0` reduces to
-/// pure profile correlation, which is the ablation anchor.
+/// histogram's supertanker at key changes. With both blends at zero this
+/// reduces exactly to pure profile correlation, the ablation anchor; each
+/// term toggles independently per the protocol's ablation rules.
 class HybridKeyDetector implements KeyDetector {
   final ProfileCorrelationKeyDetector _profile;
   final WeightedEvidenceKeyDetector _evidence;
+  final ProgressionKeyDetector _progression;
 
   /// Weight of one functional point per weighted event, in correlation units.
   final double functionalBlend;
+
+  /// Weight of one progression point per weighted event, in correlation
+  /// units. Zero disables the progression term entirely.
+  final double progressionBlend;
   final int minEvents;
   final double marginFloor;
 
@@ -40,6 +51,9 @@ class HybridKeyDetector implements KeyDetector {
     // 0.1-0.15 and the paired test against the profile floor is decisive
     // there (log entry 2026-07-07-04).
     this.functionalBlend = 0.1,
+    // Selected on the development split: paired coverage win at unchanged
+    // accuracy, plus more modulations matched (log entry 2026-07-07-08).
+    this.progressionBlend = 0.02,
     this.minEvents = 3,
     this.marginFloor = 0.05,
   }) : _profile = ProfileCorrelationKeyDetector(
@@ -55,6 +69,13 @@ class HybridKeyDetector implements KeyDetector {
          confidenceWeighted: confidenceWeighted,
          minEvents: 1,
          marginFloor: 0,
+       ),
+       _progression = ProgressionKeyDetector(
+         durationWeighted: durationWeighted,
+         decayHalfLife: decayHalfLife,
+         confidenceWeighted: confidenceWeighted,
+         minEvents: 1,
+         marginFloor: 0,
        );
 
   @override
@@ -62,14 +83,17 @@ class HybridKeyDetector implements KeyDetector {
 
   @override
   String get configuration =>
-      'functionalBlend=$functionalBlend minEvents=$minEvents '
-      'marginFloor=$marginFloor | profile: ${_profile.configuration} '
-      '| evidence: ${_evidence.configuration}';
+      'functionalBlend=$functionalBlend progressionBlend=$progressionBlend '
+      'minEvents=$minEvents marginFloor=$marginFloor '
+      '| profile: ${_profile.configuration} '
+      '| evidence: ${_evidence.configuration} '
+      '| progression: ${_progression.configuration}';
 
   @override
   void reset() {
     _profile.reset();
     _evidence.reset();
+    _progression.reset();
     _eventCount = 0;
   }
 
@@ -77,24 +101,31 @@ class HybridKeyDetector implements KeyDetector {
   KeyEstimateFrame onEvent(ChordEvent event) {
     final profileFrame = _profile.onEvent(event);
     final evidenceFrame = _evidence.onEvent(event);
+    final progressionFrame = _progression.onEvent(event);
     _eventCount += 1;
 
     final combined = <int, double>{};
     for (final estimate in profileFrame.ranked) {
-      combined[_keyIndex(estimate.tonality)] = estimate.confidence;
+      combined[KeySpace.index(estimate.tonality)] = estimate.confidence;
     }
-    for (final estimate in evidenceFrame.ranked) {
-      combined.update(
-        _keyIndex(estimate.tonality),
-        (base) => base + functionalBlend * estimate.confidence,
-        ifAbsent: () => functionalBlend * estimate.confidence,
-      );
+    void blend(List<KeyEstimate> ranked, double factor) {
+      if (factor == 0) return;
+      for (final estimate in ranked) {
+        combined.update(
+          KeySpace.index(estimate.tonality),
+          (base) => base + factor * estimate.confidence,
+          ifAbsent: () => factor * estimate.confidence,
+        );
+      }
     }
+
+    blend(evidenceFrame.ranked, functionalBlend);
+    blend(progressionFrame.ranked, progressionBlend);
     if (combined.isEmpty) return const KeyEstimateFrame.abstain([]);
 
     final byIndex = {
-      for (final tonality in ProfileCorrelationKeyDetector.canonicalTonalities)
-        _keyIndex(tonality): tonality,
+      for (final tonality in KeySpace.canonicalTonalities)
+        KeySpace.index(tonality): tonality,
     };
     final ranked = [
       for (final entry in combined.entries)
@@ -110,7 +141,4 @@ class HybridKeyDetector implements KeyDetector {
     }
     return KeyEstimateFrame(ranked: ranked, claim: ranked.first);
   }
-
-  static int _keyIndex(Tonality tonality) =>
-      tonality.tonicPitchClass * 2 + (tonality.isMinor ? 1 : 0);
 }

--- a/lib/features/key/domain/detectors/key_space.dart
+++ b/lib/features/key/domain/detectors/key_space.dart
@@ -1,0 +1,40 @@
+import 'package:whatchord/features/theory/domain/theory_domain.dart';
+
+/// The 24-key space shared by every detector: canonical tonalities and the
+/// per-key scale membership masks.
+abstract final class KeySpace {
+  /// One canonical `Tonality` per (pitch class, mode) pair, taken from the key
+  /// signature table. Detection is pitch-class based; enharmonic spelling is a
+  /// presentation concern.
+  static final List<Tonality> canonicalTonalities = _canonicalTonalities();
+
+  static List<Tonality> _canonicalTonalities() {
+    final byKey = <int, Tonality>{};
+    for (final row in keySignatureRows) {
+      for (final tonality in [row.relativeMajor, row.relativeMinor]) {
+        byKey.putIfAbsent(index(tonality), () => tonality);
+      }
+    }
+    assert(byKey.length == 24);
+    return List.unmodifiable(byKey.values);
+  }
+
+  /// Stable index of a tonality in the 24-key space.
+  static int index(Tonality tonality) =>
+      tonality.tonicPitchClass * 2 + (tonality.isMinor ? 1 : 0);
+
+  /// Scale pitch classes per key. Major keys use the major scale; minor keys
+  /// use natural union harmonic minor, mirroring `ScaleDegreeClassifier`'s
+  /// sources so the harmonic-minor dominant is diatonic evidence.
+  static int scaleMask(Tonality tonality) {
+    final relative = tonality.isMajor ? _majorMask : _minorMask;
+    final tonic = tonality.tonicPitchClass;
+    return ((relative << tonic) | (relative >> (12 - tonic))) & 0xFFF;
+  }
+
+  // 0,2,4,5,7,9,11
+  static const int _majorMask = 0xAB5;
+
+  // Natural {0,2,3,5,7,8,10} union harmonic {..., 11}: 0,2,3,5,7,8,10,11
+  static const int _minorMask = 0xDAD;
+}

--- a/lib/features/key/domain/detectors/profile_correlation_key_detector.dart
+++ b/lib/features/key/domain/detectors/profile_correlation_key_detector.dart
@@ -6,6 +6,7 @@ import 'package:whatchord/features/theory/domain/theory_domain.dart';
 import '../models/key_estimate.dart';
 import 'key_detector.dart';
 import 'key_profiles.dart';
+import 'key_space.dart';
 
 /// Profile-correlation key detection (Krumhansl-Schmuckler family): the floor
 /// every later model must beat.
@@ -141,22 +142,9 @@ class ProfileCorrelationKeyDetector implements KeyDetector {
     return covariance / (histogram.deviation * profileStats.deviation);
   }
 
-  /// One canonical `Tonality` per (pitch class, mode) pair, taken from the key
-  /// signature table. Detection is pitch-class based; enharmonic spelling is a
-  /// presentation concern.
-  static final List<Tonality> canonicalTonalities = _canonicalTonalities();
-
-  static List<Tonality> _canonicalTonalities() {
-    final byKey = <int, Tonality>{};
-    for (final row in keySignatureRows) {
-      for (final tonality in [row.relativeMajor, row.relativeMinor]) {
-        final key = tonality.tonicPitchClass * 2 + (tonality.isMinor ? 1 : 0);
-        byKey.putIfAbsent(key, () => tonality);
-      }
-    }
-    assert(byKey.length == 24);
-    return List.unmodifiable(byKey.values);
-  }
+  /// See [KeySpace.canonicalTonalities]; kept here as the historical access
+  /// point.
+  static List<Tonality> get canonicalTonalities => KeySpace.canonicalTonalities;
 }
 
 class _VectorStats {

--- a/lib/features/key/domain/detectors/progression_key_detector.dart
+++ b/lib/features/key/domain/detectors/progression_key_detector.dart
@@ -1,0 +1,301 @@
+import 'dart:math' as math;
+
+import 'package:whatchord/features/history/history_domain.dart';
+import 'package:whatchord/features/theory/domain/theory_domain.dart';
+
+import '../models/key_estimate.dart';
+import 'key_detector.dart';
+import 'key_space.dart';
+
+/// Progression-pattern key detection (design plan section 2e): scores chord
+/// _transitions_ instead of chord contents, because motion between functions
+/// carries far more key information than any single sonority.
+///
+/// Per event, each of the 24 keys is scored for the patterns the latest
+/// transition completes under that key's functional reading (function is
+/// key-relative, so the same transition reads differently under each tonic
+/// hypothesis):
+///
+/// - Authentic cadence: dominant-family on the fifth degree resolving to a
+///   tonic-quality chord, the strongest single signal. A plain major triad on
+///   V scores less (no tritone); a root-position resolution scores a bonus.
+///   The tonic quality set includes dominant7 in major, so a blues I7 counts
+///   as home rather than as V-of-IV.
+/// - Leading-tone diminished resolving to the tonic.
+/// - ii to V motion, plus a completion bonus when it lands as ii-V-I.
+/// - Deceptive cadence (V to vi, major keys).
+/// - Secondary-dominant resolution onto any diatonic degree.
+/// - Bass falling a fifth onto the tonic, quality-independent.
+///
+/// - Plagal return (IV to I, including the blues IV7 to I7), the signal that
+///   breaks the blues symmetry: I7 to IV7 reads as a cadence into the
+///   subdominant key, and only the return home distinguishes the true tonic.
+///
+/// Scores decay on elapsed time; contributions are weighted by the resolving
+/// event's hold duration and recognizer confidence, like the other detectors.
+/// Unlike the per-event-normalized evidence model, confidence here is the
+/// decayed weighted sum of pattern points: patterns are sparse, and a recent
+/// cadence must keep its full vote until decay fades it rather than being
+/// diluted by pattern-less transitions.
+class ProgressionKeyDetector implements KeyDetector {
+  final double cadencePoints;
+  final double cadenceTriadPoints;
+  final double rootPositionBonusPoints;
+  final double leadingTonePoints;
+  final double iiToVPoints;
+  final double iiVICompletionPoints;
+  final double deceptivePoints;
+  final double plagalPoints;
+  final double secondaryResolutionPoints;
+  final double bassFifthPoints;
+
+  final bool confidenceWeighted;
+  final bool durationWeighted;
+
+  /// Score half-life; null disables decay.
+  final Duration? decayHalfLife;
+  final int minEvents;
+  final double marginFloor;
+
+  final List<double> _scores = List.filled(24, 0);
+  int _eventCount = 0;
+  DateTime? _lastTimestamp;
+  ChordIdentity? _previous;
+  ChordIdentity? _previous2;
+
+  ProgressionKeyDetector({
+    this.cadencePoints = 5,
+    this.cadenceTriadPoints = 3,
+    this.rootPositionBonusPoints = 1,
+    this.leadingTonePoints = 4,
+    this.iiToVPoints = 2,
+    this.iiVICompletionPoints = 3,
+    this.deceptivePoints = 2,
+    this.plagalPoints = 2,
+    this.secondaryResolutionPoints = 1,
+    this.bassFifthPoints = 1,
+    this.confidenceWeighted = true,
+    this.durationWeighted = true,
+    this.decayHalfLife = const Duration(seconds: 30),
+    this.minEvents = 3,
+    this.marginFloor = 0.5,
+  });
+
+  @override
+  String get name => 'progression';
+
+  @override
+  String get configuration =>
+      'points=$cadencePoints/$cadenceTriadPoints/+$rootPositionBonusPoints/'
+      '$leadingTonePoints/$iiToVPoints/$iiVICompletionPoints/'
+      '$deceptivePoints/$plagalPoints/$secondaryResolutionPoints/'
+      '$bassFifthPoints '
+      'confidenceWeighted=$confidenceWeighted '
+      'durationWeighted=$durationWeighted '
+      'decayHalfLifeMs=${decayHalfLife?.inMilliseconds} '
+      'minEvents=$minEvents marginFloor=$marginFloor';
+
+  @override
+  void reset() {
+    _scores.fillRange(0, 24, 0);
+    _eventCount = 0;
+    _lastTimestamp = null;
+    _previous = null;
+    _previous2 = null;
+  }
+
+  @override
+  KeyEstimateFrame onEvent(ChordEvent event) {
+    _decayTo(event.timestamp);
+    _eventCount += 1;
+
+    final current = event.identity;
+    final previous = _previous;
+    final weight = _eventWeight(event);
+    if (previous != null && weight > 0 && previous != current) {
+      for (var k = 0; k < 24; k++) {
+        _scores[k] +=
+            weight *
+            _transitionPoints(
+              KeySpace.canonicalTonalities[k],
+              _previous2,
+              previous,
+              current,
+            );
+      }
+    }
+    _previous2 = previous;
+    _previous = current;
+
+    final ranked = _rankKeys();
+    if (ranked.isEmpty || _eventCount < minEvents) {
+      return KeyEstimateFrame.abstain(ranked);
+    }
+    final margin = ranked.length < 2
+        ? double.infinity
+        : ranked[0].confidence - ranked[1].confidence;
+    if (ranked[0].confidence <= 0 || margin < marginFloor) {
+      return KeyEstimateFrame.abstain(ranked);
+    }
+    return KeyEstimateFrame(ranked: ranked, claim: ranked.first);
+  }
+
+  double _transitionPoints(
+    Tonality key,
+    ChordIdentity? older,
+    ChordIdentity from,
+    ChordIdentity to,
+  ) {
+    final tonic = key.tonicPitchClass;
+    int interval(int pc) => (pc - tonic + 12) % 12;
+    final fromInterval = interval(from.rootPc);
+    final toInterval = interval(to.rootPc);
+    var points = 0.0;
+
+    final tonicQualities = key.isMajor ? _majorTonic : _minorTonic;
+    final toIsTonic = toInterval == 0 && tonicQualities.contains(to.quality);
+
+    if (toIsTonic && fromInterval == 7) {
+      if (_dominantFamily.contains(from.quality)) {
+        points += cadencePoints;
+      } else if (from.quality == ChordQualityToken.major) {
+        points += cadenceTriadPoints;
+      }
+      if (points > 0 && !from.hasSlashBass && !to.hasSlashBass) {
+        points += rootPositionBonusPoints;
+      }
+      // ii-V-I completion: the chord before the dominant sat on the second
+      // degree with pre-dominant quality.
+      if (older != null &&
+          interval(older.rootPc) == 2 &&
+          _predominantFamily.contains(older.quality)) {
+        points += iiVICompletionPoints;
+      }
+    }
+
+    if (toIsTonic &&
+        fromInterval == 11 &&
+        _leadingToneFamily.contains(from.quality)) {
+      points += leadingTonePoints;
+    }
+
+    if (fromInterval == 2 &&
+        toInterval == 7 &&
+        _predominantFamily.contains(from.quality) &&
+        (_dominantFamily.contains(to.quality) ||
+            to.quality == ChordQualityToken.major)) {
+      points += iiToVPoints;
+    }
+
+    if (toIsTonic &&
+        fromInterval == 5 &&
+        (from.quality == ChordQualityToken.major ||
+            from.quality == ChordQualityToken.dominant7 ||
+            from.quality == ChordQualityToken.minor)) {
+      points += plagalPoints;
+    }
+
+    if (key.isMajor &&
+        fromInterval == 7 &&
+        toInterval == 9 &&
+        _dominantFamily.contains(from.quality) &&
+        (to.quality == ChordQualityToken.minor ||
+            to.quality == ChordQualityToken.minor7)) {
+      points += deceptivePoints;
+    }
+
+    // Any dominant falling a fifth onto a diatonic degree confirms the key's
+    // functional fabric (secondary dominants resolving); the tonic landing is
+    // already covered by the cadence rule above.
+    if (!toIsTonic &&
+        _dominantFamily.contains(from.quality) &&
+        (from.rootPc - to.rootPc + 12) % 12 == 7 &&
+        (KeySpace.scaleMask(key) & (1 << to.rootPc)) != 0) {
+      points += secondaryResolutionPoints;
+    }
+
+    if (interval(from.bassPc) == 7 && interval(to.bassPc) == 0) {
+      points += bassFifthPoints;
+    }
+
+    return points;
+  }
+
+  double _eventWeight(ChordEvent event) {
+    var weight = durationWeighted
+        ? event.duration.inMilliseconds / 1000.0
+        : 1.0;
+    if (confidenceWeighted) weight *= _identityConfidence(event);
+    return weight;
+  }
+
+  static double _identityConfidence(ChordEvent event) {
+    if (event.candidates.length < 2) return 1.0;
+    final gap = event.candidates[1].cost - event.candidates.first.cost;
+    return (gap / ChordCandidateRanking.nearTieWindow).clamp(0.0, 1.0);
+  }
+
+  void _decayTo(DateTime timestamp) {
+    final halfLife = decayHalfLife;
+    final last = _lastTimestamp;
+    _lastTimestamp = timestamp;
+    if (halfLife == null || last == null) return;
+    final elapsedMs = timestamp.difference(last).inMilliseconds;
+    if (elapsedMs <= 0) return;
+    final factor = math.pow(0.5, elapsedMs / halfLife.inMilliseconds) as double;
+    for (var k = 0; k < 24; k++) {
+      _scores[k] *= factor;
+    }
+  }
+
+  List<KeyEstimate> _rankKeys() {
+    if (_scores.every((score) => score == 0)) return const [];
+    final estimates = <KeyEstimate>[
+      for (var k = 0; k < 24; k++)
+        KeyEstimate(
+          tonality: KeySpace.canonicalTonalities[k],
+          confidence: _scores[k],
+        ),
+    ]..sort((a, b) => b.confidence.compareTo(a.confidence));
+    return estimates;
+  }
+
+  /// Chords that read as "home" over the tonic. Major includes dominant7 so a
+  /// blues I7 is tonic, not V-of-IV.
+  static const Set<ChordQualityToken> _majorTonic = {
+    ChordQualityToken.major,
+    ChordQualityToken.major6,
+    ChordQualityToken.major7,
+    ChordQualityToken.dominant7,
+  };
+
+  static const Set<ChordQualityToken> _minorTonic = {
+    ChordQualityToken.minor,
+    ChordQualityToken.minor6,
+    ChordQualityToken.minor7,
+    ChordQualityToken.minorMajor7,
+  };
+
+  static const Set<ChordQualityToken> _dominantFamily = {
+    ChordQualityToken.dominant7,
+    ChordQualityToken.dominant7sus2,
+    ChordQualityToken.dominant7sus4,
+    ChordQualityToken.dominant7Flat5,
+    ChordQualityToken.dominant7Sharp5,
+  };
+
+  /// Pre-dominant qualities on the second degree: ii/ii7 in major, ii°/ii-7b5
+  /// in minor.
+  static const Set<ChordQualityToken> _predominantFamily = {
+    ChordQualityToken.minor,
+    ChordQualityToken.minor7,
+    ChordQualityToken.diminished,
+    ChordQualityToken.halfDiminished7,
+  };
+
+  static const Set<ChordQualityToken> _leadingToneFamily = {
+    ChordQualityToken.diminished,
+    ChordQualityToken.diminished7,
+    ChordQualityToken.halfDiminished7,
+  };
+}

--- a/lib/features/key/domain/detectors/weighted_evidence_key_detector.dart
+++ b/lib/features/key/domain/detectors/weighted_evidence_key_detector.dart
@@ -5,7 +5,7 @@ import 'package:whatchord/features/theory/domain/theory_domain.dart';
 
 import '../models/key_estimate.dart';
 import 'key_detector.dart';
-import 'profile_correlation_key_detector.dart';
+import 'key_space.dart';
 
 /// Weighted evidence key detection (design plan section 2d): the first model
 /// that uses chord identities and recognizer confidence rather than pitch
@@ -107,7 +107,7 @@ class WeightedEvidenceKeyDetector implements KeyDetector {
     if (weight > 0) {
       final identity = event.identity;
       final pcMask = event.input.pcMask;
-      final tonalities = ProfileCorrelationKeyDetector.canonicalTonalities;
+      final tonalities = KeySpace.canonicalTonalities;
       for (var k = 0; k < 24; k++) {
         _scores[k] += weight * _points(tonalities[k], identity, pcMask);
       }
@@ -128,7 +128,7 @@ class WeightedEvidenceKeyDetector implements KeyDetector {
   }
 
   double _points(Tonality tonality, ChordIdentity identity, int pcMask) {
-    final scaleMask = _scaleMask(tonality);
+    final scaleMask = KeySpace.scaleMask(tonality);
     var points = 0.0;
 
     if (scaleMask & (1 << identity.rootPc) != 0) {
@@ -189,7 +189,7 @@ class WeightedEvidenceKeyDetector implements KeyDetector {
 
   List<KeyEstimate> _rankKeys() {
     if (_weightMass <= 0) return const [];
-    final tonalities = ProfileCorrelationKeyDetector.canonicalTonalities;
+    final tonalities = KeySpace.canonicalTonalities;
     final estimates = <KeyEstimate>[
       // Confidence is points per weighted event, so it is scale-free across
       // stream lengths and decay states.
@@ -202,20 +202,6 @@ class WeightedEvidenceKeyDetector implements KeyDetector {
     estimates.sort((a, b) => b.confidence.compareTo(a.confidence));
     return estimates;
   }
-
-  /// Scale pitch classes per key. Major keys use the major scale; minor keys
-  /// use natural union harmonic minor, mirroring the classifier's sources.
-  static int _scaleMask(Tonality tonality) {
-    final relative = tonality.isMajor ? _majorMask : _minorMask;
-    final tonic = tonality.tonicPitchClass;
-    return ((relative << tonic) | (relative >> (12 - tonic))) & 0xFFF;
-  }
-
-  // 0,2,4,5,7,9,11
-  static const int _majorMask = 0xAB5;
-
-  // Natural {0,2,3,5,7,8,10} union harmonic {..., 11}: 0,2,3,5,7,8,10,11
-  static const int _minorMask = 0xDAD;
 
   static const Set<ChordQualityToken> _dominantFamily = {
     ChordQualityToken.dominant7,

--- a/lib/features/key/key.dart
+++ b/lib/features/key/key.dart
@@ -2,6 +2,8 @@ export 'domain/detectors/claim_hysteresis_detector.dart';
 export 'domain/detectors/hybrid_key_detector.dart';
 export 'domain/detectors/key_detector.dart';
 export 'domain/detectors/key_profiles.dart';
+export 'domain/detectors/key_space.dart';
 export 'domain/detectors/profile_correlation_key_detector.dart';
+export 'domain/detectors/progression_key_detector.dart';
 export 'domain/detectors/weighted_evidence_key_detector.dart';
 export 'domain/models/key_estimate.dart';

--- a/research/whatkey/README.md
+++ b/research/whatkey/README.md
@@ -42,15 +42,17 @@ versioned fixtures, external baselines, and dated logs.
   modulations, which is the gap the next detector targets. See `log/` for the
   numbers.
 - **Detectors so far:** the profile-correlation floor, the weighted evidence
-  model (design plan section 2d), and their hybrid, the current champion: it
-  beats the floor on the development split with paired statistics (+0.096 exact
-  per piece, Wilcoxon p = 0.003) at higher coverage. The two ingredients fail in
-  complementary places and the blend captures both; blues remains the flagship
-  open probe (function rules mis-key it toward the subdominant). See `log/` for
-  the numbers.
-- **Next:** modulation responsiveness (adaptive decay or claim hysteresis), the
-  progression-pattern layer (design plan section 2e), and the deferred
-  default-profile revisit, all gated by paired per-piece statistics.
+  model (design plan section 2d), the progression-pattern layer (section 2e),
+  and a claim-hysteresis wrapper (built, currently unused). The champion is the
+  three-way hybrid (correlation base, functional and progression blend terms):
+  it beats the floor with paired statistics (+0.096 exact per piece, p = 0.003),
+  and the progression term added a decisive paired coverage win (+0.052 per
+  piece, p = 0.0008) at unchanged accuracy. The protocol is frozen. Blues
+  remains the flagship open probe: the single-chorus fixture ends before the
+  loop-seam cadence that would identify the tonic. See `log/` for the numbers.
+- **Next:** a pop-jazz-v2 fixture set (two-chorus blues) via protocol amendment,
+  the deferred default-profile revisit, and ASAP performed-input fixtures, all
+  gated by paired per-piece statistics.
 
 ## Reading order
 
@@ -59,8 +61,8 @@ versioned fixtures, external baselines, and dated logs.
    full design and implementation plan, including the algorithm menu, decision
    points, performance analysis, and references. Denser than this page; it is
    the source of truth.
-3. [PROTOCOL.md](PROTOCOL.md): how results will be evaluated. Draft until
-   frozen; frozen before the first tuning experiment.
+3. [PROTOCOL.md](PROTOCOL.md): how results are evaluated. Frozen 2026-07-07;
+   changes are dated amendments.
 4. [GLOSSARY.md](GLOSSARY.md): plain-English definitions of the measurement
    terms the log entries and reports use.
 5. [REPRODUCING.md](REPRODUCING.md): exact steps for rebuilding the Phase 2

--- a/research/whatkey/log/2026-07-07-08-progression-detectors.md
+++ b/research/whatkey/log/2026-07-07-08-progression-detectors.md
@@ -1,0 +1,113 @@
+# 2026-07-07: Progression detectors land a paired coverage win
+
+**Goal.** Build the design plan's section 2e progression-pattern layer, the
+mechanism that attacks modulation with evidence (cadences into the new key)
+rather than forgetting speed, and the first with a plausible shot at blues.
+
+**Setup.** New `ProgressionKeyDetector` in `lib/features/key/`: scores chord
+_transitions_ per key rather than chord contents. Patterns: authentic cadence
+(dominant-family on the fifth degree to a tonic-quality chord, with a
+root-position bonus and a smaller score for a tritone-less V triad),
+leading-tone resolution, ii-V motion with a ii-V-I completion bonus, deceptive
+cadence, secondary-dominant resolutions onto diatonic degrees, bass falling a
+fifth onto the tonic, and a plagal return (IV to I). The major-key tonic quality
+set includes dominant7 so a blues I7 reads as home, not V-of-IV. Confidence is
+the decayed, weighted _sum_ of pattern points, not points per event: patterns
+are sparse, and a recent cadence must keep its vote rather than being diluted by
+pattern-less transitions. Shared 24-key plumbing extracted to `KeySpace`
+(canonical tonalities, scale masks), used by all detectors.
+
+Integrated into the hybrid as a third, independently ablatable term:
+
+```text
+correlation
+  + functionalBlend  * evidence points per weighted event
+  + progressionBlend * decayed progression point sum
+```
+
+Harness: `--detector progression` (standalone, diagnostic) and
+`--progression-blend X` on the hybrid.
+
+```sh
+for pb in 0.02 0.05 0.1; do
+  dart run tool/whatkey_harness.dart \
+    --fixtures build/whatkey-fixtures/when-in-rome-v1 \
+    --split-file research/whatkey/data/splits/when-in-rome-v1.json \
+    --detector hybrid --progression-blend "$pb" \
+    --out "build/whatkey-harness/wir-dev-hybrid-p$pb"
+done
+python3 tool/whatkey_compare.py \
+  build/whatkey-harness/wir-dev-hybrid-p0.02/report.json \
+  build/whatkey-harness/wir-dev-hybrid-b0.1/report.json
+python3 tool/whatkey_compare.py \
+  build/whatkey-harness/wir-dev-hybrid-p0.02/report.json \
+  build/whatkey-harness/wir-dev-hybrid-b0.1/report.json --metric coverage
+dart run tool/whatkey_harness.dart \
+  --fixtures research/whatkey/data/fixtures/pop-jazz-v1 \
+  --detector hybrid --progression-blend 0.02 \
+  --out build/whatkey-harness/pop-jazz-v1-hybrid-p0.02
+```
+
+**Results, development split** (hybrid, blend on top of champion config):
+
+| progression blend | coverage | exact | MIREX | modulations |
+| ----------------- | -------- | ----- | ----- | ----------- |
+| 0 (champion)      | 0.74     | 0.54  | 0.64  | 120/399     |
+| 0.02              | 0.79     | 0.55  | 0.65  | 133/399     |
+| 0.05              | 0.80     | 0.53  | 0.63  | 130/399     |
+| 0.1               | 0.81     | 0.50  | 0.61  | 131/399     |
+
+Paired at 0.02 vs champion: exact is a dead wash (+0.011, p = 0.97, 20/22/15);
+**coverage is a decisive win** (+0.052 per piece, CI95 [+0.026, +0.081], p =
+0.0008, 29/12/18), with 13 more modulations matched and spurious switches
+unchanged (median 0, p90 2). Higher blends buy nothing further and start costing
+accuracy.
+
+**Results, behavioral suite** (blend 0.02): all steady-key probes stay exact
+1.00 with zero spurious switches; ambiguous fixtures 8/8 and 7/7; the modulating
+ii-V-I chain jumps to 0.43 exact with zero spurious (champion: 0.20; the
+evidence model alone: 0.40, but with flapping). **Blues still fails (exact 0.00,
+claims F)**, for a newly precise reason: the plagal-return pattern breaks the
+I7/IV7 symmetry in principle, but our 12-bar fixture is a single chorus ending
+on the V7 turnaround, so the C-confirming cadence at the loop seam never occurs.
+A unit test with the seam (G7 to C7 across the loop boundary) claims C
+correctly. A two-chorus blues fixture would test the realistic looping case, but
+the behavioral suite is pinned by the protocol freeze, so that addition is
+deferred to a pop-jazz-v2 fixture set with an amendment.
+
+**Plain-English reading** (terms in [../GLOSSARY.md](../GLOSSARY.md)):
+
+- The new layer listens for the grammar of harmony (this chord _resolving_ to
+  that one) instead of just which notes are common. Grammar is rare but very
+  informative, so its votes are kept at full strength until they age out, rather
+  than being averaged away by ordinary chord changes.
+- On the corpus it did not make the detector more right, but it made it **speak
+  far more often while staying just as right**: where the histogram saw a
+  near-tie and stayed quiet, a cadence now breaks the tie. Speaking 5% more
+  often at unchanged accuracy is a statistically solid win (the p = 0.0008
+  coverage result), and the kind that matters for the app, where silence is a
+  blank indicator.
+- Blues taught us something subtle: hearing C7 go to F7 genuinely sounds like an
+  arrival in F; what tells your ear the song is in C is coming _back_. Our test
+  chart plays the twelve bars exactly once and stops before coming back, so the
+  detector never gets the punchline. The fix is a fairer test (two choruses),
+  not a smarter trick.
+
+**Decisions.**
+
+- `progressionBlend = 0.02` is the new default (champion: hybrid, functional
+  0.1, progression 0.02, 30 s half-life), adopted on a significant paired
+  coverage win at unchanged accuracy with modulation improvement, per the
+  protocol's coverage-and-accuracy-pair framing.
+- Progression confidence is a decayed sum, not per-event normalized; recorded
+  here because it deliberately differs from the evidence model's semantics.
+- The plagal-return pattern was added mid-development after the blues analysis
+  showed the I7/IV7 cadence symmetry; it is a legitimate classical tonic signal,
+  not a blues special case.
+- A two-chorus blues fixture goes to a future pop-jazz-v2 set via protocol
+  amendment; the v1 single-chorus probe stays as-is, documenting the limitation.
+
+**Next.** Candidates, by expected value: the pop-jazz-v2 amendment with the
+two-chorus blues; the deferred default-profile revisit (Temperley pairs looked
+stronger, needs the paired treatment); ASAP performed-input fixtures, where
+confidence weighting gets its real test.

--- a/test/hybrid_key_detector_test.dart
+++ b/test/hybrid_key_detector_test.dart
@@ -56,8 +56,11 @@ void main() {
     expect(claim.tonality.isMajor, isTrue);
   });
 
-  test('zero blend ranks identically to pure profile correlation', () {
-    final hybridFrames = _run(HybridKeyDetector(functionalBlend: 0), cCadence);
+  test('zero blends rank identically to pure profile correlation', () {
+    final hybridFrames = _run(
+      HybridKeyDetector(functionalBlend: 0, progressionBlend: 0),
+      cCadence,
+    );
     final profileFrames = _run(ProfileCorrelationKeyDetector(), cCadence);
     for (var i = 0; i < cCadence.length; i++) {
       final hybrid = hybridFrames[i].ranked;

--- a/test/progression_key_detector_test.dart
+++ b/test/progression_key_detector_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:whatchord/features/history/history.dart';
+import 'package:whatchord/features/key/key.dart';
+import 'package:whatchord/features/theory/theory.dart';
+
+const _cMajorTonality = Tonality(Tonic.c, TonalityMode.major);
+
+ChordEvent _event(
+  int index,
+  List<int> pcs,
+  ChordQualityToken quality, {
+  int? bassPc,
+}) {
+  var mask = 0;
+  for (final pc in pcs) {
+    mask |= 1 << (pc % 12);
+  }
+  final bass = bassPc ?? pcs.first % 12;
+  return ChordEvent(
+    timestamp: DateTime.fromMillisecondsSinceEpoch(index * 2000),
+    input: ChordInput(pcMask: mask, bassPc: bass, noteCount: pcs.length),
+    voicing: ObservedVoicing.fromMidi([for (final pc in pcs) 60 + pc]),
+    candidates: [
+      ChordCandidate(
+        identity: ChordIdentity(
+          rootPc: pcs.first % 12,
+          bassPc: bass,
+          quality: quality,
+          presentIntervalsMask: 1,
+        ),
+        cost: 0,
+      ),
+    ],
+    tonality: _cMajorTonality,
+    duration: const Duration(seconds: 2),
+  );
+}
+
+List<KeyEstimateFrame> _run(KeyDetector detector, List<ChordEvent> events) {
+  detector.reset();
+  return [for (final event in events) detector.onEvent(event)];
+}
+
+KeyEstimate _estimateFor(KeyEstimateFrame frame, int tonicPc, bool isMinor) =>
+    frame.ranked.firstWhere(
+      (e) =>
+          e.tonality.tonicPitchClass == tonicPc &&
+          e.tonality.isMinor == isMinor,
+    );
+
+void main() {
+  test('a G7 to C cadence tops the ranking with C major', () {
+    final frames = _run(ProgressionKeyDetector(minEvents: 2), [
+      _event(0, [7, 11, 2, 5], ChordQualityToken.dominant7),
+      _event(1, [0, 4, 7], ChordQualityToken.major),
+    ]);
+    final top = frames.last.ranked.first;
+    expect(top.tonality.tonicPitchClass, 0);
+    expect(top.tonality.isMajor, isTrue);
+  });
+
+  test('ii-V-I completion scores above a bare V-I', () {
+    final bare = _run(ProgressionKeyDetector(minEvents: 2), [
+      _event(0, [7, 11, 2, 5], ChordQualityToken.dominant7),
+      _event(1, [0, 4, 7], ChordQualityToken.major),
+    ]);
+    final complete = _run(ProgressionKeyDetector(minEvents: 2), [
+      _event(0, [2, 5, 9, 0], ChordQualityToken.minor7),
+      _event(1, [7, 11, 2, 5], ChordQualityToken.dominant7),
+      _event(2, [0, 4, 7], ChordQualityToken.major),
+    ]);
+    final bareC = _estimateFor(bare.last, 0, false).confidence;
+    final completeC = _estimateFor(complete.last, 0, false).confidence;
+    expect(completeC, greaterThan(bareC));
+  });
+
+  test('blues: V7 to I7 reads as a cadence in the tonic major', () {
+    // G7 -> C7: with dominant7 in the tonic quality set, this is V7 -> I7 in
+    // C, not motion toward F.
+    final frames = _run(ProgressionKeyDetector(minEvents: 2), [
+      _event(0, [7, 11, 2, 5], ChordQualityToken.dominant7),
+      _event(1, [0, 4, 7, 10], ChordQualityToken.dominant7),
+    ]);
+    final top = frames.last.ranked.first;
+    expect(top.tonality.tonicPitchClass, 0);
+    expect(top.tonality.isMajor, isTrue);
+  });
+
+  test('E7 to Am cadence supports A minor', () {
+    final frames = _run(ProgressionKeyDetector(minEvents: 2), [
+      _event(0, [4, 8, 11, 2], ChordQualityToken.dominant7),
+      _event(1, [9, 0, 4], ChordQualityToken.minor),
+    ]);
+    final top = frames.last.ranked.first;
+    expect(top.tonality.tonicPitchClass, 9);
+    expect(top.tonality.isMinor, isTrue);
+  });
+
+  test('repeated identical chords accumulate no transition evidence', () {
+    final frames = _run(ProgressionKeyDetector(minEvents: 1), [
+      for (var i = 0; i < 4; i++)
+        _event(i, [0, 4, 7, 10], ChordQualityToken.dominant7),
+    ]);
+    expect(frames.every((frame) => frame.isAbstention), isTrue);
+  });
+
+  test('hybrid with progression blend claims C on the blues loop', () {
+    // I7 I7 IV7 I7 V7 IV7 I7 V7, roughly the 12-bar skeleton.
+    final blues = [
+      _event(0, [0, 4, 7, 10], ChordQualityToken.dominant7),
+      _event(1, [0, 4, 7, 10], ChordQualityToken.dominant7),
+      _event(2, [5, 9, 0, 3], ChordQualityToken.dominant7),
+      _event(3, [0, 4, 7, 10], ChordQualityToken.dominant7),
+      _event(4, [7, 11, 2, 5], ChordQualityToken.dominant7),
+      _event(5, [5, 9, 0, 3], ChordQualityToken.dominant7),
+      _event(6, [0, 4, 7, 10], ChordQualityToken.dominant7),
+      _event(7, [7, 11, 2, 5], ChordQualityToken.dominant7),
+      _event(8, [0, 4, 7, 10], ChordQualityToken.dominant7),
+    ];
+    final without = _run(HybridKeyDetector(progressionBlend: 0), blues);
+    final with_ = _run(HybridKeyDetector(progressionBlend: 0.1), blues);
+
+    final withoutClaim = without.last.claim;
+    final withClaim = with_.last.claim;
+    expect(withClaim, isNotNull);
+    expect(withClaim!.tonality.tonicPitchClass, 0);
+    expect(withClaim.tonality.isMajor, isTrue);
+    // The progression term is what makes the difference: without it the
+    // hybrid reads the loop as F (the V-of-F pull from entry 04).
+    expect(
+      withoutClaim == null || withoutClaim.tonality.tonicPitchClass != 0,
+      isTrue,
+    );
+  });
+
+  test('explicit progression blend of zero is deterministic across runs', () {
+    final cadence = [
+      _event(0, [0, 4, 7], ChordQualityToken.major),
+      _event(1, [5, 9, 0], ChordQualityToken.major),
+      _event(2, [7, 11, 2, 5], ChordQualityToken.dominant7),
+      _event(3, [0, 4, 7], ChordQualityToken.major),
+    ];
+    final base = _run(
+      HybridKeyDetector(functionalBlend: 0.1, progressionBlend: 0),
+      cadence,
+    );
+    final zero = _run(
+      HybridKeyDetector(functionalBlend: 0.1, progressionBlend: 0),
+      cadence,
+    );
+    for (var i = 0; i < cadence.length; i++) {
+      expect(zero[i].ranked.length, base[i].ranked.length);
+      for (var k = 0; k < base[i].ranked.length; k++) {
+        expect(zero[i].ranked[k].tonality, base[i].ranked[k].tonality);
+        expect(
+          zero[i].ranked[k].confidence,
+          closeTo(base[i].ranked[k].confidence, 1e-12),
+        );
+      }
+    }
+  });
+}

--- a/tool/whatkey_harness.dart
+++ b/tool/whatkey_harness.dart
@@ -8,10 +8,11 @@
 // Usage:
 //   dart run tool/whatkey_harness.dart --fixtures <set-dir> \
 //     [--split-file <split.json>] [--split development|test] \
-//     [--detector profile|evidence|hybrid] \
+//     [--detector profile|evidence|progression|hybrid] \
 //     [--profiles krumhanslKessler|temperley|temperleyKostkaPayne|
 //                 albrechtShanahan] \
 //     [--confidence-weighting on|off] [--functional-blend X] \
+//     [--progression-blend X] \
 //     [--hysteresis N] \
 //     [--weighting duration|flat] [--decay-half-life-seconds N] \
 //     [--min-events N] [--margin-floor X] [--out <dir>] \
@@ -430,6 +431,7 @@ class _Options {
   final String detectorName;
   final bool confidenceWeighted;
   final double functionalBlend;
+  final double progressionBlend;
   final int hysteresis;
   final KeyProfilePair profiles;
   final bool durationWeighted;
@@ -448,6 +450,7 @@ class _Options {
     required this.detectorName,
     required this.confidenceWeighted,
     required this.functionalBlend,
+    required this.progressionBlend,
     required this.hysteresis,
     required this.profiles,
     required this.durationWeighted,
@@ -476,6 +479,13 @@ class _Options {
         minEvents: minEvents,
         marginFloor: marginFloorOverride ?? marginFloor ?? 0.05,
       ),
+      'progression' => ProgressionKeyDetector(
+        confidenceWeighted: confidenceWeighted,
+        durationWeighted: durationWeighted,
+        decayHalfLife: decay,
+        minEvents: minEvents,
+        marginFloor: marginFloorOverride ?? marginFloor ?? 0.5,
+      ),
       'evidence' => WeightedEvidenceKeyDetector(
         confidenceWeighted: confidenceWeighted,
         durationWeighted: durationWeighted,
@@ -489,11 +499,12 @@ class _Options {
         decayHalfLife: decay,
         confidenceWeighted: confidenceWeighted,
         functionalBlend: functionalBlend,
+        progressionBlend: progressionBlend,
         minEvents: minEvents,
         marginFloor: marginFloorOverride ?? marginFloor ?? 0.05,
       ),
       _ => throw ArgumentError(
-        '--detector must be profile, evidence, or hybrid',
+        '--detector must be profile, evidence, progression, or hybrid',
       ),
     };
   }
@@ -531,6 +542,7 @@ class _Options {
       confidenceWeighted:
           (values.remove('confidence-weighting') ?? 'on') != 'off',
       functionalBlend: double.parse(values.remove('functional-blend') ?? '0.1'),
+      progressionBlend: double.parse(values.remove('progression-blend') ?? '0'),
       hysteresis: int.parse(values.remove('hysteresis') ?? '1'),
       sweepMarginFloors: [
         for (final floor in (values.remove('sweep-margin-floors') ?? '').split(


### PR DESCRIPTION
Implement design section 2e: ProgressionKeyDetector scores chord transitions per key (authentic cadences with root-position and tritone distinctions, leading-tone resolutions, ii-V-I completion, deceptive cadences, secondary-dominant resolutions, bass fifth-falls, and plagal returns), with dominant7 in the major tonic set so a blues I7 reads as home. Confidence is a decayed weighted sum rather than per-event normalized, since sparse cadence votes must not be diluted by pattern-less transitions. Extract the shared 24-key space to KeySpace and add the term to the hybrid as a third independently ablatable blend, with --detector progression and --progression-blend in the harness.

Adopt progressionBlend 0.02 as the default on a decisive paired coverage win (+0.052 per piece, CI95 +0.026 to +0.081, p 0.0008) at statistically unchanged accuracy, with 13 more modulations matched and stability unchanged; the behavioral suite holds and the modulating chain improves to 0.43 exact without flapping. Blues still fails for a newly precise reason: the single-chorus fixture ends on the turnaround before the loop-seam cadence that identifies the tonic, so a two-chorus fixture is deferred to a pop-jazz-v2 set via protocol amendment.