### PR TITLE
Adapt the key page to large devices and match tooltip styling

### DIFF
--- a/lib/features/home/pages/key_page.dart
+++ b/lib/features/home/pages/key_page.dart
@@ -193,15 +193,9 @@ class _PortraitAutoPane extends ConsumerWidget {
                   child: Center(
                     child: AspectRatio(
                       aspectRatio: 1,
-                      child: ConstrainedBox(
-                        constraints: const BoxConstraints(
-                          maxWidth: 300,
-                          maxHeight: 300,
-                        ),
-                        child: KeyPosteriorWheel(
-                          ranked: inferred.ranked,
-                          claim: inferred.displayKey?.tonality,
-                        ),
+                      child: KeyPosteriorWheel(
+                        ranked: inferred.ranked,
+                        claim: inferred.displayKey?.tonality,
                       ),
                     ),
                   ),
@@ -237,7 +231,13 @@ class _LandscapeBody extends ConsumerWidget {
     Widget balanced({
       required List<Widget> children,
       required CrossAxisAlignment crossAxisAlignment,
+      bool centerGroup = false,
     }) {
+      final column = Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: crossAxisAlignment,
+        children: children,
+      );
       return LayoutBuilder(
         builder: (context, paneConstraints) => FadedScrollView(
           padding: const EdgeInsets.symmetric(vertical: 8),
@@ -245,17 +245,16 @@ class _LandscapeBody extends ConsumerWidget {
             constraints: BoxConstraints(
               minHeight: math.max(0, paneConstraints.maxHeight - 16),
             ),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: crossAxisAlignment,
-              children: children,
-            ),
+            // centerGroup shrink-wraps the column and centers it in the
+            // pane; the children stay edge-aligned to each other.
+            child: centerGroup ? Center(child: column) : column,
           ),
         ),
       );
     }
 
     final left = balanced(
+      centerGroup: true,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _ModeSegments(mode: mode),
@@ -263,7 +262,12 @@ class _LandscapeBody extends ConsumerWidget {
         if (mode == KeyMode.auto)
           const AutoKeyStatus()
         else
-          Center(
+          // Bounded so the card's internal centering has no slack and the
+          // staff lines up with the mode control above it.
+          ConstrainedBox(
+            constraints: const BoxConstraints(
+              maxWidth: KeySignatureStaffPreview.previewWidth,
+            ),
             child: KeySignatureStaffPreview(
               keySignature: selected.keySignature,
             ),
@@ -271,24 +275,58 @@ class _LandscapeBody extends ConsumerWidget {
       ],
     );
 
-    final right = mode == KeyMode.auto
-        ? balanced(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              KeyPosteriorStrip(
-                ranked: inferred.ranked,
-                claim: inferred.displayKey?.tonality,
-              ),
-              const SizedBox(height: 12),
-              const RecentChordsStrip(),
-            ],
-          )
-        : const TonalityPickerBody(
+    final right = LayoutBuilder(
+      builder: (context, paneConstraints) {
+        // Roomy landscape (tablets): the full wheel replaces the unrolled
+        // strip and the key list keeps its regular row height.
+        final roomy = paneConstraints.maxHeight >= 380;
+
+        if (mode == KeyMode.manual) {
+          return TonalityPickerBody(
             showStaffPreview: false,
-            compact: true,
+            compact: !roomy,
             headerHeight: TonalityPickerBody.slimHeaderHeight,
             listBottomPadding: 0,
           );
+        }
+
+        if (roomy) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: Center(
+                    child: AspectRatio(
+                      aspectRatio: 1,
+                      child: KeyPosteriorWheel(
+                        ranked: inferred.ranked,
+                        claim: inferred.displayKey?.tonality,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                const RecentChordsStrip(),
+              ],
+            ),
+          );
+        }
+
+        return balanced(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            KeyPosteriorStrip(
+              ranked: inferred.ranked,
+              claim: inferred.displayKey?.tonality,
+            ),
+            const SizedBox(height: 12),
+            const RecentChordsStrip(),
+          ],
+        );
+      },
+    );
 
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: horizontalInset),

--- a/lib/features/key/widgets/key_posterior_strip.dart
+++ b/lib/features/key/widgets/key_posterior_strip.dart
@@ -31,7 +31,7 @@ class KeyPosteriorStrip extends ConsumerStatefulWidget {
   ConsumerState<KeyPosteriorStrip> createState() => _KeyPosteriorStripState();
 }
 
-const _readoutLaneHeight = 28.0;
+const _readoutLaneHeight = 36.0;
 const _readoutLeftShift = 56.0;
 
 class _KeyPosteriorStripState extends ConsumerState<KeyPosteriorStrip> {
@@ -166,20 +166,35 @@ class _KeyPosteriorStripState extends ConsumerState<KeyPosteriorStrip> {
                     delegate: _ReadoutLayoutDelegate(
                       centerX: _fingerX - _readoutLeftShift,
                     ),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 10,
-                        vertical: 5,
-                      ),
+                    // Mirrors the framework's default mobile tooltip styling
+                    // so the readout matches the app's other tooltips.
+                    child: DecoratedBox(
                       decoration: BoxDecoration(
-                        color: cs.inverseSurface,
-                        borderRadius: BorderRadius.circular(6),
+                        color: theme.brightness == Brightness.dark
+                            ? Colors.white.withValues(alpha: 0.9)
+                            : Colors.grey.shade700.withValues(alpha: 0.9),
+                        borderRadius: const BorderRadius.all(
+                          Radius.circular(4),
+                        ),
                       ),
-                      child: Text(
-                        '${tonalityDisplayLabel(KeySpace.canonicalTonalities[inspected], noteNameSystem: noteNameSystem)}'
-                        ' · ${percentLabel(inspected)}',
-                        style: theme.textTheme.labelMedium?.copyWith(
-                          color: cs.onInverseSurface,
+                      child: Container(
+                        constraints: const BoxConstraints(minHeight: 32),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 4,
+                        ),
+                        child: Center(
+                          widthFactor: 1,
+                          child: Text(
+                            '${tonalityDisplayLabel(KeySpace.canonicalTonalities[inspected], noteNameSystem: noteNameSystem)}'
+                            ' · ${percentLabel(inspected)}',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              fontSize: 14,
+                              color: theme.brightness == Brightness.dark
+                                  ? Colors.black
+                                  : Colors.white,
+                            ),
+                          ),
                         ),
                       ),
                     ),

--- a/lib/features/key/widgets/key_posterior_wheel.dart
+++ b/lib/features/key/widgets/key_posterior_wheel.dart
@@ -215,8 +215,8 @@ class _WheelPainter extends CustomPainter {
     final middle = outer * _middleFraction;
     final inner = outer * _innerFraction;
 
-    final majorFontSize = (outer * 0.115).clamp(11.0, 18.0);
-    final minorFontSize = (outer * 0.095).clamp(9.0, 15.0);
+    final majorFontSize = (outer * 0.115).clamp(11.0, 26.0);
+    final minorFontSize = (outer * 0.095).clamp(9.0, 21.0);
 
     final gap = Paint()
       ..style = PaintingStyle.stroke
@@ -332,7 +332,7 @@ class _WheelPainter extends CustomPainter {
         text: TextSpan(
           text: centerTitle,
           style: labelBase.copyWith(
-            fontSize: (outer * 0.16).clamp(13.0, 22.0),
+            fontSize: (outer * 0.16).clamp(13.0, 30.0),
             fontWeight: FontWeight.w600,
             color: ink,
           ),
@@ -343,7 +343,7 @@ class _WheelPainter extends CustomPainter {
         text: TextSpan(
           text: centerDetail,
           style: labelBase.copyWith(
-            fontSize: (outer * 0.12).clamp(11.0, 17.0),
+            fontSize: (outer * 0.12).clamp(11.0, 22.0),
             fontWeight: FontWeight.w400,
             color: inkMuted,
           ),

--- a/lib/features/theory/presentation/widgets/key_signature_staff_preview.dart
+++ b/lib/features/theory/presentation/widgets/key_signature_staff_preview.dart
@@ -11,6 +11,11 @@ class KeySignatureStaffPreview extends StatelessWidget {
     this.height = 96,
   });
 
+  /// Natural width of the staff card; narrower hosts shrink to fit. Exposed
+  /// so layouts can bound the widget (whose card centers itself) when they
+  /// need edge alignment instead.
+  static const double previewWidth = 360.0;
+
   final KeySignature keySignature;
   final double height;
 
@@ -34,11 +39,11 @@ class KeySignatureStaffPreview extends StatelessWidget {
       child: ExcludeSemantics(
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final previewWidth =
+            final effectiveWidth =
                 constraints.hasBoundedWidth &&
-                    constraints.maxWidth < _previewWidth
+                    constraints.maxWidth < previewWidth
                 ? constraints.maxWidth
-                : _previewWidth;
+                : previewWidth;
 
             return Center(
               child: DecoratedBox(
@@ -49,7 +54,7 @@ class KeySignatureStaffPreview extends StatelessWidget {
                 ),
                 child: SizedBox(
                   height: height,
-                  width: previewWidth,
+                  width: effectiveWidth,
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(7),
                     child: CustomPaint(
@@ -69,7 +74,6 @@ class KeySignatureStaffPreview extends StatelessWidget {
   }
 }
 
-const _previewWidth = 360.0;
 const _staffInkColor = Color(0xFF101214);
 const _symbolFontFamily = 'WhatChord Symbols';
 const _gClef = '\u{1D11E}';

--- a/lib/features/theory/presentation/widgets/tonality_picker_sheet.dart
+++ b/lib/features/theory/presentation/widgets/tonality_picker_sheet.dart
@@ -176,7 +176,9 @@ class _TonalityPickerBodyState extends ConsumerState<TonalityPickerBody> {
   @override
   void didUpdateWidget(TonalityPickerBody oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.recenterSignal && !oldWidget.recenterSignal) {
+    // A compact change alters the row height, invalidating the offset.
+    if ((widget.recenterSignal && !oldWidget.recenterSignal) ||
+        widget.compact != oldWidget.compact) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         _centerSelectedRow(animated: false);
@@ -435,7 +437,7 @@ class _TonalityPickerHeader extends StatelessWidget {
     return SizedBox(
       height: height,
       child: Material(
-        color: backgroundColor,
+        type: MaterialType.transparency,
         child: Column(
           children: [
             if (showPanelTitle)
@@ -451,48 +453,54 @@ class _TonalityPickerHeader extends StatelessWidget {
                 ),
               ),
             Expanded(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Semantics(
-                        header: true,
-                        child: Text('Accidentals', style: headerStyle),
-                      ),
-                    ),
-                    SizedBox(
-                      width: chipWidth,
-                      child: Semantics(
-                        header: true,
-                        child: Text(
-                          'Major',
-                          textAlign: TextAlign.center,
-                          style: headerStyle,
+              child: ColoredBox(
+                color: backgroundColor,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Semantics(
+                          header: true,
+                          child: Text('Accidentals', style: headerStyle),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: 12),
-                    SizedBox(
-                      width: chipWidth,
-                      child: Semantics(
-                        header: true,
-                        child: Text(
-                          'Minor',
-                          textAlign: TextAlign.center,
-                          style: headerStyle,
+                      SizedBox(
+                        width: chipWidth,
+                        child: Semantics(
+                          header: true,
+                          child: Text(
+                            'Major',
+                            textAlign: TextAlign.center,
+                            style: headerStyle,
+                          ),
                         ),
                       ),
-                    ),
-                  ],
+                      const SizedBox(width: 12),
+                      SizedBox(
+                        width: chipWidth,
+                        child: Semantics(
+                          header: true,
+                          child: Text(
+                            'Minor',
+                            textAlign: TextAlign.center,
+                            style: headerStyle,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
-            Padding(
-              padding: fullBleedDivider
-                  ? EdgeInsets.zero
-                  : const EdgeInsets.symmetric(horizontal: 16),
-              child: const Divider(height: 1, thickness: 2),
+            ColoredBox(
+              color: backgroundColor,
+              child: Padding(
+                padding: fullBleedDivider
+                    ? EdgeInsets.zero
+                    : const EdgeInsets.symmetric(horizontal: 16),
+                child: const Divider(height: 1, thickness: 2),
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
Scope the picker header fill to the column-labels band so the staff sits on the page background, raise the wheel's label size ceilings for large wheels, and left-align the landscape staff preview with the mode control by bounding its width. Roomy landscape panes (tablets) now show the full circle of fifths instead of the unrolled strip and keep the key list at its regular row height, recentering the list when row metrics change. The strip's scrub readout adopts the framework's default tooltip styling instead of an inverse-surface fill, and the portrait wheel drops a constraint box that never took effect.