### PR TITLE
Recenter the keyboard when the viewport width changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ The format is based on [Keep a Changelog][1], and this project adheres to
   uncertainty rather than guessing. Choosing a key manually always wins and
   switches back to Manual mode.
 
+### Fixed
+
+- The piano keyboard recenters on active notes (or middle C when idle) after
+  rotating the device or resizing the window, instead of sometimes ending up
+  scrolled to an unexpected octave.
+
 ## [2026.7.6] - 2026-07-06
 
 ### Added

--- a/lib/features/piano/widgets/piano_keyboard/scrollable_piano_keyboard.dart
+++ b/lib/features/piano/widgets/piano_keyboard/scrollable_piano_keyboard.dart
@@ -914,6 +914,16 @@ class _ScrollablePianoKeyboardState
             if (!mounted) return;
             _updateIndicatorState(viewportWidth: viewportWidth);
           });
+          // A viewport width change also invalidates the preserved pixel
+          // offset, which would land on arbitrary keys; recenter like the
+          // explicit center action (active notes, middle C when idle). The
+          // first layout is handled by the initial center instead. Pinch
+          // zoom is unaffected: it changes the key count, not this width.
+          if (previousWidth != null) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted) _centerNow();
+            });
+          }
         }
 
         final whiteKeyWidth = PianoGeometry.whiteKeyWidthForViewport(


### PR DESCRIPTION
Rotation previously recentered only when notes were highlighted, and only on pages that rebuilt the keyboard per orientation, so the Key page and Scale Explorer could come out of a rotation scrolled to an arbitrary octave. The keyboard now recenters on active notes (middle C when idle) whenever its viewport width changes after first layout, matching the explicit center action. Pinch zoom is unaffected since it changes the visible key count, not the viewport width.