### PR TITLE
Add a Zenodo bundling task for manual research deposits

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -165,6 +165,10 @@ run = """
 typst compile research/whatkey/paper/main.typ
 """
 
+[tasks."research:whatkey-zenodo-bundle"]
+description = "Bundle a tagged source archive and the WhatKey preprint for a manual Zenodo deposit"
+run = "bash tool/whatkey_zenodo_bundle.sh \"$@\""
+
 [tasks."research:whatkey-headline-verify"]
 description = "Verify the README headline table from committed WhatKey result artifacts without rerunning detectors"
 run = "python tool/whatkey_headline_table.py --check"

--- a/tool/whatkey_zenodo_bundle.sh
+++ b/tool/whatkey_zenodo_bundle.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Bundle a tagged source archive plus the WhatKey preprint for a manual
+# Zenodo deposit, so the paper is visible on the record without untarring.
+#
+# Usage: tool/whatkey_zenodo_bundle.sh [tag]   (defaults to the latest tag)
+#
+# Everything is taken from the tag, not the working tree, so the bundle
+# matches the released state exactly; git archive output is deterministic
+# for a given tag. Upload the bundle as a "New version" of the existing
+# Zenodo record to keep all deposits under one concept DOI.
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+tag="${1:-$(git describe --tags --abbrev=0)}"
+git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null || {
+	echo "error: tag '${tag}' not found" >&2
+	exit 1
+}
+
+out="build/zenodo/${tag}"
+mkdir -p "${out}"
+
+archive="${out}/whatchord-${tag}.tar.gz"
+git archive --format=tar.gz --prefix="whatchord-${tag}/" -o "${archive}" "${tag}"
+
+# The paper carries its own version (draft-version in main.typ), which is
+# allowed to trail the repository tag when a research release did not touch
+# the paper; the PDF is named by the version it claims for itself.
+paper_version="$(
+	{ git show "${tag}:research/whatkey/paper/main.typ" 2>/dev/null || true; } |
+		sed -n 's/^#let draft-version = "\(.*\)"$/\1/p' | head -1
+)"
+if [[ -z ${paper_version} ]]; then
+	echo "error: could not read draft-version from main.typ at ${tag}" >&2
+	echo "(does the paper exist at this tag?)" >&2
+	exit 1
+fi
+
+paper="${out}/whatkey-preprint-${paper_version}.pdf"
+if ! git show "${tag}:research/whatkey/paper/main.pdf" >"${paper}" 2>/dev/null; then
+	rm -f "${paper}"
+	echo "error: research/whatkey/paper/main.pdf does not exist at ${tag}" >&2
+	exit 1
+fi
+
+echo "Zenodo bundle for ${tag} (paper ${paper_version}):"
+ls -lh "${out}"
+echo
+echo "Upload both files as a New Version of the existing Zenodo record,"
+echo "with the record version set to ${tag}; the preprint filename keeps"
+echo "the paper's own version, which may trail the repository tag."


### PR DESCRIPTION
tool/whatkey_zenodo_bundle.sh builds a deterministic git archive of a tag plus the WhatKey preprint PDF extracted from that same tag, staged under build/zenodo/ for a manual "New version" upload to the Zenodo record. Bundling from the tag keeps the visible PDF byte-identical to the archived source, and the script refuses tags that predate the paper. The preprint file is named by the paper's own draft version read from main.typ at the tag, which may trail the repository tag when a research release does not touch the paper; the record version stays the repository tag.