### PR TITLE
Update marketing copy for automatic key detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@
   /></a>
 </p>
 
-WhatChord is an interactive chord identification and harmony exploration app.
-Identify voicings from live Bluetooth or USB MIDI input or manual note entry,
-then explore chords, scales, keyboard patterns, and harmonic context. It is
-optimized for speed, accuracy, and musician-expected naming, favoring stable,
-conventional interpretations over simple note-matching.
+WhatChord is an interactive chord identification, key detection, and harmony
+exploration app. Identify voicings from live Bluetooth or USB MIDI input or
+manual note entry, follow the key as you play, then explore chords, scales,
+keyboard patterns, and harmonic context. It is optimized for speed, accuracy,
+and musician-expected naming, favoring stable, conventional interpretations over
+simple note-matching.
 
 **Website:** <https://whatchord.earthmanmuons.com>
 
@@ -38,6 +39,12 @@ conventional interpretations over simple note-matching.
 - **Live chord identification**  
   Connect a Bluetooth or USB MIDI keyboard and see chords update instantly as
   you play.
+
+- **Automatic key detection**\
+  Auto mode listens to your recent live chords, estimates the current key, shows
+  confidence across all 24 major and minor keys, and can keep the app's key
+  context following your playing. When the evidence is ambiguous, it waits
+  instead of guessing.
 
 - **Manual chord lookup**  
   Enter notes directly to identify a chord from any instrument, sheet music, or
@@ -68,6 +75,15 @@ conventional interpretations over simple note-matching.
 - **Notation style preferences**  
   Choose between text-based and traditional symbolic chord notation conventions
   so chord names read naturally to you.
+
+## Research-Backed Key Detection
+
+Automatic key detection is documented as [WhatKey][WHATKEY], a streaming
+key-estimation research project with a frozen evaluation protocol, versioned
+fixtures, external baselines, dated experiment logs, and a one-shot held-out
+evaluation.
+
+[WHATKEY]: https://github.com/EarthmanMuons/whatchord/tree/main/research/whatkey
 
 ## Screenshots
 

--- a/docs/marketplace/description.md
+++ b/docs/marketplace/description.md
@@ -1,17 +1,20 @@
-Identify chords from live MIDI or manual note entry, then explore the harmony behind them.
+Identify chords from live MIDI or manual note entry, follow the key as you play, then explore the harmony behind them.
 
 Stop guessing what chord you're playing.
 
-WhatChord gives musicians fast, musically informed chord names. Connect a Bluetooth or USB MIDI keyboard for instant feedback, or use the lookup pad to enter notes from any instrument, sheet music, or recording. Explore Chords and Explore Scales let you build and hear chords, browse a wide range of scales, inspect keyboard patterns, and understand diatonic harmony.
+WhatChord gives musicians fast, musically informed chord names and live key context. Connect a Bluetooth or USB MIDI keyboard for instant feedback, or use the lookup pad to enter notes from any instrument, sheet music, or recording. Auto key detection listens to your recent live chords, shows confidence, and waits when the evidence is ambiguous. Explore Chords and Explore Scales let you build and hear chords, browse a wide range of scales, inspect keyboard patterns, and understand diatonic harmony.
 
 Play it. Explore it. Learn it.
 
-WhatChord goes beyond simple note matching. Its musically informed analysis considers inversions, extensions, slash chords, altered tones, harmonic context, and conventional naming practices so chord names appear the way musicians expect to see them.
+WhatChord goes beyond simple note matching. Its musically informed analysis considers inversions, extensions, slash chords, altered tones, key context, and conventional naming practices so chord names appear the way musicians expect to see them.
 
 FEATURES
 
 - Real-time chord recognition  
   Chord names update immediately as you play.
+
+- Automatic key detection
+  Auto mode estimates the current key from recent live chords, shows confidence across major and minor keys, and can keep the app's key context following your playing.
 
 - Manual chord lookup
   Enter notes directly to identify a chord, choose its bass note, and inspect alternative interpretations without connecting a MIDI device.
@@ -39,7 +42,7 @@ FEATURES
 
 RECOGNITION
 
-WhatChord identifies everything from simple triads to rich extended harmony. Whether you're practicing theory, learning progressions, exploring altered dominants, or working through dense extended chords, the app names what you play with accuracy and musical intent.
+WhatChord identifies everything from simple triads to rich extended harmony and follows key context from real playing. Whether you're practicing theory, learning progressions, exploring altered dominants, or working through dense extended chords, the app names what you play with accuracy and musical intent.
 
 PRIVACY
 
@@ -47,4 +50,4 @@ WhatChord is free, contains no ads, and collects no personal data. All analysis 
 
 GET STARTED
 
-Play through MIDI, enter notes manually, or start exploring chords and scales right away.
+Play through MIDI, enter notes manually, or start exploring chords, keys, and scales right away.

--- a/docs/site/articles/index.html
+++ b/docs/site/articles/index.html
@@ -9,12 +9,12 @@
     <title>Articles | WhatChord</title>
     <meta
       name="description"
-      content="Writing on chords, harmony, and how WhatChord works: guides for musicians on naming, writing, and identifying chords, plus technical deep-dives into our analysis engine and the chord data behind it."
+      content="Writing on chords, harmony, and how WhatChord works: guides for musicians on naming, writing, and identifying chords, plus technical deep-dives and research notes behind the analysis engine."
     />
     <meta property="og:title" content="WhatChord Articles" />
     <meta
       property="og:description"
-      content="Guides for musicians on naming, writing, and identifying chords, plus technical deep-dives into our analysis engine and the chord data behind it."
+      content="Guides for musicians on naming, writing, and identifying chords, plus technical deep-dives and research notes behind the analysis engine."
     />
     <meta
       property="og:image"
@@ -36,7 +36,7 @@
     <meta name="twitter:title" content="WhatChord Articles" />
     <meta
       name="twitter:description"
-      content="Guides for musicians on naming, writing, and identifying chords, plus technical deep-dives into our analysis engine and the chord data behind it."
+      content="Guides for musicians on naming, writing, and identifying chords, plus technical deep-dives and research notes behind the analysis engine."
     />
     <meta
       name="twitter:image"
@@ -116,8 +116,8 @@
           </h1>
           <p class="section-sub">
             Guides for musicians on naming, writing, and identifying chords,
-            plus technical deep-dives into our analysis engine and the chord
-            data behind it.
+            plus technical deep-dives and research notes behind the analysis
+            engine.
           </p>
 
           <div class="article-group">
@@ -180,6 +180,18 @@
                   chord vocabulary and guide future recognition priorities.
                 </p>
                 <span class="read-more">Read the article →</span>
+              </a>
+              <a
+                class="article-card"
+                href="https://github.com/EarthmanMuons/whatchord/tree/main/research/whatkey"
+              >
+                <h3>Streaming Key Estimation Research</h3>
+                <p>
+                  The research project behind automatic key detection: a frozen
+                  evaluation protocol, versioned fixtures, external baselines,
+                  dated experiment logs, and held-out results.
+                </p>
+                <span class="read-more">Read the research notes →</span>
               </a>
             </div>
           </div>

--- a/docs/site/articles/million-chord-annotations.html
+++ b/docs/site/articles/million-chord-annotations.html
@@ -444,7 +444,7 @@
           </div>
 
           <div class="article-related">
-            <h4>Also on this site</h4>
+            <h4>Related reading</h4>
             <a
               class="article-card article-card-first"
               href="why-chord-naming-is-hard.html"
@@ -473,15 +473,16 @@
             </a>
             <a
               class="article-card article-card-following"
-              href="chord-symbols.html"
+              href="https://github.com/EarthmanMuons/whatchord/tree/main/research/whatkey"
             >
-              <div class="article-tag">Reference</div>
-              <h3>Chord Symbol Guide</h3>
+              <div class="article-tag">Key Detection</div>
+              <h3>Streaming Key Estimation Research</h3>
               <p>
-                How to format chord symbols: extensions, added tones,
-                alterations, parentheses, and slash bass.
+                The research project behind automatic key detection: a frozen
+                evaluation protocol, external baselines, dated experiment logs,
+                and held-out results.
               </p>
-              <span class="read-more">Read the guide →</span>
+              <span class="read-more">Read the research notes →</span>
             </a>
           </div>
         </div>

--- a/docs/site/css/style.css
+++ b/docs/site/css/style.css
@@ -800,7 +800,7 @@ section {
 
 .articles-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 20px;
   margin-top: 52px;
 }
@@ -878,7 +878,7 @@ section {
 
 .article-group-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 360px));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 20px;
 }
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -6,18 +6,20 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
-    <title>WhatChord - Chord Identification and Harmony Exploration</title>
+    <title>
+      WhatChord - Chord Identification, Key Detection, and Harmony Exploration
+    </title>
     <meta
       name="description"
-      content="Identify chords from live MIDI or manual note entry, then explore chords, scales, voicings, and harmonic context. Free, no ads, all on-device."
+      content="Identify chords from live MIDI or manual note entry, follow the key as you play, then explore chords, scales, voicings, and harmonic context. Free, no ads, all on-device."
     />
     <meta
       property="og:title"
-      content="WhatChord - Chord Identification and Harmony Exploration"
+      content="WhatChord - Chord Identification, Key Detection, and Harmony Exploration"
     />
     <meta
       property="og:description"
-      content="Play it. Explore it. Learn it. Identify chords and understand their harmonic context with WhatChord."
+      content="Play it. Explore it. Learn it. Identify chords, follow the key, and understand harmonic context with WhatChord."
     />
     <meta
       property="og:image"
@@ -103,8 +105,9 @@
           <p class="hero-sub">
             Identify chords instantly as you play a Bluetooth or USB MIDI
             keyboard, or enter notes manually. WhatChord names the voicing,
-            explains close alternatives, and connects it to chord structures,
-            scales, and key context. Available on iOS and Android.
+            follows the key from recent live chords, explains close
+            alternatives, and connects it to chord structures, scales, and key
+            context. Available on iOS and Android.
           </p>
           <div class="store-badges">
             <a href="https://apps.apple.com/us/app/whatchord-midi/id6758409779">
@@ -402,9 +405,8 @@
           <div class="section-label">Go deeper</div>
           <h2 class="section-title">How it works.</h2>
           <p class="section-sub">
-            Three in-depth pieces: one for musicians curious about why chord
-            naming is hard, one for engineers who want to see the algorithm, and
-            one about how real chord data guides development.
+            Practical articles and research notes for musicians, engineers, and
+            anyone curious about the evidence behind WhatChord's analysis.
           </p>
           <div class="articles-grid">
             <a
@@ -425,7 +427,7 @@
               href="articles/chord-recognition-algorithm.html"
             >
               <div class="article-tag">Technical deep-dive</div>
-              <h3>Under the Hood: Building a Real-Time Chord Recognizer</h3>
+              <h3>Building a Real-Time Chord Recognizer</h3>
               <p>
                 A detailed look at the bitmasks, chord-quality templates,
                 explanation costs, ranking heuristics, and LRU cache that power
@@ -445,6 +447,19 @@
                 evidence rather than guesswork.
               </p>
               <span class="read-more">Read the article →</span>
+            </a>
+            <a
+              class="article-card"
+              href="https://github.com/EarthmanMuons/whatchord/tree/main/research/whatkey"
+            >
+              <div class="article-tag">Key Detection</div>
+              <h3>Streaming Key Estimation Research</h3>
+              <p>
+                The research project behind automatic key detection: a frozen
+                evaluation protocol, versioned fixtures, external baselines,
+                dated experiment logs, and held-out results.
+              </p>
+              <span class="read-more">Read the research notes →</span>
             </a>
           </div>
         </div>


### PR DESCRIPTION
Mention automatic key detection in the README, marketplace description, and homepage copy. Add a homepage link to the WhatKey research notes and adjust the article grid for the additional card.