### PR TITLE
Polish the public API naming across both packages

### DIFF
--- a/benchmark/analyze_benchmark.dart
+++ b/benchmark/analyze_benchmark.dart
@@ -147,7 +147,7 @@ Future<Map<String, Object?>> _runBenchmark() async {
       'targetRelCi95': _targetRelCi,
       'referenceIterations': referenceIterations,
       'referenceDisplayScale': referenceDisplayScale,
-      'countersEnabled': kEngineCountersEnabled,
+      'countersEnabled': engineCountersEnabled,
     },
     'referenceUs': reference.toJson(targetRelCi: _targetRelCi),
     // Compare normalized values across runs, not raw microseconds.

--- a/lib/features/chords/widgets/explore_controls.dart
+++ b/lib/features/chords/widgets/explore_controls.dart
@@ -33,7 +33,7 @@ class ExploreControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final extensionGroups = buildExtensionControlGroups(state.quality);
+    final extensionGroups = buildExtensionOptionGroups(state.quality);
     final seventhKindChoices = availableSeventhKindsFor(state.baseQuality);
     final fifthAlterationChoices = availableFifthAlterationsFor(
       baseQuality: state.baseQuality,
@@ -280,9 +280,7 @@ class _CoreTonesSelector extends StatelessWidget {
                         ),
                         labels: [
                           for (final choice in fifthAlterationChoices)
-                            theoryTokenDisplayLabel(
-                              _fifthAlterationLabel(choice),
-                            ),
+                            toGlyphAccidentals(_fifthAlterationLabel(choice)),
                         ],
                         semanticLabels: [
                           for (final choice in fifthAlterationChoices)
@@ -304,7 +302,7 @@ class _CoreTonesSelector extends StatelessWidget {
                   ),
                   labels: [
                     for (final choice in seventhKindChoices)
-                      theoryTokenDisplayLabel(
+                      toGlyphAccidentals(
                         _seventhKindLabel(choice, baseQuality),
                       ),
                   ],
@@ -403,7 +401,7 @@ class _OptionWheel<T> extends StatelessWidget {
       label: label,
       value: value,
       choices: choices,
-      displayLabelFor: (value) => theoryTokenDisplayLabel(labelFor(value)),
+      displayLabelFor: (value) => toGlyphAccidentals(labelFor(value)),
       semanticLabelFor: semanticLabelFor,
       onChanged: onChanged,
     );
@@ -580,9 +578,9 @@ class _ExtensionBuilder extends StatelessWidget {
     required this.onChoiceSelected,
   });
 
-  final List<ExtensionControlGroup> groups;
+  final List<ExtensionOptionGroup> groups;
   final Set<ChordExtension> selectedExtensions;
-  final void Function(ExtensionControlGroup group, ExtensionChoice choice)
+  final void Function(ExtensionOptionGroup group, ExtensionChoice choice)
   onChoiceSelected;
 
   @override
@@ -651,7 +649,7 @@ class _ExtensionBuilder extends StatelessWidget {
     );
   }
 
-  bool _isSelected(ExtensionControlGroup group, ExtensionChoice choice) {
+  bool _isSelected(ExtensionOptionGroup group, ExtensionChoice choice) {
     final extension = choice.extension;
     if (extension != null) return selectedExtensions.contains(extension);
 
@@ -662,7 +660,7 @@ class _ExtensionBuilder extends StatelessWidget {
         );
   }
 
-  int _selectedIndex(ExtensionControlGroup group) {
+  int _selectedIndex(ExtensionOptionGroup group) {
     for (var index = 0; index < group.choices.length; index++) {
       if (_isSelected(group, group.choices[index])) return index;
     }

--- a/lib/features/home/widgets/chord_ranking_details_sheet.dart
+++ b/lib/features/home/widgets/chord_ranking_details_sheet.dart
@@ -613,7 +613,7 @@ class _CandidateCostBack extends StatelessWidget {
     for (final interval in intervals) {
       final pitchClass = (identity.rootPc + interval) % 12;
       final pc = {pitchClass};
-      final degree = theoryTokenDisplayLabel(
+      final degree = toGlyphAccidentals(
         ChordMemberDegreeFormatter.formatDegrees(
           identity: identity,
           pitchClasses: pc,
@@ -1020,7 +1020,7 @@ String _evidenceFor(ExplainedCandidate row) {
       rootPc: id.rootPc,
       presentIntervalsMask: id.presentIntervalsMask,
     ),
-  ).map(theoryTokenDisplayLabel).toList(growable: false);
+  ).map(toGlyphAccidentals).toList(growable: false);
   final bassRole = _bassRoleLabel(id);
   final requiredCount = _reasonCount(row, 'required tones');
   final optionalCount = _reasonCount(row, 'optional tones');

--- a/lib/features/key/widgets/key_posterior_strip.dart
+++ b/lib/features/key/widgets/key_posterior_strip.dart
@@ -82,7 +82,7 @@ class _KeyPosteriorStripState extends ConsumerState<KeyPosteriorStrip> {
           final t = math.sqrt(confidence).clamp(0.0, 1.0);
           final fill = Color.lerp(cs.surfaceContainerHighest, cs.primary, t)!;
           // Uppercase majors, lowercase minors; the rows disambiguate.
-          final label = tonalityPickerTonicLabel(
+          final label = tonalityTonicLabel(
             tonality,
             noteNameSystem: noteNameSystem,
           );

--- a/lib/features/key/widgets/key_posterior_wheel.dart
+++ b/lib/features/key/widgets/key_posterior_wheel.dart
@@ -53,14 +53,14 @@ class _KeyPosteriorWheelState extends ConsumerState<KeyPosteriorWheel> {
     };
 
     String tonicLabel(Tonality tonality) =>
-        tonalityPickerTonicLabel(tonality, noteNameSystem: noteNameSystem);
+        tonalityTonicLabel(tonality, noteNameSystem: noteNameSystem);
 
     // Both spellings for keys with an enharmonic twin, the more common
     // (fewer accidentals) first. Detection is pitch-class based, so which
     // spelling the detector picked carries no information.
     String keyLabel(Tonality tonality) {
       final spellings = [
-        for (final row in keySignatureRows)
+        for (final row in keySignatures)
           for (final spelled in [row.relativeMajor, row.relativeMinor])
             if (spelled.mode == tonality.mode &&
                 spelled.tonicPitchClass == tonality.tonicPitchClass)

--- a/lib/features/theory/presentation/widgets/tonality_picker_sheet.dart
+++ b/lib/features/theory/presentation/widgets/tonality_picker_sheet.dart
@@ -318,7 +318,7 @@ class _TonalityPickerBodyState extends ConsumerState<TonalityPickerBody> {
 
   List<KeySignature> _buildOrderedRows() {
     KeySignature rowFor(int acc) =>
-        keySignatureRows.firstWhere((r) => r.accidentalCount == acc);
+        keySignatures.firstWhere((r) => r.accidentalCount == acc);
 
     return <KeySignature>[
       for (var n = 7; n >= 1; n--) rowFor(n), // 7# … 1#
@@ -392,7 +392,7 @@ class _TonalityPickerBodyState extends ConsumerState<TonalityPickerBody> {
 }
 
 String _tonalityDisplayLabel(Tonality tonality, NoteNameSystem noteNameSystem) {
-  return tonalityPickerTonicLabel(tonality, noteNameSystem: noteNameSystem);
+  return tonalityTonicLabel(tonality, noteNameSystem: noteNameSystem);
 }
 
 String _tonalitySemanticsLabel(

--- a/lib/features/theory/state/providers/chord_member_spellings_providers.dart
+++ b/lib/features/theory/state/providers/chord_member_spellings_providers.dart
@@ -27,7 +27,7 @@ final chordMemberSpellingsByPcProvider = Provider<Map<int, String>>((ref) {
   final id = presentation.identity;
   final tonality = ref.watch(analysisContextProvider.select((c) => c.tonality));
   // Use the chord-aware root spelling (matching the identity card/symbol), not
-  // the plain chromatic pcToName. Otherwise a non-diatonic root such as Bb in C
+  // the plain chromatic noteNameForPitchClass. Otherwise a non-diatonic root such as Bb in C
   // major resolves to A#, and every member is spelled relative to A# (Cx, E#,
   // Gx, B#) even though the card reads Bbmaj9.
   final rootName = spellChordRoot(id, tonality: tonality);

--- a/lib/features/theory/state/providers/identity_display_provider.dart
+++ b/lib/features/theory/state/providers/identity_display_provider.dart
@@ -33,7 +33,7 @@ final identityDisplayProvider = Provider<IdentityDisplay?>((ref) {
     case AnalysisMode.single:
       {
         final pc = midis.first % 12;
-        final name = pcToName(pc, tonality: tonality);
+        final name = noteNameForPitchClass(pc, tonality: tonality);
         final displayName = noteDisplayLabel(
           name,
           noteNameSystem: noteNameSystem,
@@ -71,7 +71,7 @@ final identityDisplayProvider = Provider<IdentityDisplay?>((ref) {
         );
 
         final bassPc = bassMidi % 12;
-        final root = pcToName(bassPc, tonality: tonality);
+        final root = noteNameForPitchClass(bassPc, tonality: tonality);
         final displayRoot = noteDisplayLabel(
           root,
           noteNameSystem: noteNameSystem,
@@ -126,7 +126,7 @@ final identityDisplayProvider = Provider<IdentityDisplay?>((ref) {
           ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
 
         final extensionLabels = extensions
-            .map((e) => theoryTokenDisplayLabel(e.shortLabel))
+            .map((e) => toGlyphAccidentals(e.shortLabel))
             .toList();
         final debugText = _debugForChord(
           midis: midis,
@@ -144,9 +144,7 @@ final identityDisplayProvider = Provider<IdentityDisplay?>((ref) {
           members: presentation.members
               .map((m) => noteDisplayLabel(m, noteNameSystem: noteNameSystem))
               .toList(),
-          degrees: presentation.memberDegrees
-              .map(theoryTokenDisplayLabel)
-              .toList(),
+          degrees: presentation.memberDegrees.map(toGlyphAccidentals).toList(),
           appVersion: appVersion,
         );
 

--- a/lib/features/theory/state/providers/pitch_class_names_provider.dart
+++ b/lib/features/theory/state/providers/pitch_class_names_provider.dart
@@ -10,7 +10,7 @@ final pitchClassNamesProvider = Provider<List<String>>((ref) {
 
   return List<String>.generate(
     12,
-    (pc) => pcToName(pc, tonality: tonality),
+    (pc) => noteNameForPitchClass(pc, tonality: tonality),
     growable: false,
   );
 });

--- a/lib/features/theory/state/providers/selected_key_signature_provider.dart
+++ b/lib/features/theory/state/providers/selected_key_signature_provider.dart
@@ -6,7 +6,7 @@ import 'selected_tonality_notifier.dart';
 final selectedKeySignatureProvider = Provider<KeySignature>((ref) {
   final tonality = ref.watch(selectedTonalityProvider);
 
-  for (final ks in keySignatureRows) {
+  for (final ks in keySignatures) {
     if (tonality.mode == TonalityMode.major && ks.relativeMajor == tonality) {
       return ks;
     }
@@ -15,5 +15,5 @@ final selectedKeySignatureProvider = Provider<KeySignature>((ref) {
     }
   }
 
-  return keySignatureRows.firstWhere((k) => k.accidentalCount == 0);
+  return keySignatures.firstWhere((k) => k.accidentalCount == 0);
 });

--- a/packages/whatchord/example/example.dart
+++ b/packages/whatchord/example/example.dart
@@ -46,7 +46,7 @@ void main() {
   // root, quality, and extensions, produce a canonical example.
   final construction = ChordConstruction(
     rootPc: Tonic.d.pitchClass,
-    quality: ChordQualityToken.minor7,
+    quality: ChordQuality.minor7,
     extensions: {ChordExtension.eleven},
     bassPc: Tonic.d.pitchClass,
   );

--- a/packages/whatchord/lib/src/analysis/candidate_features.dart
+++ b/packages/whatchord/lib/src/analysis/candidate_features.dart
@@ -118,15 +118,15 @@ class CandidateFeatures {
     final realExt = (pref.naturalCount + pref.alterationCount) > 0;
     final bassRoleRank = _bassRoleRank(id);
 
-    final isDim7 = q == ChordQualityToken.diminished7;
-    final isDimFamily = isDim7 || q == ChordQualityToken.halfDiminished7;
+    final isDim7 = q == ChordQuality.diminished7;
+    final isDimFamily = isDim7 || q == ChordQuality.halfDiminished7;
     final isSlashBass = !rootPos;
     final bassIsColorTone = isSlashBass ? _bassIsColorTone(id) : false;
 
-    final isDom7 = q == ChordQualityToken.dominant7;
-    final isFlatFiveDom7 = q == ChordQualityToken.dominant7Flat5;
+    final isDom7 = q == ChordQuality.dominant7;
+    final isFlatFiveDom7 = q == ChordQuality.dominant7Flat5;
     final isAlteredFifthDom7 =
-        isFlatFiveDom7 || q == ChordQualityToken.dominant7Sharp5;
+        isFlatFiveDom7 || q == ChordQuality.dominant7Sharp5;
     final isDom7RootPosition = isDom7 && rootPos;
     final isDom7Slash = isDom7 && isSlashBass;
 
@@ -159,10 +159,10 @@ class CandidateFeatures {
       isRootDominantSus: _isRootDominantSus(id, rootPos),
       isRootPositionNaturalAddChord:
           rootPos &&
-          (q == ChordQualityToken.major ||
-              q == ChordQualityToken.minor ||
-              q == ChordQualityToken.major6 ||
-              q == ChordQualityToken.minor6) &&
+          (q == ChordQuality.major ||
+              q == ChordQuality.minor ||
+              q == ChordQuality.major6 ||
+              q == ChordQuality.minor6) &&
           pref.alterationCount == 0 &&
           pref.naturalCount == 0,
       isStructurallyDeficient: _isStructurallyDeficient(id, rootPos),
@@ -176,7 +176,7 @@ class CandidateFeatures {
       dom7SlashHasNonBassAlterations: dom7SlashHasNonBassAlterations,
       isCompleteDominantFlat9: _isCompleteDominantWithAlteration(
         id,
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         alteration: ChordExtension.flat9,
         alterationRole: ChordToneRole.flat9,
         fifthRole: ChordToneRole.perfect5,
@@ -187,7 +187,7 @@ class CandidateFeatures {
       ),
       isCompleteDominantSharp9: _isCompleteDominantWithAlteration(
         id,
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         alteration: ChordExtension.sharp9,
         alterationRole: ChordToneRole.sharp9,
         fifthRole: ChordToneRole.perfect5,
@@ -223,7 +223,7 @@ class CandidateFeatures {
 
   static bool _isCompleteDominantWithAlteration(
     ChordIdentity id, {
-    required ChordQualityToken quality,
+    required ChordQuality quality,
     required ChordExtension alteration,
     required ChordToneRole alterationRole,
     required ChordToneRole fifthRole,
@@ -255,7 +255,7 @@ class CandidateFeatures {
   /// This identifies the narrow ambiguous shape that can be heard as a familiar
   /// altered-dominant shell or as a more remote chord rooted on the bass.
   static bool _isFifthlessFlatNineBassDominant(ChordIdentity id) {
-    if (id.quality != ChordQualityToken.dominant7) return false;
+    if (id.quality != ChordQuality.dominant7) return false;
     if (!id.extensions.contains(ChordExtension.flat9)) {
       return false;
     }
@@ -281,8 +281,8 @@ class CandidateFeatures {
 
   static bool _isCompleteAlteredFifthDominant(ChordIdentity id) {
     final quality = id.quality;
-    if (quality != ChordQualityToken.dominant7Flat5 &&
-        quality != ChordQualityToken.dominant7Sharp5) {
+    if (quality != ChordQuality.dominant7Flat5 &&
+        quality != ChordQuality.dominant7Sharp5) {
       return false;
     }
 
@@ -296,16 +296,16 @@ class CandidateFeatures {
         roles.contains(ChordToneRole.flat7);
   }
 
-  static bool _isUnusualSeventhQuality(ChordQualityToken quality) {
-    return quality == ChordQualityToken.minor7Sharp5 ||
-        quality == ChordQualityToken.dominant7sus2 ||
-        quality == ChordQualityToken.dominant7sus4 ||
-        quality == ChordQualityToken.dominant7Flat5 ||
-        quality == ChordQualityToken.dominant7Sharp5 ||
-        quality == ChordQualityToken.major7sus2 ||
-        quality == ChordQualityToken.major7sus4 ||
-        quality == ChordQualityToken.major7Flat5 ||
-        quality == ChordQualityToken.major7Sharp5;
+  static bool _isUnusualSeventhQuality(ChordQuality quality) {
+    return quality == ChordQuality.minor7Sharp5 ||
+        quality == ChordQuality.dominant7sus2 ||
+        quality == ChordQuality.dominant7sus4 ||
+        quality == ChordQuality.dominant7Flat5 ||
+        quality == ChordQuality.dominant7Sharp5 ||
+        quality == ChordQuality.major7sus2 ||
+        quality == ChordQuality.major7sus4 ||
+        quality == ChordQuality.major7Flat5 ||
+        quality == ChordQuality.major7Sharp5;
   }
 
   static bool _isRootPositionMinor7Add11Shell(
@@ -313,7 +313,7 @@ class CandidateFeatures {
     bool rootPosition,
   ) {
     if (!rootPosition ||
-        id.quality != ChordQualityToken.minor7 ||
+        id.quality != ChordQuality.minor7 ||
         id.extensions.length != 1 ||
         !_hasNaturalEleventhColor(id.extensions)) {
       return false;
@@ -335,7 +335,7 @@ class CandidateFeatures {
 
   static bool _isCompleteMajorMinorTriadCore(ChordIdentity id) {
     final q = id.quality;
-    if (q != ChordQualityToken.major && q != ChordQualityToken.minor) {
+    if (q != ChordQuality.major && q != ChordQuality.minor) {
       return false;
     }
     if (id.extensions.any(
@@ -345,7 +345,7 @@ class CandidateFeatures {
     }
 
     final roles = id.toneRolesByInterval.values;
-    final hasThird = q == ChordQualityToken.major
+    final hasThird = q == ChordQuality.major
         ? roles.contains(ChordToneRole.major3)
         : roles.contains(ChordToneRole.minor3);
 
@@ -356,7 +356,7 @@ class CandidateFeatures {
 
   static bool _isCompleteTriadCore(ChordIdentity id) {
     final q = id.quality;
-    if (q == ChordQualityToken.diminished) {
+    if (q == ChordQuality.diminished) {
       if (id.extensions.isNotEmpty) return false;
 
       final roles = id.toneRolesByInterval.values;
@@ -370,7 +370,7 @@ class CandidateFeatures {
 
   static bool _isCompleteMajorTriadInversion(ChordIdentity id, bool rootPos) {
     if (rootPos) return false;
-    if (id.quality != ChordQualityToken.major) return false;
+    if (id.quality != ChordQuality.major) return false;
     if (_bassRoleRank(id) > 2) return false;
 
     final roles = id.toneRolesByInterval.values;
@@ -381,10 +381,9 @@ class CandidateFeatures {
 
   static bool _isTriadCoreDestabilizingExtension(
     ChordExtension extension, {
-    required ChordQualityToken quality,
+    required ChordQuality quality,
   }) {
-    if (quality == ChordQualityToken.major &&
-        extension == ChordExtension.add11) {
+    if (quality == ChordQuality.major && extension == ChordExtension.add11) {
       return true;
     }
 
@@ -433,13 +432,12 @@ class CandidateFeatures {
   static bool _isRootDominantSus(ChordIdentity id, bool rootPos) {
     if (!rootPos) return false;
     final q = id.quality;
-    if (q != ChordQualityToken.dominant7sus2 &&
-        q != ChordQualityToken.dominant7sus4) {
+    if (q != ChordQuality.dominant7sus2 && q != ChordQuality.dominant7sus4) {
       return false;
     }
 
     final roles = id.toneRolesByInterval.values;
-    final hasSuspension = q == ChordQualityToken.dominant7sus2
+    final hasSuspension = q == ChordQuality.dominant7sus2
         ? roles.contains(ChordToneRole.sus2)
         : roles.contains(ChordToneRole.sus4);
     return hasSuspension && roles.contains(ChordToneRole.flat7);
@@ -454,7 +452,7 @@ class CandidateFeatures {
     // Plain suspended triad: no third, and no seventh that would make it a real
     // dominant/major sus. Dominant7sus/major7sus keep their seventh and are not
     // deficient.
-    if (q == ChordQualityToken.sus2 || q == ChordQualityToken.sus4) {
+    if (q == ChordQuality.sus2 || q == ChordQuality.sus4) {
       return true;
     }
 
@@ -482,9 +480,9 @@ class CandidateFeatures {
     bool hasMaj3Nat11,
   ) {
     if (rootPos) return false;
-    if (id.quality == ChordQualityToken.dominant7 ||
-        id.quality == ChordQualityToken.dominant7Flat5 ||
-        id.quality == ChordQualityToken.dominant7Sharp5) {
+    if (id.quality == ChordQuality.dominant7 ||
+        id.quality == ChordQuality.dominant7Flat5 ||
+        id.quality == ChordQuality.dominant7Sharp5) {
       return false;
     }
     return hasMaj3Nat11;
@@ -523,7 +521,7 @@ class CandidateFeatures {
   }
 
   static bool _dom7SlashHasNonBassAlterations(ChordIdentity id) {
-    if (id.quality != ChordQualityToken.dominant7) return false;
+    if (id.quality != ChordQuality.dominant7) return false;
     if (id.rootPc == id.bassPc) return false;
 
     // Identify which extension token corresponds to the bass role (if any),

--- a/packages/whatchord/lib/src/analysis/chord_analyzer.dart
+++ b/packages/whatchord/lib/src/analysis/chord_analyzer.dart
@@ -65,7 +65,7 @@ class ExplainedCandidate {
   final RankingDecision? vsPrevious;
 
   /// The quality of the template that generated this candidate.
-  final ChordQualityToken templateQuality;
+  final ChordQuality templateQuality;
 
   const ExplainedCandidate({
     required this.candidate,
@@ -208,7 +208,7 @@ abstract final class ChordAnalyzer {
     );
     final cached = _cache[key];
     if (cached != null) {
-      if (kEngineCountersEnabled) EngineCounters.cacheHits++;
+      if (engineCountersEnabled) EngineCounters.cacheHits++;
       // Promote cache hits so eviction removes the least recently used entry,
       // not merely the oldest inserted entry.
       _cache
@@ -216,7 +216,7 @@ abstract final class ChordAnalyzer {
         ..[key] = cached;
       return cached;
     }
-    if (kEngineCountersEnabled) EngineCounters.cacheMisses++;
+    if (engineCountersEnabled) EngineCounters.cacheMisses++;
 
     final eval = _evaluateAll(
       input,
@@ -302,13 +302,13 @@ abstract final class ChordAnalyzer {
     // This prevents generating "ghost root" interpretations.
     for (var rootPc = 0; rootPc < 12; rootPc++) {
       if ((pcMask & (1 << rootPc)) == 0) continue;
-      if (kEngineCountersEnabled) EngineCounters.rootsConsidered++;
+      if (engineCountersEnabled) EngineCounters.rootsConsidered++;
 
       final relMask = _rotateMaskToRoot(pcMask, rootPc);
       final bassInterval = intervalAboveRoot(input.bassPc, rootPc);
 
       for (final tmpl in chordTemplates) {
-        if (kEngineCountersEnabled) EngineCounters.templatesEvaluated++;
+        if (engineCountersEnabled) EngineCounters.templatesEvaluated++;
         final reasons = debug ? <CostReason>[] : null;
 
         final priced = _priceTemplate(
@@ -333,7 +333,7 @@ abstract final class ChordAnalyzer {
           cost: priced.cost,
         );
 
-        if (kEngineCountersEnabled) EngineCounters.candidatesProduced++;
+        if (engineCountersEnabled) EngineCounters.candidatesProduced++;
         out.add(
           _Evaluated(candidate: candidate, template: tmpl, reasons: reasons),
         );
@@ -344,7 +344,7 @@ abstract final class ChordAnalyzer {
     // Costs are a pure function of the input, so this is transposition-invariant
     // (both a chord and its transposition prune to the same set).
     final toRank = _pruneForRanking(out, take);
-    if (kEngineCountersEnabled) {
+    if (engineCountersEnabled) {
       EngineCounters.candidatesRanked += toRank.length;
     }
 
@@ -451,7 +451,7 @@ abstract final class ChordAnalyzer {
     // More than 1 missing tone suggests wrong template entirely. A power
     // chord is nothing but its fifth, so it gets no such allowance.
     if (missCount > 1) return null;
-    if (missCount > 0 && template.quality == ChordQualityToken.power) {
+    if (missCount > 0 && template.quality == ChordQuality.power) {
       return null;
     }
 
@@ -468,8 +468,8 @@ abstract final class ChordAnalyzer {
     // reading survives as the conventional triad-over-sixth symbol (A-C-E as
     // C/A), so only tones above the bass trigger the rejection.
     final isBareTriad =
-        template.quality == ChordQualityToken.major ||
-        template.quality == ChordQualityToken.minor;
+        template.quality == ChordQuality.major ||
+        template.quality == ChordQuality.minor;
     if (isBareTriad &&
         (extrasMask & (1 << majorSixthInterval)) != 0 &&
         bassInterval != majorSixthInterval) {
@@ -537,8 +537,8 @@ abstract final class ChordAnalyzer {
     // upper-structure slash idiom (D/E, C#/D#): the bass reads as an
     // independent pedal, not as chord color the name must justify.
     final isUpperTriadOverNinthBass =
-        (template.quality == ChordQualityToken.major ||
-            template.quality == ChordQualityToken.minor) &&
+        (template.quality == ChordQuality.major ||
+            template.quality == ChordQuality.minor) &&
         bassInterval == majorSecondInterval &&
         extensions.length == 1 &&
         extensions.contains(ChordExtension.add9) &&
@@ -603,7 +603,7 @@ abstract final class ChordAnalyzer {
     // A power chord is only a credible reading when the bare fifth plus its
     // named colors account for every sounding tone; a leftover tone means
     // some other harmony is in play.
-    if (unexplainedMask != 0 && template.quality == ChordQualityToken.power) {
+    if (unexplainedMask != 0 && template.quality == ChordQuality.power) {
       return null;
     }
 
@@ -648,32 +648,32 @@ abstract final class ChordAnalyzer {
   /// How readily a musician reaches for this quality name. Everyday names
   /// (major, minor, 7, m7, maj7, sus4, 6ths) are free; a rare name has to be
   /// much cheaper at explaining the tones than a common one to win.
-  static double _vocabularyCost(ChordQualityToken quality) {
+  static double _vocabularyCost(ChordQuality quality) {
     return switch (quality) {
-      ChordQualityToken.sus2 ||
-      ChordQualityToken.sus2sus4 ||
-      ChordQualityToken.diminished ||
-      ChordQualityToken.augmented ||
-      ChordQualityToken.diminished7 ||
-      ChordQualityToken.halfDiminished7 ||
-      ChordQualityToken.minorMajor7 ||
-      ChordQualityToken.dominant7sus4 => _vocabularyMarked,
-      ChordQualityToken.dominant7Flat5 ||
-      ChordQualityToken.dominant7Sharp5 ||
-      ChordQualityToken.major7sus4 ||
-      ChordQualityToken.major7Sharp5 => _vocabularyUncommon,
+      ChordQuality.sus2 ||
+      ChordQuality.sus2sus4 ||
+      ChordQuality.diminished ||
+      ChordQuality.augmented ||
+      ChordQuality.diminished7 ||
+      ChordQuality.halfDiminished7 ||
+      ChordQuality.minorMajor7 ||
+      ChordQuality.dominant7sus4 => _vocabularyMarked,
+      ChordQuality.dominant7Flat5 ||
+      ChordQuality.dominant7Sharp5 ||
+      ChordQuality.major7sus4 ||
+      ChordQuality.major7Sharp5 => _vocabularyUncommon,
       _ when quality.isRareVocabulary => _vocabularyRare,
       _ => 0,
     };
   }
 
-  static bool _isDominantFamily(ChordQualityToken quality) {
+  static bool _isDominantFamily(ChordQuality quality) {
     return switch (quality) {
-      ChordQualityToken.dominant7 ||
-      ChordQualityToken.dominant7sus2 ||
-      ChordQualityToken.dominant7sus4 ||
-      ChordQualityToken.dominant7Flat5 ||
-      ChordQualityToken.dominant7Sharp5 => true,
+      ChordQuality.dominant7 ||
+      ChordQuality.dominant7sus2 ||
+      ChordQuality.dominant7sus4 ||
+      ChordQuality.dominant7Flat5 ||
+      ChordQuality.dominant7Sharp5 => true,
       _ => false,
     };
   }
@@ -682,26 +682,26 @@ abstract final class ChordAnalyzer {
   /// alteration: Lydian majors, dominants, minor family (Dorian #11), and
   /// sus4 frames (where the split-fourth surcharge prices the clash
   /// separately). On diminished and sus2 hosts it stays multiplied.
-  static bool _isSharpElevenFriendly(ChordQualityToken quality) {
+  static bool _isSharpElevenFriendly(ChordQuality quality) {
     return _isDominantFamily(quality) ||
         switch (quality) {
-          ChordQualityToken.major ||
-          ChordQualityToken.major6 ||
-          ChordQualityToken.major7 ||
-          ChordQualityToken.minor ||
-          ChordQualityToken.minor6 ||
-          ChordQualityToken.minor7 ||
-          ChordQualityToken.minorMajor7 ||
-          ChordQualityToken.sus4 ||
-          ChordQualityToken.major7sus4 ||
-          ChordQualityToken.sus2sus4 => true,
+          ChordQuality.major ||
+          ChordQuality.major6 ||
+          ChordQuality.major7 ||
+          ChordQuality.minor ||
+          ChordQuality.minor6 ||
+          ChordQuality.minor7 ||
+          ChordQuality.minorMajor7 ||
+          ChordQuality.sus4 ||
+          ChordQuality.major7sus4 ||
+          ChordQuality.sus2sus4 => true,
           _ => false,
         };
   }
 
   static double _tonePrice({
     required ChordToneRole role,
-    required ChordQualityToken quality,
+    required ChordQuality quality,
     required int relMask,
     required Map<int, ChordToneRole> roles,
     required bool isBassTone,
@@ -767,7 +767,7 @@ abstract final class ChordAnalyzer {
 
   static double _alteredTonePrice({
     required ChordToneRole role,
-    required ChordQualityToken quality,
+    required ChordQuality quality,
     required int relMask,
     required Map<int, ChordToneRole> roles,
     required bool isStackedColor,
@@ -794,9 +794,9 @@ abstract final class ChordAnalyzer {
     final majorFamilyLydianStack =
         has(majorSecondInterval) &&
         switch (quality) {
-          ChordQualityToken.major ||
-          ChordQualityToken.major6 ||
-          ChordQualityToken.major7 => true,
+          ChordQuality.major ||
+          ChordQuality.major6 ||
+          ChordQuality.major7 => true,
           _ => false,
         };
     if (role == ChordToneRole.sharp11 &&
@@ -821,7 +821,7 @@ abstract final class ChordAnalyzer {
     if (role == ChordToneRole.flat13 &&
         !has(perfectFifthInterval) &&
         !flatFiveMinorHost &&
-        quality != ChordQualityToken.minorMajor7) {
+        quality != ChordQuality.minorMajor7) {
       price += _flatThirteenEmptyFifthSurcharge;
     }
     if ((role == ChordToneRole.flat9 || role == ChordToneRole.sharp9) &&
@@ -838,16 +838,16 @@ abstract final class ChordAnalyzer {
     if (role == ChordToneRole.flat9 &&
         isStackedColor &&
         switch (quality) {
-          ChordQualityToken.major6 ||
-          ChordQualityToken.major7 ||
-          ChordQualityToken.major7Flat5 ||
-          ChordQualityToken.major7Sharp5 => true,
+          ChordQuality.major6 ||
+          ChordQuality.major7 ||
+          ChordQuality.major7Flat5 ||
+          ChordQuality.major7Sharp5 => true,
           _ => false,
         }) {
       price += _flatNineMajorHostSurcharge;
     }
     if (role == ChordToneRole.flat9 &&
-        quality == ChordQualityToken.minorMajor7 &&
+        quality == ChordQuality.minorMajor7 &&
         roles[perfectFifthInterval] != ChordToneRole.perfect5 &&
         roles.containsValue(ChordToneRole.eleven)) {
       price += _minorMajorFlatNineElevenSurcharge;
@@ -870,7 +870,7 @@ abstract final class ChordAnalyzer {
     return multiplied ? price * _offDominantAlterationMultiplier : price;
   }
 
-  static double _naturalExtensionPrice(double base, ChordQualityToken quality) {
+  static double _naturalExtensionPrice(double base, ChordQuality quality) {
     return _isMarkedExtensionHost(quality)
         ? base * _markedHostExtensionMultiplier
         : base;
@@ -880,22 +880,22 @@ abstract final class ChordAnalyzer {
   /// added color tone reads as a stretch rather than everyday vocabulary.
   /// Dominants (including sus dominants), plain major/minor sevenths, and
   /// sixth chords keep flat extension prices.
-  static bool _isMarkedExtensionHost(ChordQualityToken quality) {
+  static bool _isMarkedExtensionHost(ChordQuality quality) {
     return switch (quality) {
-      ChordQualityToken.diminished ||
-      ChordQualityToken.augmented ||
-      ChordQualityToken.diminished7 ||
-      ChordQualityToken.halfDiminished7 ||
-      ChordQualityToken.minorMajor7 ||
-      ChordQualityToken.minorSharp5 ||
-      ChordQualityToken.minor7Sharp5 ||
-      ChordQualityToken.majorFlat5 ||
-      ChordQualityToken.major7Flat5 ||
-      ChordQualityToken.major7Sharp5 ||
-      ChordQualityToken.major7sus2 ||
-      ChordQualityToken.sus2 ||
-      ChordQualityToken.sus2sus4 ||
-      ChordQualityToken.dominant7sus2 => true,
+      ChordQuality.diminished ||
+      ChordQuality.augmented ||
+      ChordQuality.diminished7 ||
+      ChordQuality.halfDiminished7 ||
+      ChordQuality.minorMajor7 ||
+      ChordQuality.minorSharp5 ||
+      ChordQuality.minor7Sharp5 ||
+      ChordQuality.majorFlat5 ||
+      ChordQuality.major7Flat5 ||
+      ChordQuality.major7Sharp5 ||
+      ChordQuality.major7sus2 ||
+      ChordQuality.sus2 ||
+      ChordQuality.sus2sus4 ||
+      ChordQuality.dominant7sus2 => true,
       _ => false,
     };
   }
@@ -957,15 +957,15 @@ abstract final class ChordAnalyzer {
 
   static double _bassPlacementCost(
     ChordToneRole? bassRole,
-    ChordQualityToken quality,
+    ChordQuality quality,
   ) {
     // Diminished and augmented chords invert freely; their fifth in the bass
     // is a plain core tone, unlike the altered fifth of a m#5 or 7#5.
     final fifthIsDefinitional = switch (quality) {
-      ChordQualityToken.diminished ||
-      ChordQualityToken.diminished7 ||
-      ChordQualityToken.halfDiminished7 ||
-      ChordQualityToken.augmented => true,
+      ChordQuality.diminished ||
+      ChordQuality.diminished7 ||
+      ChordQuality.halfDiminished7 ||
+      ChordQuality.augmented => true,
       _ => false,
     };
     if (bassRole == null) return _bassUnexplainedCost;
@@ -1007,15 +1007,15 @@ abstract final class ChordAnalyzer {
       return 1 << minorThirdInterval;
     }
 
-    if (quality == ChordQualityToken.major7 &&
+    if (quality == ChordQuality.major7 &&
         _hasMajorSeventhSharpNineColor(relMask)) {
       return 1 << minorThirdInterval;
     }
 
     final isSharpNineDominantQuality =
-        quality == ChordQualityToken.dominant7 ||
-        quality == ChordQualityToken.dominant7Flat5 ||
-        quality == ChordQualityToken.dominant7Sharp5;
+        quality == ChordQuality.dominant7 ||
+        quality == ChordQuality.dominant7Flat5 ||
+        quality == ChordQuality.dominant7Sharp5;
     if (!isSharpNineDominantQuality) return 0;
 
     final hasDominantShell =
@@ -1054,16 +1054,13 @@ abstract final class ChordAnalyzer {
     return isConventionalInversion && hasPerfectFifth;
   }
 
-  static bool _allowsAddSharpNine(ChordQualityToken quality) {
-    return quality == ChordQualityToken.major ||
-        quality == ChordQualityToken.major6 ||
-        quality == ChordQualityToken.augmented;
+  static bool _allowsAddSharpNine(ChordQuality quality) {
+    return quality == ChordQuality.major ||
+        quality == ChordQuality.major6 ||
+        quality == ChordQuality.augmented;
   }
 
-  static bool _isSplitThirdMajorQuality(
-    ChordQualityToken quality,
-    int relMask,
-  ) {
+  static bool _isSplitThirdMajorQuality(ChordQuality quality, int relMask) {
     if (!_allowsAddSharpNine(quality)) return false;
     const majorThirdBit = 1 << majorThirdInterval;
     const minorThirdBit = 1 << minorThirdInterval;
@@ -1071,14 +1068,14 @@ abstract final class ChordAnalyzer {
   }
 
   static bool _flatFiveConflictsWithNaturalThirteenth({
-    required ChordQualityToken quality,
+    required ChordQuality quality,
     required Set<ChordExtension> extensions,
     required int relMask,
     required int bassInterval,
   }) {
     final isFlatFiveQuality =
-        quality == ChordQualityToken.dominant7Flat5 ||
-        quality == ChordQualityToken.major7Flat5;
+        quality == ChordQuality.dominant7Flat5 ||
+        quality == ChordQuality.major7Flat5;
     if (!isFlatFiveQuality) return false;
 
     // With a natural thirteenth present, the tritone usually functions as #11
@@ -1121,7 +1118,7 @@ abstract final class ChordAnalyzer {
   static Set<ChordExtension> _extensionsFromExtras(
     int extrasMask, {
     required bool has7,
-    required ChordQualityToken quality,
+    required ChordQuality quality,
   }) {
     final out = <ChordExtension>{};
 

--- a/packages/whatchord/lib/src/analysis/chord_templates.dart
+++ b/packages/whatchord/lib/src/analysis/chord_templates.dart
@@ -22,7 +22,7 @@ import '../services/interval_constants.dart';
 @immutable
 class ChordTemplate {
   /// Quality token for this template.
-  final ChordQualityToken quality;
+  final ChordQuality quality;
 
   /// Required intervals (as a 12-bit mask relative to root).
   final int requiredMask;
@@ -88,7 +88,7 @@ final chordTemplates = <ChordTemplate>[
   // - P5 optional for sparse voicings
   // - Penalty: m3, b7, M7 (would suggest minor/seventh chords)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.major.intervals,
+    ChordQuality.major.intervals,
     penaltyMask:
         (1 << minorThirdInterval) |
         (1 << minorSeventhInterval) |
@@ -100,7 +100,7 @@ final chordTemplates = <ChordTemplate>[
   // - No optional tones (all three intervals are the chord)
   // - Penalty: P5 (contradicts b5), m3 (contradicts major), b7/M7 (would suggest seventh chords)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.majorFlat5.intervals,
+    ChordQuality.majorFlat5.intervals,
     penaltyMask:
         (1 << perfectFifthInterval) |
         (1 << minorThirdInterval) |
@@ -112,7 +112,7 @@ final chordTemplates = <ChordTemplate>[
   // - m3 defines minor quality
   // - Penalty: M3, b7, M7 (would suggest major/seventh chords)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.minor.intervals,
+    ChordQuality.minor.intervals,
     penaltyMask:
         (1 << majorThirdInterval) |
         (1 << minorSeventhInterval) |
@@ -124,7 +124,7 @@ final chordTemplates = <ChordTemplate>[
   // - No optional tones; the altered fifth is the distinguishing tone
   // - Penalty: M3, P5, b7, M7 (would suggest other minor/seventh qualities)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.minorSharp5.intervals,
+    ChordQuality.minorSharp5.intervals,
     penaltyMask:
         (1 << majorThirdInterval) |
         (1 << perfectFifthInterval) |
@@ -137,7 +137,7 @@ final chordTemplates = <ChordTemplate>[
   // - No optional tones (tight structure)
   // - Penalty: M3, P5 (would contradict diminished quality)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.diminished.intervals,
+    ChordQuality.diminished.intervals,
     penaltyMask: (1 << majorThirdInterval) | (1 << perfectFifthInterval),
   ),
 
@@ -146,7 +146,7 @@ final chordTemplates = <ChordTemplate>[
   // - No optional tones (symmetric structure)
   // - Penalty: m3, P5 (would contradict augmented quality)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.augmented.intervals,
+    ChordQuality.augmented.intervals,
     penaltyMask: (1 << minorThirdInterval) | (1 << perfectFifthInterval),
   ),
 
@@ -158,7 +158,7 @@ final chordTemplates = <ChordTemplate>[
   // - Second and fourth extras stay nameable so sparse fifth-plus-color
   //   voicings can be read directly (C-Db-G as C5(addb9))
   ChordTemplate.fromIntervals(
-    ChordQualityToken.power.intervals,
+    ChordQuality.power.intervals,
     penaltyMask:
         (1 << minorThirdInterval) |
         (1 << majorThirdInterval) |
@@ -174,7 +174,7 @@ final chordTemplates = <ChordTemplate>[
   // - P5 required (standard triad definition; prevents ambiguous two-note matches)
   // - Penalty: any third (would resolve the suspension) or seventh (would suggest 7sus2)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.sus2.intervals,
+    ChordQuality.sus2.intervals,
     penaltyMask:
         (1 << minorThirdInterval) |
         (1 << majorThirdInterval) |
@@ -187,7 +187,7 @@ final chordTemplates = <ChordTemplate>[
   // - P5 required (standard triad definition)
   // - Penalty: any third (would resolve the suspension) or seventh (would suggest 7sus4)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.sus4.intervals,
+    ChordQuality.sus4.intervals,
     penaltyMask:
         (1 << minorThirdInterval) |
         (1 << majorThirdInterval) |
@@ -199,7 +199,7 @@ final chordTemplates = <ChordTemplate>[
   // - Both suspended tones replace the third
   // - Exact match prevents incomplete or extended double-sus readings
   ChordTemplate.fromIntervals(
-    ChordQualityToken.sus2sus4.intervals,
+    ChordQuality.sus2sus4.intervals,
     penaltyMask: 0,
     requiresExactMatch: true,
   ),
@@ -210,7 +210,7 @@ final chordTemplates = <ChordTemplate>[
   // - Penalty: b7/M7 (ambiguous with inverted minor7/major7)
   //            m3 (would suggest minor6)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.major6.intervals,
+    ChordQuality.major6.intervals,
     penaltyMask:
         (1 << minorSeventhInterval) |
         (1 << majorSeventhInterval) |
@@ -223,7 +223,7 @@ final chordTemplates = <ChordTemplate>[
   // - Penalty: b7/M7 (ambiguous with seventh chords)
   //            M3 (would suggest major6)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.minor6.intervals,
+    ChordQuality.minor6.intervals,
     penaltyMask:
         (1 << minorSeventhInterval) |
         (1 << majorSeventhInterval) |
@@ -235,7 +235,7 @@ final chordTemplates = <ChordTemplate>[
   // - P5 optional (shell voicing: R-3-b7)
   // - Penalty: M7 (would suggest major7), m3 (would suggest minor7)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.dominant7.intervals,
+    ChordQuality.dominant7.intervals,
     penaltyMask: (1 << majorSeventhInterval) | (1 << minorThirdInterval),
   ),
 
@@ -244,7 +244,7 @@ final chordTemplates = <ChordTemplate>[
   // - P5 optional (common voicings omit it: R-2-b7)
   // - Penalty: any third (would resolve suspension), P4 (sus4), M7
   ChordTemplate.fromIntervals(
-    ChordQualityToken.dominant7sus2.intervals,
+    ChordQuality.dominant7sus2.intervals,
     penaltyMask:
         (1 << minorThirdInterval) |
         (1 << majorThirdInterval) |
@@ -257,7 +257,7 @@ final chordTemplates = <ChordTemplate>[
   // - P5 optional (common voicings omit it: R-4-b7)
   // - Penalty: any third (would resolve suspension), M7 (would suggest maj7 color)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.dominant7sus4.intervals,
+    ChordQuality.dominant7sus4.intervals,
     penaltyMask:
         (1 << minorThirdInterval) |
         (1 << majorThirdInterval) |
@@ -268,7 +268,7 @@ final chordTemplates = <ChordTemplate>[
   // - Diminished fifth is a defining chord tone, not a #11 color
   // - Penalty: P5 (would suggest plain dominant7), M7, m3
   ChordTemplate.fromIntervals(
-    ChordQualityToken.dominant7Flat5.intervals,
+    ChordQuality.dominant7Flat5.intervals,
     penaltyMask:
         (1 << perfectFifthInterval) |
         (1 << majorSeventhInterval) |
@@ -279,7 +279,7 @@ final chordTemplates = <ChordTemplate>[
   // - Augmented fifth is a defining chord tone, not a b13 color
   // - Penalty: P5 (would suggest plain dominant7), M7, m3
   ChordTemplate.fromIntervals(
-    ChordQualityToken.dominant7Sharp5.intervals,
+    ChordQuality.dominant7Sharp5.intervals,
     penaltyMask:
         (1 << perfectFifthInterval) |
         (1 << majorSeventhInterval) |
@@ -291,7 +291,7 @@ final chordTemplates = <ChordTemplate>[
   // - P5 optional
   // - Penalty: b7 (would suggest dominant7), m3 (would suggest minor-major7)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.major7.intervals,
+    ChordQuality.major7.intervals,
     penaltyMask: (1 << minorSeventhInterval) | (1 << minorThirdInterval),
   ),
 
@@ -300,7 +300,7 @@ final chordTemplates = <ChordTemplate>[
   // - P5 optional
   // - Penalty: any third (would resolve suspension), P4 (sus4), b7
   ChordTemplate.fromIntervals(
-    ChordQualityToken.major7sus2.intervals,
+    ChordQuality.major7sus2.intervals,
     penaltyMask:
         (1 << minorThirdInterval) |
         (1 << majorThirdInterval) |
@@ -314,7 +314,7 @@ final chordTemplates = <ChordTemplate>[
   // - Penalty: any third (would resolve suspension), b7
   // - M2 is allowed as natural ninth color, e.g. maj9sus4
   ChordTemplate.fromIntervals(
-    ChordQualityToken.major7sus4.intervals,
+    ChordQuality.major7sus4.intervals,
     penaltyMask:
         (1 << minorThirdInterval) |
         (1 << majorThirdInterval) |
@@ -325,7 +325,7 @@ final chordTemplates = <ChordTemplate>[
   // - Diminished fifth is a defining chord tone, not a #11 color
   // - Penalty: P5 (would suggest plain major7), b7, m3
   ChordTemplate.fromIntervals(
-    ChordQualityToken.major7Flat5.intervals,
+    ChordQuality.major7Flat5.intervals,
     penaltyMask:
         (1 << perfectFifthInterval) |
         (1 << minorSeventhInterval) |
@@ -336,7 +336,7 @@ final chordTemplates = <ChordTemplate>[
   // - Augmented major seventh color, common as maj7#5
   // - Penalty: P5 (would suggest plain major7), b7, m3
   ChordTemplate.fromIntervals(
-    ChordQualityToken.major7Sharp5.intervals,
+    ChordQuality.major7Sharp5.intervals,
     penaltyMask:
         (1 << perfectFifthInterval) |
         (1 << minorSeventhInterval) |
@@ -348,7 +348,7 @@ final chordTemplates = <ChordTemplate>[
   // - P5 optional
   // - Penalty: M7 (would suggest minor-major7), M3 (would suggest dominant7)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.minor7.intervals,
+    ChordQuality.minor7.intervals,
     penaltyMask: (1 << majorSeventhInterval) | (1 << majorThirdInterval),
   ),
 
@@ -356,7 +356,7 @@ final chordTemplates = <ChordTemplate>[
   // - Augmented fifth is a defining chord tone, not a b13 color
   // - Penalty: P5 (would suggest plain minor7), M7, M3
   ChordTemplate.fromIntervals(
-    ChordQualityToken.minor7Sharp5.intervals,
+    ChordQuality.minor7Sharp5.intervals,
     penaltyMask:
         (1 << perfectFifthInterval) |
         (1 << majorSeventhInterval) |
@@ -368,7 +368,7 @@ final chordTemplates = <ChordTemplate>[
   // - P5 optional (shell voicings)
   // - Penalty: M3 (contradicts m3), b7 (would suggest minor7)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.minorMajor7.intervals,
+    ChordQuality.minorMajor7.intervals,
     penaltyMask: (1 << majorThirdInterval) | (1 << minorSeventhInterval),
   ),
 
@@ -377,7 +377,7 @@ final chordTemplates = <ChordTemplate>[
   // - No optional tones (all intervals define the quality)
   // - Penalty: P5 (contradicts b5), M3 (contradicts m3), M7 (contradicts b7)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.halfDiminished7.intervals,
+    ChordQuality.halfDiminished7.intervals,
     penaltyMask:
         (1 << perfectFifthInterval) |
         (1 << majorThirdInterval) |
@@ -390,7 +390,7 @@ final chordTemplates = <ChordTemplate>[
   // - No optional tones (tight, symmetrical structure)
   // - Penalty: b7 (would suggest half-diminished), P5/M3/M7 (contradict structure)
   ChordTemplate.fromIntervals(
-    ChordQualityToken.diminished7.intervals,
+    ChordQuality.diminished7.intervals,
     penaltyMask:
         (1 << minorSeventhInterval) |
         (1 << perfectFifthInterval) |

--- a/packages/whatchord/lib/src/analysis/common_name_prior_rule.dart
+++ b/packages/whatchord/lib/src/analysis/common_name_prior_rule.dart
@@ -57,8 +57,8 @@ bool _isSharpFiveDominantOverFlatFiveDominant(
   ChordIdentity preferred,
   ChordIdentity other,
 ) {
-  return preferred.quality == ChordQualityToken.dominant7Sharp5 &&
-      other.quality == ChordQualityToken.dominant7Flat5;
+  return preferred.quality == ChordQuality.dominant7Sharp5 &&
+      other.quality == ChordQuality.dominant7Flat5;
 }
 
 int _commonNamePriorCount(ChordIdentity identity) {

--- a/packages/whatchord/lib/src/analysis/engine_counters.dart
+++ b/packages/whatchord/lib/src/analysis/engine_counters.dart
@@ -2,7 +2,7 @@
 ///
 /// When `whatchord.counters` is not defined (the default, which includes every
 /// release build), this resolves to a `const false`. Each guarded
-/// `if (kEngineCountersEnabled) ...` call site then folds to `if (false)` and is
+/// `if (engineCountersEnabled) ...` call site then folds to `if (false)` and is
 /// dead-code eliminated by the compiler, so the counters cost nothing in normal
 /// builds.
 ///
@@ -11,14 +11,14 @@
 /// ```
 /// dart run --define=whatchord.counters=true benchmark/analyze_benchmark.dart
 /// ```
-const bool kEngineCountersEnabled = bool.fromEnvironment('whatchord.counters');
+const bool engineCountersEnabled = bool.fromEnvironment('whatchord.counters');
 
 /// Deterministic, hardware-independent tallies of analysis work.
 ///
 /// These count algorithmic steps (cache lookups, roots considered, templates
 /// evaluated, candidates produced, candidates ranked) rather than wall-clock
 /// time, so they are a reproducible regression signal regardless of the machine.
-/// Only mutated when [kEngineCountersEnabled] is true; otherwise the increments
+/// Only mutated when [engineCountersEnabled] is true; otherwise the increments
 /// compile away.
 abstract final class EngineCounters {
   /// Analysis results served from the cache.

--- a/packages/whatchord/lib/src/analysis/ranking_rules.dart
+++ b/packages/whatchord/lib/src/analysis/ranking_rules.dart
@@ -69,15 +69,15 @@ final List<NamedRule> hardRules = <NamedRule>[
     gate: (c, f, _) =>
         _isStableDominantFlatNineShell(c.identity, f) ||
         f.isDimFamily ||
-        c.identity.quality == ChordQualityToken.diminished,
+        c.identity.quality == ChordQuality.diminished,
   ),
   NamedRule(
     'prefer flat-nine-bass dominant over remote reinterpretation',
     _preferFlatNineBassDominantOverRemoteReinterpretation,
     gate: (c, f, _) =>
         f.isFifthlessFlatNineBassDominant ||
-        c.identity.quality == ChordQualityToken.minorMajor7 ||
-        c.identity.quality == ChordQualityToken.diminished,
+        c.identity.quality == ChordQuality.minorMajor7 ||
+        c.identity.quality == ChordQuality.diminished,
   ),
   NamedRule(
     'prefer complete dominant sharp-nine over non-seventh color',
@@ -149,8 +149,8 @@ final List<NamedRule> hardRules = <NamedRule>[
     _preferRootMinor7Add11ShellOverSusSlash,
     gate: (c, f, _) =>
         f.isRootPositionMinor7Add11Shell ||
-        c.identity.quality == ChordQualityToken.dominant7sus4 ||
-        c.identity.quality == ChordQualityToken.sus2sus4,
+        c.identity.quality == ChordQuality.dominant7sus4 ||
+        c.identity.quality == ChordQuality.sus2sus4,
   ),
   NamedRule(
     'prefer simple triad add-tone over seventh-family unusual quality',
@@ -163,10 +163,10 @@ final List<NamedRule> hardRules = <NamedRule>[
     'prefer readable sharp-eleven major over flat-five spelling',
     _preferReadableSharpElevenMajorOverFlatFive,
     gate: (c, _, _) =>
-        c.identity.quality == ChordQualityToken.major ||
-        c.identity.quality == ChordQualityToken.major7 ||
-        c.identity.quality == ChordQualityToken.major7Flat5 ||
-        c.identity.quality == ChordQualityToken.majorFlat5,
+        c.identity.quality == ChordQuality.major ||
+        c.identity.quality == ChordQuality.major7 ||
+        c.identity.quality == ChordQuality.major7Flat5 ||
+        c.identity.quality == ChordQuality.majorFlat5,
   ),
 ];
 
@@ -202,14 +202,14 @@ int? _preferConventionalSplitNineTritoneDominant(
 }
 
 bool _isSplitNineFlatFiveDominant(ChordIdentity id) {
-  return id.quality == ChordQualityToken.dominant7Flat5 &&
+  return id.quality == ChordQuality.dominant7Flat5 &&
       id.extensions.length == 2 &&
       id.extensions.contains(ChordExtension.flat9) &&
       id.extensions.contains(ChordExtension.nine);
 }
 
 bool _isSharp11Flat13Dominant(ChordIdentity id) {
-  return id.quality == ChordQualityToken.dominant7 &&
+  return id.quality == ChordQuality.dominant7 &&
       id.extensions.length == 2 &&
       id.extensions.contains(ChordExtension.sharp11) &&
       id.extensions.contains(ChordExtension.flat13);
@@ -236,10 +236,9 @@ int? _preferRootMinor7Add11ShellOverSusSlash(
   final fOther = aIsPreferred ? fb : fa;
   final otherIsInvertedDominantSus =
       !fOther.isRootPosition &&
-      other.identity.quality == ChordQualityToken.dominant7sus4;
+      other.identity.quality == ChordQuality.dominant7sus4;
   final otherIsInvertedDoubleSus =
-      !fOther.isRootPosition &&
-      other.identity.quality == ChordQualityToken.sus2sus4;
+      !fOther.isRootPosition && other.identity.quality == ChordQuality.sus2sus4;
   if (!otherIsInvertedDominantSus && !otherIsInvertedDoubleSus) return null;
 
   final preferred = aIsPreferred ? a : b;
@@ -475,7 +474,7 @@ bool _isMajorSeventhUpperStructureSusSlash(
 ) {
   if (!otherFeatures.isRootDominantSus) return false;
   if (slash.rootPc == slash.bassPc) return false;
-  if (slash.quality != ChordQualityToken.major7) return false;
+  if (slash.quality != ChordQuality.major7) return false;
   if (intervalAboveRoot(slash.bassPc, slash.rootPc) != majorSecondInterval) {
     return false;
   }
@@ -530,8 +529,8 @@ int? _preferCompleteDominantSharp9OverNonSeventhColor(
 
 bool _isCompleteDominantSharpNineReading(ChordIdentity id) {
   final fifthRole = switch (id.quality) {
-    ChordQualityToken.dominant7 => ChordToneRole.perfect5,
-    ChordQualityToken.dominant7Sharp5 => ChordToneRole.sharp5,
+    ChordQuality.dominant7 => ChordToneRole.perfect5,
+    ChordQuality.dominant7Sharp5 => ChordToneRole.sharp5,
     _ => null,
   };
   if (fifthRole == null) return false;
@@ -573,7 +572,7 @@ int? _preferCompleteFlatNineFlatThirteenthDominantOverRemoteSpelling(
 }
 
 bool _isCompleteFlatNineFlatThirteenthDominant(ChordIdentity id) {
-  if (id.quality != ChordQualityToken.dominant7) return false;
+  if (id.quality != ChordQuality.dominant7) return false;
   if (!id.extensions.contains(ChordExtension.flat9) ||
       !id.extensions.contains(ChordExtension.flat13)) {
     return false;
@@ -665,7 +664,7 @@ bool _isStableDominantFlatNineShell(
   ChordIdentity id,
   CandidateFeatures features,
 ) {
-  if (id.quality != ChordQualityToken.dominant7) return false;
+  if (id.quality != ChordQuality.dominant7) return false;
   if (!features.hasStableBassRole) return false;
   if (!id.extensions.contains(ChordExtension.flat9)) return false;
   for (final extension in id.extensions) {
@@ -684,7 +683,7 @@ bool _isStableDominantFlatNineShell(
 }
 
 bool _isColoredDiminishedReading(ChordIdentity id, CandidateFeatures features) {
-  if (!features.isDimFamily && id.quality != ChordQualityToken.diminished) {
+  if (!features.isDimFamily && id.quality != ChordQuality.diminished) {
     return false;
   }
   if (features.extensionCount == 0) return false;
@@ -720,9 +719,9 @@ int? _preferFlatNineBassDominantOverRemoteReinterpretation(
   final fOther = aIsPreferred ? fb : fa;
   final otherIsBassRootedMinorMajor7 =
       fOther.isRootPosition &&
-      other.identity.quality == ChordQualityToken.minorMajor7;
+      other.identity.quality == ChordQuality.minorMajor7;
   final otherIsDiminishedTriad =
-      other.identity.quality == ChordQualityToken.diminished;
+      other.identity.quality == ChordQuality.diminished;
   if (!otherIsBassRootedMinorMajor7 && !otherIsDiminishedTriad) return null;
 
   if (tonality.isMinor &&
@@ -881,8 +880,8 @@ int? _preferRootDominantSusOverSlash(
   // favor it, so resolve directly here.
   final slashQuality = aIsPreferred ? b.identity.quality : a.identity.quality;
   final isConventionalSlash =
-      (slashQuality == ChordQualityToken.major ||
-          slashQuality == ChordQualityToken.minor) &&
+      (slashQuality == ChordQuality.major ||
+          slashQuality == ChordQuality.minor) &&
       fOther.extPref.alterationCount == 0 &&
       fOther.extPref.naturalCount == 0;
   if (isConventionalSlash) return aIsPreferred ? 1 : -1;
@@ -892,7 +891,7 @@ int? _preferRootDominantSusOverSlash(
 
 bool _isRootDominantSusFlatNine(ChordIdentity id) {
   return id.bassPc == id.rootPc &&
-      id.quality == ChordQualityToken.dominant7sus4 &&
+      id.quality == ChordQuality.dominant7sus4 &&
       id.extensions.length == 1 &&
       id.extensions.contains(ChordExtension.flat9);
 }
@@ -939,7 +938,7 @@ bool _isCompleteMajorSharpElevenInversion(
 }
 
 bool _isSparseMajorThirteenSusFour(ChordIdentity id) {
-  if (id.quality != ChordQualityToken.major7sus4) return false;
+  if (id.quality != ChordQuality.major7sus4) return false;
   if (!id.extensions.contains(ChordExtension.thirteen)) return false;
 
   final roles = id.toneRolesByInterval.values;
@@ -1021,7 +1020,7 @@ int? _preferCompleteAlteredThirteenthDominantOverAlteredMinorThirteenth(
 }
 
 bool _isCompleteSharpNineSharpElevenThirteenthDominant(ChordIdentity id) {
-  if (id.quality != ChordQualityToken.dominant7) return false;
+  if (id.quality != ChordQuality.dominant7) return false;
   if (id.extensions.length != 3 ||
       !id.extensions.contains(ChordExtension.sharp9) ||
       !id.extensions.contains(ChordExtension.sharp11) ||
@@ -1040,7 +1039,7 @@ bool _isCompleteSharpNineSharpElevenThirteenthDominant(ChordIdentity id) {
 }
 
 bool _isAlteredMinorThirteenth(ChordIdentity id, CandidateFeatures features) {
-  if (id.quality != ChordQualityToken.minor7 || !features.hasStableBassRole) {
+  if (id.quality != ChordQuality.minor7 || !features.hasStableBassRole) {
     return false;
   }
   if (id.extensions.length != 3 ||
@@ -1102,7 +1101,7 @@ int? _preferCompleteAlteredSharpFiveDominantOverRemoteSpellings(
 }
 
 bool _isAlteredSharpFiveDominant(ChordIdentity id) {
-  if (id.quality != ChordQualityToken.dominant7Sharp5) return false;
+  if (id.quality != ChordQuality.dominant7Sharp5) return false;
   if (!id.extensions.contains(ChordExtension.flat9)) return false;
 
   final roles = id.toneRolesByInterval.values;
@@ -1131,16 +1130,16 @@ bool _alteredSharpFiveHasDoubleAccidental(ChordIdentity id, Tonality tonality) {
 
 bool _isRemoteAlteredNonDominantReading(ChordIdentity id) {
   final isRemoteQuality = switch (id.quality) {
-    ChordQualityToken.minorMajor7 ||
-    ChordQualityToken.minor7Sharp5 ||
-    ChordQualityToken.halfDiminished7 => true,
+    ChordQuality.minorMajor7 ||
+    ChordQuality.minor7Sharp5 ||
+    ChordQuality.halfDiminished7 => true,
     _ => false,
   };
   return isRemoteQuality && id.extensions.isNotEmpty;
 }
 
 bool _isNaturalEleventhSharpFiveDominant(ChordIdentity id) {
-  if (id.quality != ChordQualityToken.dominant7Sharp5) return false;
+  if (id.quality != ChordQuality.dominant7Sharp5) return false;
   if (!id.extensions.contains(ChordExtension.eleven)) return false;
 
   final roles = id.toneRolesByInterval.values;
@@ -1287,8 +1286,8 @@ bool _isWholeToneAlteredFifthRootVsNinthSlash(
   final slashIsNinthAlteredFifth =
       slashExtensions.length == 1 &&
       slashExtensions.contains(ChordExtension.nine) &&
-      (slashCandidate.identity.quality == ChordQualityToken.dominant7Sharp5 ||
-          slashCandidate.identity.quality == ChordQualityToken.dominant7Flat5);
+      (slashCandidate.identity.quality == ChordQuality.dominant7Sharp5 ||
+          slashCandidate.identity.quality == ChordQuality.dominant7Flat5);
   if (!slashIsNinthAlteredFifth) return false;
 
   return slashCandidate.cost <= rootCandidate.cost;
@@ -1597,7 +1596,7 @@ bool _isSparseSharpElevenMajor(ChordIdentity id) {
 }
 
 bool _isSparseSharpElevenMajorTriad(ChordIdentity id) {
-  if (id.quality != ChordQualityToken.major) return false;
+  if (id.quality != ChordQuality.major) return false;
   if (id.extensions.length != 1 ||
       !id.extensions.contains(ChordExtension.sharp11)) {
     return false;
@@ -1611,7 +1610,7 @@ bool _isSparseSharpElevenMajorTriad(ChordIdentity id) {
 }
 
 bool _isFifthlessSharpElevenMajorSeventh(ChordIdentity id) {
-  if (id.quality != ChordQualityToken.major7) return false;
+  if (id.quality != ChordQuality.major7) return false;
   if (id.extensions.length != 1 ||
       !id.extensions.contains(ChordExtension.sharp11)) {
     return false;
@@ -1630,7 +1629,7 @@ bool _isMatchingMajorFlatFiveCounterpart(ChordIdentity id) {
 }
 
 bool _isPlainMajorFlatFive(ChordIdentity id) {
-  if (id.quality != ChordQualityToken.majorFlat5) return false;
+  if (id.quality != ChordQuality.majorFlat5) return false;
   if (id.extensions.isNotEmpty) return false;
 
   final roles = id.toneRolesByInterval.values;
@@ -1641,7 +1640,7 @@ bool _isPlainMajorFlatFive(ChordIdentity id) {
 }
 
 bool _isPlainMajorSeventhFlatFive(ChordIdentity id) {
-  if (id.quality != ChordQualityToken.major7Flat5) return false;
+  if (id.quality != ChordQuality.major7Flat5) return false;
   if (id.extensions.isNotEmpty) return false;
 
   final roles = id.toneRolesByInterval.values;
@@ -1801,15 +1800,15 @@ bool _shouldNotPreferDecoratedReadingOverLowerCostNinthShell(
 }
 
 bool _isMajorSeventhSplitNinth(ChordIdentity id) {
-  return id.quality == ChordQualityToken.major7 &&
+  return id.quality == ChordQuality.major7 &&
       id.extensions.length == 2 &&
       id.extensions.contains(ChordExtension.flat9) &&
       id.extensions.contains(ChordExtension.sharp9);
 }
 
 bool _isDominantOrMinorSeventhNinthShell(ChordIdentity id) {
-  if ((id.quality != ChordQualityToken.dominant7 &&
-          id.quality != ChordQualityToken.minor7) ||
+  if ((id.quality != ChordQuality.dominant7 &&
+          id.quality != ChordQuality.minor7) ||
       !id.extensions.contains(ChordExtension.nine)) {
     return false;
   }
@@ -1823,8 +1822,7 @@ bool _isDominantOrMinorSeventhNinthShell(ChordIdentity id) {
 }
 
 bool _isMajorMinorAddChord(ChordIdentity id, CandidateFeatures features) {
-  if (id.quality != ChordQualityToken.major &&
-      id.quality != ChordQualityToken.minor) {
+  if (id.quality != ChordQuality.major && id.quality != ChordQuality.minor) {
     return false;
   }
   return features.hasOnlyAddColor;
@@ -1878,7 +1876,7 @@ int? _preferHarmonicMinorTonicOverSplitThirdInversion(
 
   bool isHarmonicMinorTonic(ChordCandidate candidate, CandidateFeatures f) {
     if (!f.isRootPosition ||
-        candidate.identity.quality != ChordQualityToken.minorMajor7 ||
+        candidate.identity.quality != ChordQuality.minorMajor7 ||
         candidate.identity.extensions.length != 1 ||
         !candidate.identity.extensions.contains(ChordExtension.flat13)) {
       return false;
@@ -1979,8 +1977,8 @@ int? _preferRootMinor7OverMajor6Slash(
   CandidateFeatures fb,
   Tonality _,
 ) {
-  final aIsMinor7 = a.identity.quality == ChordQualityToken.minor7;
-  final bIsMinor7 = b.identity.quality == ChordQualityToken.minor7;
+  final aIsMinor7 = a.identity.quality == ChordQuality.minor7;
+  final bIsMinor7 = b.identity.quality == ChordQuality.minor7;
   if (aIsMinor7 == bIsMinor7) return null;
 
   final minor7 = aIsMinor7 ? a : b;
@@ -1989,7 +1987,7 @@ int? _preferRootMinor7OverMajor6Slash(
   final fMajor6 = aIsMinor7 ? fb : fa;
 
   if (!fMinor7.isRootPosition ||
-      major6.identity.quality != ChordQualityToken.major6 ||
+      major6.identity.quality != ChordQuality.major6 ||
       !fMajor6.isSlashBass ||
       major6.identity.bassPc != minor7.identity.rootPc) {
     return null;
@@ -2221,8 +2219,8 @@ int? _preferCleanerTritoneFlatFiveDominantSpelling(
 }
 
 bool _isPlainTritoneFlatFiveDominantPair(ChordIdentity a, ChordIdentity b) {
-  return a.quality == ChordQualityToken.dominant7Flat5 &&
-      b.quality == ChordQualityToken.dominant7Flat5 &&
+  return a.quality == ChordQuality.dominant7Flat5 &&
+      b.quality == ChordQuality.dominant7Flat5 &&
       a.extensions.isEmpty &&
       b.extensions.isEmpty &&
       intervalAboveRoot(a.rootPc, b.rootPc) == tritoneInterval;

--- a/packages/whatchord/lib/src/construction/models/chord_construction.dart
+++ b/packages/whatchord/lib/src/construction/models/chord_construction.dart
@@ -17,7 +17,7 @@ class ChordConstruction {
   /// [ChordSpec].
   factory ChordConstruction({
     required int rootPc,
-    required ChordQualityToken quality,
+    required ChordQuality quality,
     required Set<ChordExtension> extensions,
     required int bassPc,
   }) {
@@ -66,7 +66,9 @@ class ChordConstruction {
     );
   }
 
-  /// The spelled chord root.
+  /// The spelled chord root, drawn from the [Tonic] vocabulary: chord
+  /// symbols conventionally spell roots with the same 21 single-accidental
+  /// names used for tonal centers.
   final Tonic root;
 
   /// The selected quality parts.
@@ -82,7 +84,7 @@ class ChordConstruction {
   int get rootPc => root.pitchClass;
 
   /// The complete quality named by [spec].
-  ChordQualityToken get quality => spec.quality;
+  ChordQuality get quality => spec.quality;
 
   /// Shorthand for `spec.baseQuality`.
   BaseQuality get baseQuality => spec.baseQuality;

--- a/packages/whatchord/lib/src/construction/models/chord_spec.dart
+++ b/packages/whatchord/lib/src/construction/models/chord_spec.dart
@@ -34,7 +34,7 @@ enum FifthAlteration { natural, flat, sharp }
 ///
 /// Not every combination is a real chord; [normalized] snaps invalid
 /// combinations to the nearest valid spec, and [quality] maps the result to
-/// its [ChordQualityToken].
+/// its [ChordQuality].
 @immutable
 class ChordSpec {
   const ChordSpec({
@@ -44,139 +44,139 @@ class ChordSpec {
   });
 
   /// Decomposes [quality] into its spec parts.
-  factory ChordSpec.fromQuality(ChordQualityToken quality) {
+  factory ChordSpec.fromQuality(ChordQuality quality) {
     return switch (quality) {
-      ChordQualityToken.major => const ChordSpec(
+      ChordQuality.major => const ChordSpec(
         baseQuality: BaseQuality.major,
         seventhKind: SeventhKind.none,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.majorFlat5 => const ChordSpec(
+      ChordQuality.majorFlat5 => const ChordSpec(
         baseQuality: BaseQuality.major,
         seventhKind: SeventhKind.none,
         fifthAlteration: FifthAlteration.flat,
       ),
-      ChordQualityToken.minor => const ChordSpec(
+      ChordQuality.minor => const ChordSpec(
         baseQuality: BaseQuality.minor,
         seventhKind: SeventhKind.none,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.minorSharp5 => const ChordSpec(
+      ChordQuality.minorSharp5 => const ChordSpec(
         baseQuality: BaseQuality.minor,
         seventhKind: SeventhKind.none,
         fifthAlteration: FifthAlteration.sharp,
       ),
-      ChordQualityToken.diminished => const ChordSpec(
+      ChordQuality.diminished => const ChordSpec(
         baseQuality: BaseQuality.diminished,
         seventhKind: SeventhKind.none,
         fifthAlteration: FifthAlteration.flat,
       ),
-      ChordQualityToken.augmented => const ChordSpec(
+      ChordQuality.augmented => const ChordSpec(
         baseQuality: BaseQuality.augmented,
         seventhKind: SeventhKind.none,
         fifthAlteration: FifthAlteration.sharp,
       ),
-      ChordQualityToken.sus2 => const ChordSpec(
+      ChordQuality.sus2 => const ChordSpec(
         baseQuality: BaseQuality.sus2,
         seventhKind: SeventhKind.none,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.sus4 => const ChordSpec(
+      ChordQuality.sus4 => const ChordSpec(
         baseQuality: BaseQuality.sus4,
         seventhKind: SeventhKind.none,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.sus2sus4 => const ChordSpec(
+      ChordQuality.sus2sus4 => const ChordSpec(
         baseQuality: BaseQuality.sus2sus4,
         seventhKind: SeventhKind.none,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.power => const ChordSpec(
+      ChordQuality.power => const ChordSpec(
         baseQuality: BaseQuality.power,
         seventhKind: SeventhKind.none,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.major6 => const ChordSpec(
+      ChordQuality.major6 => const ChordSpec(
         baseQuality: BaseQuality.major,
         seventhKind: SeventhKind.sixth,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.minor6 => const ChordSpec(
+      ChordQuality.minor6 => const ChordSpec(
         baseQuality: BaseQuality.minor,
         seventhKind: SeventhKind.sixth,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.dominant7 => const ChordSpec(
+      ChordQuality.dominant7 => const ChordSpec(
         baseQuality: BaseQuality.major,
         seventhKind: SeventhKind.dominant7,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.dominant7sus2 => const ChordSpec(
+      ChordQuality.dominant7sus2 => const ChordSpec(
         baseQuality: BaseQuality.sus2,
         seventhKind: SeventhKind.dominant7,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.dominant7sus4 => const ChordSpec(
+      ChordQuality.dominant7sus4 => const ChordSpec(
         baseQuality: BaseQuality.sus4,
         seventhKind: SeventhKind.dominant7,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.dominant7Flat5 => const ChordSpec(
+      ChordQuality.dominant7Flat5 => const ChordSpec(
         baseQuality: BaseQuality.major,
         seventhKind: SeventhKind.dominant7,
         fifthAlteration: FifthAlteration.flat,
       ),
-      ChordQualityToken.dominant7Sharp5 => const ChordSpec(
+      ChordQuality.dominant7Sharp5 => const ChordSpec(
         baseQuality: BaseQuality.major,
         seventhKind: SeventhKind.dominant7,
         fifthAlteration: FifthAlteration.sharp,
       ),
-      ChordQualityToken.major7 => const ChordSpec(
+      ChordQuality.major7 => const ChordSpec(
         baseQuality: BaseQuality.major,
         seventhKind: SeventhKind.major7,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.major7sus2 => const ChordSpec(
+      ChordQuality.major7sus2 => const ChordSpec(
         baseQuality: BaseQuality.sus2,
         seventhKind: SeventhKind.major7,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.major7sus4 => const ChordSpec(
+      ChordQuality.major7sus4 => const ChordSpec(
         baseQuality: BaseQuality.sus4,
         seventhKind: SeventhKind.major7,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.major7Flat5 => const ChordSpec(
+      ChordQuality.major7Flat5 => const ChordSpec(
         baseQuality: BaseQuality.major,
         seventhKind: SeventhKind.major7,
         fifthAlteration: FifthAlteration.flat,
       ),
-      ChordQualityToken.major7Sharp5 => const ChordSpec(
+      ChordQuality.major7Sharp5 => const ChordSpec(
         baseQuality: BaseQuality.major,
         seventhKind: SeventhKind.major7,
         fifthAlteration: FifthAlteration.sharp,
       ),
-      ChordQualityToken.minor7 => const ChordSpec(
+      ChordQuality.minor7 => const ChordSpec(
         baseQuality: BaseQuality.minor,
         seventhKind: SeventhKind.minor7,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.minor7Sharp5 => const ChordSpec(
+      ChordQuality.minor7Sharp5 => const ChordSpec(
         baseQuality: BaseQuality.minor,
         seventhKind: SeventhKind.minor7,
         fifthAlteration: FifthAlteration.sharp,
       ),
-      ChordQualityToken.minorMajor7 => const ChordSpec(
+      ChordQuality.minorMajor7 => const ChordSpec(
         baseQuality: BaseQuality.minor,
         seventhKind: SeventhKind.minorMajor7,
         fifthAlteration: FifthAlteration.natural,
       ),
-      ChordQualityToken.halfDiminished7 => const ChordSpec(
+      ChordQuality.halfDiminished7 => const ChordSpec(
         baseQuality: BaseQuality.diminished,
         seventhKind: SeventhKind.halfDiminished7,
         fifthAlteration: FifthAlteration.flat,
       ),
-      ChordQualityToken.diminished7 => const ChordSpec(
+      ChordQuality.diminished7 => const ChordSpec(
         baseQuality: BaseQuality.diminished,
         seventhKind: SeventhKind.diminished7,
         fifthAlteration: FifthAlteration.flat,
@@ -217,7 +217,7 @@ class ChordSpec {
   }
 
   /// The chord quality this spec names, after normalization.
-  ChordQualityToken get quality {
+  ChordQuality get quality {
     final spec = normalized();
     return _qualityFromSpec(
       baseQuality: spec.baseQuality,
@@ -326,59 +326,55 @@ FifthAlteration defaultFifthAlterationFor(BaseQuality baseQuality) {
   };
 }
 
-ChordQualityToken _qualityFromSpec({
+ChordQuality _qualityFromSpec({
   required BaseQuality baseQuality,
   required SeventhKind seventhKind,
   required FifthAlteration fifthAlteration,
 }) {
   if (seventhKind == SeventhKind.halfDiminished7) {
-    return ChordQualityToken.halfDiminished7;
+    return ChordQuality.halfDiminished7;
   }
   if (seventhKind == SeventhKind.diminished7) {
-    return ChordQualityToken.diminished7;
+    return ChordQuality.diminished7;
   }
   if (seventhKind == SeventhKind.minor7) {
     return fifthAlteration == FifthAlteration.sharp
-        ? ChordQualityToken.minor7Sharp5
-        : ChordQualityToken.minor7;
+        ? ChordQuality.minor7Sharp5
+        : ChordQuality.minor7;
   }
   if (seventhKind == SeventhKind.minorMajor7) {
-    return ChordQualityToken.minorMajor7;
+    return ChordQuality.minorMajor7;
   }
 
   return switch ((baseQuality, seventhKind, fifthAlteration)) {
     (BaseQuality.major, SeventhKind.none, FifthAlteration.flat) =>
-      ChordQualityToken.majorFlat5,
-    (BaseQuality.major, SeventhKind.none, _) => ChordQualityToken.major,
-    (BaseQuality.major, SeventhKind.sixth, _) => ChordQualityToken.major6,
+      ChordQuality.majorFlat5,
+    (BaseQuality.major, SeventhKind.none, _) => ChordQuality.major,
+    (BaseQuality.major, SeventhKind.sixth, _) => ChordQuality.major6,
     (BaseQuality.major, SeventhKind.dominant7, FifthAlteration.flat) =>
-      ChordQualityToken.dominant7Flat5,
+      ChordQuality.dominant7Flat5,
     (BaseQuality.major, SeventhKind.dominant7, FifthAlteration.sharp) =>
-      ChordQualityToken.dominant7Sharp5,
-    (BaseQuality.major, SeventhKind.dominant7, _) =>
-      ChordQualityToken.dominant7,
+      ChordQuality.dominant7Sharp5,
+    (BaseQuality.major, SeventhKind.dominant7, _) => ChordQuality.dominant7,
     (BaseQuality.major, SeventhKind.major7, FifthAlteration.flat) =>
-      ChordQualityToken.major7Flat5,
+      ChordQuality.major7Flat5,
     (BaseQuality.major, SeventhKind.major7, FifthAlteration.sharp) =>
-      ChordQualityToken.major7Sharp5,
-    (BaseQuality.major, SeventhKind.major7, _) => ChordQualityToken.major7,
+      ChordQuality.major7Sharp5,
+    (BaseQuality.major, SeventhKind.major7, _) => ChordQuality.major7,
     (BaseQuality.minor, SeventhKind.none, FifthAlteration.sharp) =>
-      ChordQualityToken.minorSharp5,
-    (BaseQuality.minor, SeventhKind.none, _) => ChordQualityToken.minor,
-    (BaseQuality.minor, SeventhKind.sixth, _) => ChordQualityToken.minor6,
-    (BaseQuality.diminished, SeventhKind.none, _) =>
-      ChordQualityToken.diminished,
-    (BaseQuality.augmented, SeventhKind.none, _) => ChordQualityToken.augmented,
-    (BaseQuality.power, _, _) => ChordQualityToken.power,
-    (BaseQuality.sus2, SeventhKind.none, _) => ChordQualityToken.sus2,
-    (BaseQuality.sus2, SeventhKind.dominant7, _) =>
-      ChordQualityToken.dominant7sus2,
-    (BaseQuality.sus2, SeventhKind.major7, _) => ChordQualityToken.major7sus2,
-    (BaseQuality.sus4, SeventhKind.none, _) => ChordQualityToken.sus4,
-    (BaseQuality.sus4, SeventhKind.dominant7, _) =>
-      ChordQualityToken.dominant7sus4,
-    (BaseQuality.sus4, SeventhKind.major7, _) => ChordQualityToken.major7sus4,
-    (BaseQuality.sus2sus4, SeventhKind.none, _) => ChordQualityToken.sus2sus4,
-    _ => ChordQualityToken.major,
+      ChordQuality.minorSharp5,
+    (BaseQuality.minor, SeventhKind.none, _) => ChordQuality.minor,
+    (BaseQuality.minor, SeventhKind.sixth, _) => ChordQuality.minor6,
+    (BaseQuality.diminished, SeventhKind.none, _) => ChordQuality.diminished,
+    (BaseQuality.augmented, SeventhKind.none, _) => ChordQuality.augmented,
+    (BaseQuality.power, _, _) => ChordQuality.power,
+    (BaseQuality.sus2, SeventhKind.none, _) => ChordQuality.sus2,
+    (BaseQuality.sus2, SeventhKind.dominant7, _) => ChordQuality.dominant7sus2,
+    (BaseQuality.sus2, SeventhKind.major7, _) => ChordQuality.major7sus2,
+    (BaseQuality.sus4, SeventhKind.none, _) => ChordQuality.sus4,
+    (BaseQuality.sus4, SeventhKind.dominant7, _) => ChordQuality.dominant7sus4,
+    (BaseQuality.sus4, SeventhKind.major7, _) => ChordQuality.major7sus4,
+    (BaseQuality.sus2sus4, SeventhKind.none, _) => ChordQuality.sus2sus4,
+    _ => ChordQuality.major,
   };
 }

--- a/packages/whatchord/lib/src/construction/services/chord_example_builder.dart
+++ b/packages/whatchord/lib/src/construction/services/chord_example_builder.dart
@@ -138,7 +138,7 @@ abstract final class ChordExampleBuilder {
   }
 
   static Set<ChordExtension> _canonicalExampleExtensions(
-    ChordQualityToken quality,
+    ChordQuality quality,
     Set<ChordExtension> selected,
   ) {
     if (!quality.isSeventhFamily) {
@@ -160,7 +160,7 @@ abstract final class ChordExampleBuilder {
   }
 
   static Set<ChordExtension> _canonicalTriadLikeExampleExtensions(
-    ChordQualityToken quality,
+    ChordQuality quality,
     Set<ChordExtension> selected,
   ) {
     return Set<ChordExtension>.unmodifiable(selected);

--- a/packages/whatchord/lib/src/construction/services/construction_derivation.dart
+++ b/packages/whatchord/lib/src/construction/services/construction_derivation.dart
@@ -38,7 +38,7 @@ ChordIdentity buildConstructionIdentity(ChordConstruction state) {
 }
 
 int canonicalPresentIntervalsMask({
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required Set<ChordExtension> extensions,
 }) {
   var mask = 0;

--- a/packages/whatchord/lib/src/construction/services/construction_transitions.dart
+++ b/packages/whatchord/lib/src/construction/services/construction_transitions.dart
@@ -51,7 +51,7 @@ ChordConstruction constructionWithFifthAlteration(
 /// [state] respecified to a complete [quality], renormalized.
 ChordConstruction constructionWithQuality(
   ChordConstruction state,
-  ChordQualityToken quality,
+  ChordQuality quality,
 ) {
   final nextSpec = ChordSpec.fromQuality(quality);
   return _withSpec(state, nextSpec);

--- a/packages/whatchord/lib/src/construction/services/extension_options.dart
+++ b/packages/whatchord/lib/src/construction/services/extension_options.dart
@@ -4,11 +4,11 @@ import '../../models/chord_identity.dart';
 import 'extension_rules.dart';
 
 /// How a group of extension choices behaves for a quality.
-enum ExtensionControlRole { highestExtension, addedTones, alterations }
+enum ExtensionOptionRole { highestExtension, addedTones, alterations }
 
 /// A labeled group of extension choices that are valid together on a quality.
-class ExtensionControlGroup {
-  const ExtensionControlGroup({
+class ExtensionOptionGroup {
+  const ExtensionOptionGroup({
     required this.label,
     required this.role,
     required this.allowsMultiple,
@@ -19,7 +19,7 @@ class ExtensionControlGroup {
   final String label;
 
   /// The group's selection behavior.
-  final ExtensionControlRole role;
+  final ExtensionOptionRole role;
 
   /// Whether multiple choices may be selected at once.
   final bool allowsMultiple;
@@ -48,9 +48,7 @@ class ExtensionChoice {
 }
 
 /// The extension choice groups that make musical sense on [quality].
-List<ExtensionControlGroup> buildExtensionControlGroups(
-  ChordQualityToken quality,
-) {
+List<ExtensionOptionGroup> buildExtensionOptionGroups(ChordQuality quality) {
   return quality.isSeventhFamily
       ? _seventhExtensionGroups(quality)
       : _triadLikeExtensionGroups(quality);
@@ -59,9 +57,9 @@ List<ExtensionControlGroup> buildExtensionControlGroups(
 /// Applies picking [choice] from [group] to [currentExtensions], resolving
 /// conflicts so the result stays musically coherent on [quality].
 Set<ChordExtension> selectExtensionChoice({
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required Set<ChordExtension> currentExtensions,
-  required ExtensionControlGroup group,
+  required ExtensionOptionGroup group,
   required ExtensionChoice choice,
 }) {
   final next = normalizeExtensionsForQuality(
@@ -85,7 +83,7 @@ Set<ChordExtension> selectExtensionChoice({
 
     if (selected &&
         quality.isSeventhFamily &&
-        group.role == ExtensionControlRole.addedTones) {
+        group.role == ExtensionOptionRole.addedTones) {
       promoteAddedToneToStack(next, extension);
     }
   } else {
@@ -106,13 +104,13 @@ Set<ChordExtension> selectExtensionChoice({
 
 ExtensionChoice _choice(ChordExtension extension) {
   return ExtensionChoice(
-    label: theoryTokenDisplayLabel(extension.shortLabel),
+    label: toGlyphAccidentals(extension.shortLabel),
     semanticLabel: extension.longLabel,
     extension: extension,
   );
 }
 
-List<ExtensionControlGroup> _seventhExtensionGroups(ChordQualityToken quality) {
+List<ExtensionOptionGroup> _seventhExtensionGroups(ChordQuality quality) {
   final addToneChoices = _choicesInOrder(
     seventhAddTones(quality),
     _seventhAddToneChoiceOrder,
@@ -124,9 +122,9 @@ List<ExtensionControlGroup> _seventhExtensionGroups(ChordQualityToken quality) {
   );
 
   return [
-    ExtensionControlGroup(
+    ExtensionOptionGroup(
       label: 'Stacked extension',
-      role: ExtensionControlRole.highestExtension,
+      role: ExtensionOptionRole.highestExtension,
       allowsMultiple: false,
       choices: [
         const ExtensionChoice(
@@ -140,25 +138,23 @@ List<ExtensionControlGroup> _seventhExtensionGroups(ChordQualityToken quality) {
       ],
     ),
     if (addToneChoices.isNotEmpty)
-      ExtensionControlGroup(
+      ExtensionOptionGroup(
         label: 'Added tones',
-        role: ExtensionControlRole.addedTones,
+        role: ExtensionOptionRole.addedTones,
         allowsMultiple: true,
         choices: addToneChoices,
       ),
     if (alterationChoices.isNotEmpty)
-      ExtensionControlGroup(
+      ExtensionOptionGroup(
         label: 'Alterations',
-        role: ExtensionControlRole.alterations,
+        role: ExtensionOptionRole.alterations,
         allowsMultiple: true,
         choices: alterationChoices,
       ),
   ];
 }
 
-List<ExtensionControlGroup> _triadLikeExtensionGroups(
-  ChordQualityToken quality,
-) {
+List<ExtensionOptionGroup> _triadLikeExtensionGroups(ChordQuality quality) {
   final addToneChoices = _choicesInOrder(
     triadLikeAddTones(quality),
     _triadLikeAddToneChoiceOrder,
@@ -171,16 +167,16 @@ List<ExtensionControlGroup> _triadLikeExtensionGroups(
 
   return [
     if (addToneChoices.isNotEmpty)
-      ExtensionControlGroup(
+      ExtensionOptionGroup(
         label: 'Added tones',
-        role: ExtensionControlRole.addedTones,
+        role: ExtensionOptionRole.addedTones,
         allowsMultiple: true,
         choices: addToneChoices,
       ),
     if (alterationChoices.isNotEmpty)
-      ExtensionControlGroup(
+      ExtensionOptionGroup(
         label: 'Alterations',
-        role: ExtensionControlRole.alterations,
+        role: ExtensionOptionRole.alterations,
         allowsMultiple: true,
         choices: alterationChoices,
       ),
@@ -201,22 +197,22 @@ List<ExtensionChoice> _choicesInOrder(
 ExtensionChoice _alterationChoice(ChordExtension extension) {
   return switch (extension) {
     ChordExtension.flat9 => ExtensionChoice(
-      label: theoryTokenDisplayLabel('b9'),
+      label: toGlyphAccidentals('b9'),
       semanticLabel: 'Flat ninth',
       extension: ChordExtension.flat9,
     ),
     ChordExtension.sharp9 => ExtensionChoice(
-      label: theoryTokenDisplayLabel('#9'),
+      label: toGlyphAccidentals('#9'),
       semanticLabel: 'Sharp ninth',
       extension: ChordExtension.sharp9,
     ),
     ChordExtension.sharp11 => ExtensionChoice(
-      label: theoryTokenDisplayLabel('#11'),
+      label: toGlyphAccidentals('#11'),
       semanticLabel: 'Sharp eleventh',
       extension: ChordExtension.sharp11,
     ),
     ChordExtension.flat13 => ExtensionChoice(
-      label: theoryTokenDisplayLabel('b13'),
+      label: toGlyphAccidentals('b13'),
       semanticLabel: 'Flat thirteenth',
       extension: ChordExtension.flat13,
     ),
@@ -227,7 +223,7 @@ ExtensionChoice _alterationChoice(ChordExtension extension) {
 ExtensionChoice _triadLikeAlterationChoice(ChordExtension extension) {
   if (extension == ChordExtension.addSharp9) {
     return ExtensionChoice(
-      label: theoryTokenDisplayLabel('#9'),
+      label: toGlyphAccidentals('#9'),
       semanticLabel: 'Sharp ninth',
       extension: ChordExtension.addSharp9,
     );
@@ -235,7 +231,7 @@ ExtensionChoice _triadLikeAlterationChoice(ChordExtension extension) {
 
   if (extension == ChordExtension.addFlat9) {
     return ExtensionChoice(
-      label: theoryTokenDisplayLabel('b9'),
+      label: toGlyphAccidentals('b9'),
       semanticLabel: 'Flat ninth',
       extension: ChordExtension.addFlat9,
     );

--- a/packages/whatchord/lib/src/construction/services/extension_rules.dart
+++ b/packages/whatchord/lib/src/construction/services/extension_rules.dart
@@ -8,7 +8,7 @@ import '../../services/chord_quality_intervals.dart';
 /// chords use add tones, while seventh-family chords can use stacked 9/11/13
 /// extensions once the lower stack is present.
 Set<ChordExtension> normalizeExtensionsForQuality({
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required Set<ChordExtension> extensions,
 }) {
   final normalized = <ChordExtension>{};
@@ -315,13 +315,13 @@ void removeSeventhConflicts(
 }
 
 /// Extensions available before splitting them into add-tone and alteration UI.
-Set<ChordExtension> triadLikeExtensions(ChordQualityToken quality) {
+Set<ChordExtension> triadLikeExtensions(ChordQuality quality) {
   return Set<ChordExtension>.unmodifiable(
     _triadLikeExtensionsByQuality[quality] ?? const <ChordExtension>{},
   );
 }
 
-Set<ChordExtension> triadLikeAddTones(ChordQualityToken quality) {
+Set<ChordExtension> triadLikeAddTones(ChordQuality quality) {
   final available = triadLikeExtensions(quality);
   return {
     for (final extension in const {
@@ -333,7 +333,7 @@ Set<ChordExtension> triadLikeAddTones(ChordQualityToken quality) {
   };
 }
 
-Set<ChordExtension> triadLikeAlterations(ChordQualityToken quality) {
+Set<ChordExtension> triadLikeAlterations(ChordQuality quality) {
   final available = triadLikeExtensions(quality);
   return {
     if (available.contains(ChordExtension.flat9)) ChordExtension.flat9,
@@ -344,7 +344,7 @@ Set<ChordExtension> triadLikeAlterations(ChordQualityToken quality) {
   };
 }
 
-Set<ChordExtension> seventhStackExtensions(ChordQualityToken quality) {
+Set<ChordExtension> seventhStackExtensions(ChordQuality quality) {
   return _extensionsNotInCore(quality, _seventhStackExtensionOrder);
 }
 
@@ -352,16 +352,16 @@ Set<ChordExtension> seventhStackExtensions(ChordQualityToken quality) {
 ///
 /// In this UI, choosing an added ninth on a seventh chord promotes directly to
 /// the stacked ninth.
-Set<ChordExtension> seventhAddTones(ChordQualityToken quality) {
+Set<ChordExtension> seventhAddTones(ChordQuality quality) {
   return _extensionsNotInCore(quality, _seventhAddToneOrder);
 }
 
-Set<ChordExtension> seventhAlterations(ChordQualityToken quality) {
+Set<ChordExtension> seventhAlterations(ChordQuality quality) {
   return _extensionsNotInCore(quality, _seventhAlterationOrder);
 }
 
 Set<ChordExtension> _extensionsNotInCore(
-  ChordQualityToken quality,
+  ChordQuality quality,
   List<ChordExtension> candidates,
 ) {
   final canonicalIntervals = quality.canonicalIntervals;
@@ -378,10 +378,10 @@ void _replaceWithStackedEleventh(Set<ChordExtension> extensions) {
   extensions.add(ChordExtension.eleven);
 }
 
-const _triadLikeExtensionsByQuality = <ChordQualityToken, Set<ChordExtension>>{
+const _triadLikeExtensionsByQuality = <ChordQuality, Set<ChordExtension>>{
   // Major/minor 6ths and diminished sevenths are core-tone choices, so plain
   // major, minor, and diminished triads do not expose add13 duplicates.
-  ChordQualityToken.major: {
+  ChordQuality.major: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.addFlat9,
@@ -389,51 +389,51 @@ const _triadLikeExtensionsByQuality = <ChordQualityToken, Set<ChordExtension>>{
     ChordExtension.sharp11,
     ChordExtension.flat13,
   },
-  ChordQualityToken.minor: {
+  ChordQuality.minor: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.addFlat9,
     ChordExtension.sharp11,
     ChordExtension.flat13,
   },
-  ChordQualityToken.minorSharp5: {
+  ChordQuality.minorSharp5: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.add13,
     ChordExtension.sharp11,
   },
-  ChordQualityToken.diminished: {
+  ChordQuality.diminished: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.flat13,
   },
-  ChordQualityToken.augmented: {
+  ChordQuality.augmented: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.add13,
     ChordExtension.addSharp9,
     ChordExtension.sharp11,
   },
-  ChordQualityToken.sus2: {
+  ChordQuality.sus2: {
     ChordExtension.add11,
     ChordExtension.add13,
     ChordExtension.flat13,
   },
-  ChordQualityToken.sus4: {
+  ChordQuality.sus4: {
     ChordExtension.add9,
     ChordExtension.add13,
     ChordExtension.addFlat9,
     ChordExtension.flat13,
   },
-  ChordQualityToken.sus2sus4: {ChordExtension.add13, ChordExtension.flat13},
-  ChordQualityToken.major6: {
+  ChordQuality.sus2sus4: {ChordExtension.add13, ChordExtension.flat13},
+  ChordQuality.major6: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.flat9,
     ChordExtension.addSharp9,
     ChordExtension.sharp11,
   },
-  ChordQualityToken.minor6: {
+  ChordQuality.minor6: {
     ChordExtension.add9,
     ChordExtension.add11,
     ChordExtension.flat9,

--- a/packages/whatchord/lib/src/construction/services/seed_derivation.dart
+++ b/packages/whatchord/lib/src/construction/services/seed_derivation.dart
@@ -31,19 +31,19 @@ ChordIdentity buildSeedIdentity({
   return _seedIdentity(rootPc: rootPc, quality: quality);
 }
 
-ChordQualityToken _defaultQualityForTonality(Tonality tonality) {
-  return tonality.isMinor ? ChordQualityToken.minor : ChordQualityToken.major;
+ChordQuality _defaultQualityForTonality(Tonality tonality) {
+  return tonality.isMinor ? ChordQuality.minor : ChordQuality.major;
 }
 
-ChordQualityToken _qualityForDyad(ChordInput input, Tonality tonality) {
+ChordQuality _qualityForDyad(ChordInput input, Tonality tonality) {
   final upperInterval = _upperIntervalFromBass(input);
 
   return switch (upperInterval) {
-    2 => ChordQualityToken.sus2,
-    3 => ChordQualityToken.minor,
-    4 => ChordQualityToken.major,
-    5 => ChordQualityToken.sus4,
-    6 => ChordQualityToken.diminished,
+    2 => ChordQuality.sus2,
+    3 => ChordQuality.minor,
+    4 => ChordQuality.major,
+    5 => ChordQuality.sus4,
+    6 => ChordQuality.diminished,
     _ => _defaultQualityForTonality(tonality),
   };
 }
@@ -58,7 +58,7 @@ int? _upperIntervalFromBass(ChordInput input) {
 
 ChordIdentity _seedIdentity({
   required int rootPc,
-  required ChordQualityToken quality,
+  required ChordQuality quality,
 }) {
   return buildConstructionIdentity(
     ChordConstruction(

--- a/packages/whatchord/lib/src/formatting/services/chord_long_form_formatter.dart
+++ b/packages/whatchord/lib/src/formatting/services/chord_long_form_formatter.dart
@@ -4,7 +4,7 @@ import '../../models/tonality.dart';
 import '../../services/note_spelling.dart';
 import '../models/chord_symbol.dart';
 import 'chord_display_conventions.dart';
-import 'chord_quality_token_labels.dart';
+import 'chord_quality_labels.dart';
 import 'note_display_formatter.dart';
 
 /// Renders a chord identity as its long-form academic name
@@ -143,7 +143,7 @@ String _extensionsLongPhrase(
 }
 
 String _qualityLongPhrase({
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required Set<ChordExtension> extensions,
 }) {
   final base = quality.coreLabel(ChordQualityLabelForm.academic);
@@ -165,17 +165,17 @@ String _qualityLongPhrase({
 }
 
 ChordExtension? _absorbedLongFormExtensionForParts({
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required Set<ChordExtension> extensions,
 }) {
   return _headlineExtensionForParts(quality: quality, extensions: extensions);
 }
 
 ChordExtension? _headlineExtensionForParts({
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required Set<ChordExtension> extensions,
 }) {
-  if (!quality.isSeventhFamily || quality == ChordQualityToken.diminished7) {
+  if (!quality.isSeventhFamily || quality == ChordQuality.diminished7) {
     return null;
   }
 

--- a/packages/whatchord/lib/src/formatting/services/chord_quality_formatter.dart
+++ b/packages/whatchord/lib/src/formatting/services/chord_quality_formatter.dart
@@ -1,12 +1,12 @@
 import '../../models/chord_extension.dart';
 import '../../models/chord_identity.dart';
 import '../models/chord_symbol.dart';
-import 'chord_quality_token_labels.dart';
+import 'chord_quality_labels.dart';
 
 /// Formats the "quality+extensions" portion of a chord symbol.
 class ChordQualityFormatter {
   static String format({
-    required ChordQualityToken quality,
+    required ChordQuality quality,
     required Set<ChordExtension> extensions,
     required ChordNotationStyle notation,
     ChordQualityLabelForm? qualityFormOverride,
@@ -14,7 +14,7 @@ class ChordQualityFormatter {
     final form = qualityFormOverride ?? _defaultQualityFormFor(notation);
 
     final textualMinorMajor =
-        quality == ChordQualityToken.minorMajor7 &&
+        quality == ChordQuality.minorMajor7 &&
         form == ChordQualityLabelForm.textual;
 
     var base = textualMinorMajor ? 'm' : quality.coreLabel(form);
@@ -136,25 +136,25 @@ class ChordQualityFormatter {
   /// Whether it is conventional to "promote" 9/11/13 into the headline
   /// (C9, C11, C13, Cmaj9, Cm11, etc.) for this quality/form.
   static bool _allowsHeadlinePromotion({
-    required ChordQualityToken quality,
+    required ChordQuality quality,
     required ChordQualityLabelForm form,
   }) {
     // Seventh-family qualities are the ones that headline 9/11/13.
     switch (quality) {
-      case ChordQualityToken.dominant7:
-      case ChordQualityToken.dominant7sus2:
-      case ChordQualityToken.dominant7sus4:
-      case ChordQualityToken.dominant7Flat5:
-      case ChordQualityToken.dominant7Sharp5:
-      case ChordQualityToken.major7:
-      case ChordQualityToken.major7sus2:
-      case ChordQualityToken.major7sus4:
-      case ChordQualityToken.major7Flat5:
-      case ChordQualityToken.major7Sharp5:
-      case ChordQualityToken.minor7:
-      case ChordQualityToken.minor7Sharp5:
-      case ChordQualityToken.minorMajor7:
-      case ChordQualityToken.halfDiminished7:
+      case ChordQuality.dominant7:
+      case ChordQuality.dominant7sus2:
+      case ChordQuality.dominant7sus4:
+      case ChordQuality.dominant7Flat5:
+      case ChordQuality.dominant7Sharp5:
+      case ChordQuality.major7:
+      case ChordQuality.major7sus2:
+      case ChordQuality.major7sus4:
+      case ChordQuality.major7Flat5:
+      case ChordQuality.major7Sharp5:
+      case ChordQuality.minor7:
+      case ChordQuality.minor7Sharp5:
+      case ChordQuality.minorMajor7:
+      case ChordQuality.halfDiminished7:
         return true;
       default:
         return false;
@@ -162,12 +162,12 @@ class ChordQualityFormatter {
   }
 
   static ChordExtension _displayExtensionFor({
-    required ChordQualityToken quality,
+    required ChordQuality quality,
     required ChordExtension ext,
   }) {
     // For fully diminished seventh chords, natural extensions are commonly
     // rendered as added tones: Cdim7(add9), Cdim7(add11), etc.
-    if (quality == ChordQualityToken.diminished7 && ext.isNaturalExtension) {
+    if (quality == ChordQuality.diminished7 && ext.isNaturalExtension) {
       switch (ext) {
         case ChordExtension.nine:
           return ChordExtension.add9;
@@ -210,14 +210,14 @@ class ChordQualityFormatter {
   }
 
   static bool _shouldUseParens({
-    required ChordQualityToken quality,
+    required ChordQuality quality,
     required ChordNotationStyle notation,
     required List<ChordExtension> mods,
     required ChordExtension? headline,
     required bool textualMinorMajor,
   }) {
     if (textualMinorMajor) return true;
-    if (quality == ChordQualityToken.diminished7) return true;
+    if (quality == ChordQuality.diminished7) return true;
     if (mods.isEmpty) return false;
 
     // Suspended seventh-family chords group their modifiers instead of running
@@ -236,8 +236,8 @@ class ChordQualityFormatter {
       if (ext.isAddTone) {
         if (quality.isSeventhFamily) return true;
         return notation == ChordNotationStyle.textual &&
-            (quality == ChordQualityToken.augmented ||
-                quality == ChordQualityToken.diminished);
+            (quality == ChordQuality.augmented ||
+                quality == ChordQuality.diminished);
       }
 
       if (_isDensePromotedMajorFamilyLabel(quality, headline)) return true;
@@ -250,7 +250,7 @@ class ChordQualityFormatter {
   }
 
   static bool _isDensePromotedMajorFamilyLabel(
-    ChordQualityToken quality,
+    ChordQuality quality,
     ChordExtension? headline,
   ) {
     if (headline != ChordExtension.eleven &&
@@ -259,9 +259,9 @@ class ChordQualityFormatter {
     }
 
     switch (quality) {
-      case ChordQualityToken.major7:
-      case ChordQualityToken.major7Flat5:
-      case ChordQualityToken.major7Sharp5:
+      case ChordQuality.major7:
+      case ChordQuality.major7Flat5:
+      case ChordQuality.major7Sharp5:
         return true;
       default:
         return false;

--- a/packages/whatchord/lib/src/formatting/services/chord_quality_labels.dart
+++ b/packages/whatchord/lib/src/formatting/services/chord_quality_labels.dart
@@ -7,12 +7,12 @@ import '../../models/chord_identity.dart';
 enum ChordQualityLabelForm { symbolic, textual, academic, idiomatic }
 
 /// How a quality's altered fifth relates to its perfect fifth.
-enum ChordFifthAlteration { none, flat5, sharp5 }
+enum _Fifth { none, flat, sharp }
 
 const _symbolicMinorSign = '−';
 
-/// Formatting-only labels for chord quality tokens.
-extension ChordQualityTokenLabels on ChordQualityToken {
+/// Formatting-only labels for chord qualities.
+extension ChordQualityLabels on ChordQuality {
   /// The conventional label for a chord of this quality with no added
   /// extensions, e.g. "7♭5", "m7(♭5)", "(♭5)", "ø7".
   String label(ChordQualityLabelForm form) {
@@ -47,45 +47,43 @@ extension ChordQualityTokenLabels on ChordQualityToken {
     }
   }
 
-  /// How this quality's fifth is altered.
-  ChordFifthAlteration get fifthAlteration {
+  _Fifth get _fifth {
     switch (this) {
-      case ChordQualityToken.majorFlat5:
-      case ChordQualityToken.dominant7Flat5:
-      case ChordQualityToken.major7Flat5:
-      case ChordQualityToken.halfDiminished7:
-        return ChordFifthAlteration.flat5;
-      case ChordQualityToken.minorSharp5:
-      case ChordQualityToken.dominant7Sharp5:
-      case ChordQualityToken.major7Sharp5:
-      case ChordQualityToken.minor7Sharp5:
-        return ChordFifthAlteration.sharp5;
+      case ChordQuality.majorFlat5:
+      case ChordQuality.dominant7Flat5:
+      case ChordQuality.major7Flat5:
+      case ChordQuality.halfDiminished7:
+        return _Fifth.flat;
+      case ChordQuality.minorSharp5:
+      case ChordQuality.dominant7Sharp5:
+      case ChordQuality.major7Sharp5:
+      case ChordQuality.minor7Sharp5:
+        return _Fifth.sharp;
       default:
-        return ChordFifthAlteration.none;
+        return _Fifth.none;
     }
   }
 
   /// Whether a lone altered fifth is conventionally parenthesized for this
   /// quality (Cm7(♭5), C(♭5)) rather than written inline (C7♭5, Cm♯5).
   bool get fifthParenthesizedWhenLone =>
-      this == ChordQualityToken.majorFlat5 ||
-      this == ChordQualityToken.halfDiminished7;
+      this == ChordQuality.majorFlat5 || this == ChordQuality.halfDiminished7;
 
   /// The altered-fifth token for a given form, or null when the fifth is not
   /// spelled separately: when there is none, or when the quality names it in
   /// itself (the symbolic ø and the academic/idiomatic "half-diminished" all
   /// imply the ♭5).
   String? fifthModifierLabel(ChordQualityLabelForm form) {
-    final alteration = fifthAlteration;
-    if (alteration == ChordFifthAlteration.none) return null;
+    final alteration = _fifth;
+    if (alteration == _Fifth.none) return null;
 
     // Half-diminished names the fifth into its quality everywhere but textual.
-    if (this == ChordQualityToken.halfDiminished7 &&
+    if (this == ChordQuality.halfDiminished7 &&
         form != ChordQualityLabelForm.textual) {
       return null;
     }
 
-    final isFlat = alteration == ChordFifthAlteration.flat5;
+    final isFlat = alteration == _Fifth.flat;
     switch (form) {
       case ChordQualityLabelForm.symbolic:
         return isFlat ? '♭5' : '♯5';
@@ -99,236 +97,236 @@ extension ChordQualityTokenLabels on ChordQualityToken {
 
   String _coreSymbol() {
     switch (this) {
-      case ChordQualityToken.major:
+      case ChordQuality.major:
         return '';
-      case ChordQualityToken.majorFlat5:
+      case ChordQuality.majorFlat5:
         return '';
-      case ChordQualityToken.minor:
+      case ChordQuality.minor:
         return _symbolicMinorSign;
-      case ChordQualityToken.minorSharp5:
+      case ChordQuality.minorSharp5:
         return _symbolicMinorSign;
-      case ChordQualityToken.diminished:
+      case ChordQuality.diminished:
         return '°';
-      case ChordQualityToken.augmented:
+      case ChordQuality.augmented:
         return '+';
-      case ChordQualityToken.power:
+      case ChordQuality.power:
         return '5';
-      case ChordQualityToken.sus2:
+      case ChordQuality.sus2:
         return 'sus2';
-      case ChordQualityToken.sus4:
+      case ChordQuality.sus4:
         return 'sus4';
-      case ChordQualityToken.sus2sus4:
+      case ChordQuality.sus2sus4:
         return 'sus2sus4';
-      case ChordQualityToken.major6:
+      case ChordQuality.major6:
         return '6';
-      case ChordQualityToken.minor6:
+      case ChordQuality.minor6:
         return '${_symbolicMinorSign}6';
-      case ChordQualityToken.dominant7:
+      case ChordQuality.dominant7:
         return '7';
-      case ChordQualityToken.dominant7sus2:
+      case ChordQuality.dominant7sus2:
         return '7sus2';
-      case ChordQualityToken.dominant7sus4:
+      case ChordQuality.dominant7sus4:
         return '7sus4';
-      case ChordQualityToken.dominant7Flat5:
+      case ChordQuality.dominant7Flat5:
         return '7';
-      case ChordQualityToken.dominant7Sharp5:
+      case ChordQuality.dominant7Sharp5:
         return '7';
-      case ChordQualityToken.major7:
+      case ChordQuality.major7:
         return 'Δ7';
-      case ChordQualityToken.major7sus2:
+      case ChordQuality.major7sus2:
         return 'Δ7sus2';
-      case ChordQualityToken.major7sus4:
+      case ChordQuality.major7sus4:
         return 'Δ7sus4';
-      case ChordQualityToken.major7Flat5:
+      case ChordQuality.major7Flat5:
         return 'Δ7';
-      case ChordQualityToken.major7Sharp5:
+      case ChordQuality.major7Sharp5:
         return 'Δ7';
-      case ChordQualityToken.minor7:
+      case ChordQuality.minor7:
         return '${_symbolicMinorSign}7';
-      case ChordQualityToken.minor7Sharp5:
+      case ChordQuality.minor7Sharp5:
         return '${_symbolicMinorSign}7';
-      case ChordQualityToken.minorMajor7:
+      case ChordQuality.minorMajor7:
         return '$_symbolicMinorSignΔ7';
-      case ChordQualityToken.halfDiminished7:
+      case ChordQuality.halfDiminished7:
         return 'ø7';
-      case ChordQualityToken.diminished7:
+      case ChordQuality.diminished7:
         return '°7';
     }
   }
 
   String _coreSuffix() {
     switch (this) {
-      case ChordQualityToken.major:
+      case ChordQuality.major:
         return '';
-      case ChordQualityToken.majorFlat5:
+      case ChordQuality.majorFlat5:
         return '';
-      case ChordQualityToken.minor:
+      case ChordQuality.minor:
         return 'm';
-      case ChordQualityToken.minorSharp5:
+      case ChordQuality.minorSharp5:
         return 'm';
-      case ChordQualityToken.diminished:
+      case ChordQuality.diminished:
         return 'dim';
-      case ChordQualityToken.augmented:
+      case ChordQuality.augmented:
         return 'aug';
-      case ChordQualityToken.power:
+      case ChordQuality.power:
         return '5';
-      case ChordQualityToken.sus2:
+      case ChordQuality.sus2:
         return 'sus2';
-      case ChordQualityToken.sus4:
+      case ChordQuality.sus4:
         return 'sus4';
-      case ChordQualityToken.sus2sus4:
+      case ChordQuality.sus2sus4:
         return 'sus2sus4';
-      case ChordQualityToken.major6:
+      case ChordQuality.major6:
         return '6';
-      case ChordQualityToken.minor6:
+      case ChordQuality.minor6:
         return 'm6';
-      case ChordQualityToken.dominant7:
+      case ChordQuality.dominant7:
         return '7';
-      case ChordQualityToken.dominant7sus2:
+      case ChordQuality.dominant7sus2:
         return '7sus2';
-      case ChordQualityToken.dominant7sus4:
+      case ChordQuality.dominant7sus4:
         return '7sus4';
-      case ChordQualityToken.dominant7Flat5:
+      case ChordQuality.dominant7Flat5:
         return '7';
-      case ChordQualityToken.dominant7Sharp5:
+      case ChordQuality.dominant7Sharp5:
         return '7';
-      case ChordQualityToken.major7:
+      case ChordQuality.major7:
         return 'maj7';
-      case ChordQualityToken.major7sus2:
+      case ChordQuality.major7sus2:
         return 'maj7sus2';
-      case ChordQualityToken.major7sus4:
+      case ChordQuality.major7sus4:
         return 'maj7sus4';
-      case ChordQualityToken.major7Flat5:
+      case ChordQuality.major7Flat5:
         return 'maj7';
-      case ChordQualityToken.major7Sharp5:
+      case ChordQuality.major7Sharp5:
         return 'maj7';
-      case ChordQualityToken.minor7:
+      case ChordQuality.minor7:
         return 'm7';
-      case ChordQualityToken.minor7Sharp5:
+      case ChordQuality.minor7Sharp5:
         return 'm7';
-      case ChordQualityToken.minorMajor7:
+      case ChordQuality.minorMajor7:
         return 'mmaj7';
-      case ChordQualityToken.halfDiminished7:
+      case ChordQuality.halfDiminished7:
         return 'm7';
-      case ChordQualityToken.diminished7:
+      case ChordQuality.diminished7:
         return 'dim7';
     }
   }
 
   String _coreLong() {
     switch (this) {
-      case ChordQualityToken.major:
+      case ChordQuality.major:
         return 'major';
-      case ChordQualityToken.majorFlat5:
+      case ChordQuality.majorFlat5:
         return 'major';
-      case ChordQualityToken.minor:
+      case ChordQuality.minor:
         return 'minor';
-      case ChordQualityToken.minorSharp5:
+      case ChordQuality.minorSharp5:
         return 'minor';
-      case ChordQualityToken.diminished:
+      case ChordQuality.diminished:
         return 'diminished';
-      case ChordQualityToken.augmented:
+      case ChordQuality.augmented:
         return 'augmented';
-      case ChordQualityToken.power:
+      case ChordQuality.power:
         return 'power chord';
-      case ChordQualityToken.sus2:
+      case ChordQuality.sus2:
         return 'suspended second';
-      case ChordQualityToken.sus4:
+      case ChordQuality.sus4:
         return 'suspended fourth';
-      case ChordQualityToken.sus2sus4:
+      case ChordQuality.sus2sus4:
         return 'suspended second and fourth';
-      case ChordQualityToken.major6:
+      case ChordQuality.major6:
         return 'major sixth';
-      case ChordQualityToken.minor6:
+      case ChordQuality.minor6:
         return 'minor sixth';
-      case ChordQualityToken.dominant7:
+      case ChordQuality.dominant7:
         return 'dominant seventh';
-      case ChordQualityToken.dominant7sus2:
+      case ChordQuality.dominant7sus2:
         return 'dominant seventh suspended second';
-      case ChordQualityToken.dominant7sus4:
+      case ChordQuality.dominant7sus4:
         return 'dominant seventh suspended fourth';
-      case ChordQualityToken.dominant7Flat5:
+      case ChordQuality.dominant7Flat5:
         return 'dominant seventh';
-      case ChordQualityToken.dominant7Sharp5:
+      case ChordQuality.dominant7Sharp5:
         return 'dominant seventh';
-      case ChordQualityToken.major7:
+      case ChordQuality.major7:
         return 'major seventh';
-      case ChordQualityToken.major7sus2:
+      case ChordQuality.major7sus2:
         return 'major seventh suspended second';
-      case ChordQualityToken.major7sus4:
+      case ChordQuality.major7sus4:
         return 'major seventh suspended fourth';
-      case ChordQualityToken.major7Flat5:
+      case ChordQuality.major7Flat5:
         return 'major seventh';
-      case ChordQualityToken.major7Sharp5:
+      case ChordQuality.major7Sharp5:
         return 'major seventh';
-      case ChordQualityToken.minor7:
+      case ChordQuality.minor7:
         return 'minor seventh';
-      case ChordQualityToken.minor7Sharp5:
+      case ChordQuality.minor7Sharp5:
         return 'minor seventh';
-      case ChordQualityToken.minorMajor7:
+      case ChordQuality.minorMajor7:
         return 'minor-major seventh';
-      case ChordQualityToken.halfDiminished7:
+      case ChordQuality.halfDiminished7:
         return 'half-diminished seventh';
-      case ChordQualityToken.diminished7:
+      case ChordQuality.diminished7:
         return 'diminished seventh';
     }
   }
 
   String _coreSpoken() {
     switch (this) {
-      case ChordQualityToken.major:
+      case ChordQuality.major:
         return '';
-      case ChordQualityToken.majorFlat5:
+      case ChordQuality.majorFlat5:
         return '';
-      case ChordQualityToken.minor:
+      case ChordQuality.minor:
         return 'minor';
-      case ChordQualityToken.minorSharp5:
+      case ChordQuality.minorSharp5:
         return 'minor';
-      case ChordQualityToken.diminished:
+      case ChordQuality.diminished:
         return 'diminished';
-      case ChordQualityToken.augmented:
+      case ChordQuality.augmented:
         return 'augmented';
-      case ChordQualityToken.power:
+      case ChordQuality.power:
         return 'five';
-      case ChordQualityToken.sus2:
+      case ChordQuality.sus2:
         return 'sus two';
-      case ChordQualityToken.sus4:
+      case ChordQuality.sus4:
         return 'sus';
-      case ChordQualityToken.sus2sus4:
+      case ChordQuality.sus2sus4:
         return 'sus two sus four';
-      case ChordQualityToken.major6:
+      case ChordQuality.major6:
         return 'six';
-      case ChordQualityToken.minor6:
+      case ChordQuality.minor6:
         return 'minor six';
-      case ChordQualityToken.dominant7:
+      case ChordQuality.dominant7:
         return 'seven';
-      case ChordQualityToken.dominant7sus2:
+      case ChordQuality.dominant7sus2:
         return 'seven sus two';
-      case ChordQualityToken.dominant7sus4:
+      case ChordQuality.dominant7sus4:
         return 'seven sus';
-      case ChordQualityToken.dominant7Flat5:
+      case ChordQuality.dominant7Flat5:
         return 'seven';
-      case ChordQualityToken.dominant7Sharp5:
+      case ChordQuality.dominant7Sharp5:
         return 'seven';
-      case ChordQualityToken.major7:
+      case ChordQuality.major7:
         return 'major seven';
-      case ChordQualityToken.major7sus2:
+      case ChordQuality.major7sus2:
         return 'major seven sus two';
-      case ChordQualityToken.major7sus4:
+      case ChordQuality.major7sus4:
         return 'major seven sus';
-      case ChordQualityToken.major7Flat5:
+      case ChordQuality.major7Flat5:
         return 'major seven';
-      case ChordQualityToken.major7Sharp5:
+      case ChordQuality.major7Sharp5:
         return 'major seven';
-      case ChordQualityToken.minor7:
+      case ChordQuality.minor7:
         return 'minor seven';
-      case ChordQualityToken.minor7Sharp5:
+      case ChordQuality.minor7Sharp5:
         return 'minor seven';
-      case ChordQualityToken.minorMajor7:
+      case ChordQuality.minorMajor7:
         return 'minor major seven';
-      case ChordQualityToken.halfDiminished7:
+      case ChordQuality.halfDiminished7:
         return 'half-diminished';
-      case ChordQualityToken.diminished7:
+      case ChordQuality.diminished7:
         return 'diminished seven';
     }
   }

--- a/packages/whatchord/lib/src/formatting/services/chord_spoken_name_formatter.dart
+++ b/packages/whatchord/lib/src/formatting/services/chord_spoken_name_formatter.dart
@@ -4,7 +4,7 @@ import '../../models/tonality.dart';
 import '../../services/note_spelling.dart';
 import '../models/chord_symbol.dart';
 import 'chord_display_conventions.dart';
-import 'chord_quality_token_labels.dart';
+import 'chord_quality_labels.dart';
 import 'note_display_formatter.dart';
 
 /// Renders a chord identity as its idiomatic spoken name
@@ -59,13 +59,13 @@ class ChordSpokenNameFormatter {
 }
 
 (String quality, ChordExtension? absorbed) _qualitySpokenPhraseAndHeadline({
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required Set<ChordExtension> extensions,
 }) {
   if (quality.isSixFamily && extensions.contains(ChordExtension.add9)) {
     final q = switch (quality) {
-      ChordQualityToken.major6 => 'six-nine',
-      ChordQualityToken.minor6 => 'minor six-nine',
+      ChordQuality.major6 => 'six-nine',
+      ChordQuality.minor6 => 'minor six-nine',
       _ => quality.label(ChordQualityLabelForm.idiomatic),
     };
     return (q, ChordExtension.add9);
@@ -102,10 +102,10 @@ String _extensionsSpokenPhrase(
 }
 
 ChordExtension? _headlineExtension({
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required Set<ChordExtension> extensions,
 }) {
-  if (!quality.isSeventhFamily || quality == ChordQualityToken.diminished7) {
+  if (!quality.isSeventhFamily || quality == ChordQuality.diminished7) {
     return null;
   }
   if (extensions.contains(ChordExtension.thirteen)) {

--- a/packages/whatchord/lib/src/formatting/services/inversion_formatter.dart
+++ b/packages/whatchord/lib/src/formatting/services/inversion_formatter.dart
@@ -25,7 +25,7 @@ abstract final class InversionFormatter {
       final role = id.toneRolesByInterval[bassInterval];
       return role == null
           ? 'non-root bass'
-          : 'non-root bass: ${theoryTokenDisplayLabel(role.label)}';
+          : 'non-root bass: ${toGlyphAccidentals(role.label)}';
     }
 
     // Bass is a core chord tone -> classical inversion naming is appropriate.
@@ -34,85 +34,85 @@ abstract final class InversionFormatter {
         : _triadInversion(bassInterval);
   }
 
-  static Set<int> _coreMemberIntervals(ChordQualityToken q) {
+  static Set<int> _coreMemberIntervals(ChordQuality q) {
     switch (q) {
       // Triad-family
-      case ChordQualityToken.major:
-      case ChordQualityToken.major6:
+      case ChordQuality.major:
+      case ChordQuality.major6:
         return const {0, 4, 7}; // 1, 3, 5
 
-      case ChordQualityToken.majorFlat5:
+      case ChordQuality.majorFlat5:
         return const {0, 4, 6}; // 1, 3, b5
 
-      case ChordQualityToken.minor:
-      case ChordQualityToken.minor6:
+      case ChordQuality.minor:
+      case ChordQuality.minor6:
         return const {0, 3, 7}; // 1, b3, 5
 
-      case ChordQualityToken.minorSharp5:
+      case ChordQuality.minorSharp5:
         return const {0, 3, 8}; // 1, b3, #5
 
-      case ChordQualityToken.diminished:
+      case ChordQuality.diminished:
         return const {0, 3, 6}; // 1, b3, b5
 
-      case ChordQualityToken.augmented:
+      case ChordQuality.augmented:
         return const {0, 4, 8}; // 1, 3, #5
 
-      case ChordQualityToken.power:
+      case ChordQuality.power:
         return const {0, 7}; // 1, 5
 
-      case ChordQualityToken.sus2:
+      case ChordQuality.sus2:
         return const {0, 2, 7}; // 1, 2, 5
 
-      case ChordQualityToken.sus4:
+      case ChordQuality.sus4:
         return const {0, 5, 7}; // 1, 4, 5
 
-      case ChordQualityToken.sus2sus4:
+      case ChordQuality.sus2sus4:
         return const {0, 2, 5, 7}; // 1, 2, 4, 5
 
       // Seventh-family (include the seventh as core)
-      case ChordQualityToken.dominant7:
+      case ChordQuality.dominant7:
         return const {0, 4, 7, 10}; // 1, 3, 5, b7
 
-      case ChordQualityToken.dominant7sus2:
+      case ChordQuality.dominant7sus2:
         return const {0, 2, 7, 10}; // 1, 2, 5, b7
 
-      case ChordQualityToken.dominant7sus4:
+      case ChordQuality.dominant7sus4:
         return const {0, 5, 7, 10}; // 1, 4, 5, b7
 
-      case ChordQualityToken.dominant7Flat5:
+      case ChordQuality.dominant7Flat5:
         return const {0, 4, 6, 10}; // 1, 3, b5, b7
 
-      case ChordQualityToken.dominant7Sharp5:
+      case ChordQuality.dominant7Sharp5:
         return const {0, 4, 8, 10}; // 1, 3, #5, b7
 
-      case ChordQualityToken.major7:
+      case ChordQuality.major7:
         return const {0, 4, 7, 11}; // 1, 3, 5, 7
 
-      case ChordQualityToken.major7sus2:
+      case ChordQuality.major7sus2:
         return const {0, 2, 7, 11}; // 1, 2, 5, 7
 
-      case ChordQualityToken.major7sus4:
+      case ChordQuality.major7sus4:
         return const {0, 5, 7, 11}; // 1, 4, 5, 7
 
-      case ChordQualityToken.major7Flat5:
+      case ChordQuality.major7Flat5:
         return const {0, 4, 6, 11}; // 1, 3, b5, 7
 
-      case ChordQualityToken.major7Sharp5:
+      case ChordQuality.major7Sharp5:
         return const {0, 4, 8, 11}; // 1, 3, #5, 7
 
-      case ChordQualityToken.minor7:
+      case ChordQuality.minor7:
         return const {0, 3, 7, 10}; // 1, b3, 5, b7
 
-      case ChordQualityToken.minor7Sharp5:
+      case ChordQuality.minor7Sharp5:
         return const {0, 3, 8, 10}; // 1, b3, #5, b7
 
-      case ChordQualityToken.minorMajor7:
+      case ChordQuality.minorMajor7:
         return const {0, 3, 7, 11}; // 1, b3, 5, 7
 
-      case ChordQualityToken.halfDiminished7:
+      case ChordQuality.halfDiminished7:
         return const {0, 3, 6, 10}; // 1, b3, b5, b7
 
-      case ChordQualityToken.diminished7:
+      case ChordQuality.diminished7:
         return const {0, 3, 6, 9}; // 1, b3, b5, bb7(=6)
     }
   }

--- a/packages/whatchord/lib/src/formatting/services/note_display_formatter.dart
+++ b/packages/whatchord/lib/src/formatting/services/note_display_formatter.dart
@@ -96,7 +96,7 @@ String tonalitySemanticLabel(
 }
 
 /// Just the tonic label for a key, in the given note-name system.
-String tonalityPickerTonicLabel(
+String tonalityTonicLabel(
   Tonality tonality, {
   NoteNameSystem noteNameSystem = NoteNameSystem.international,
 }) {
@@ -104,9 +104,6 @@ String tonalityPickerTonicLabel(
     noteNameSystem,
   ).tonalityTonic(tonality.tonic.label, isMajor: tonality.isMajor);
 }
-
-/// Converts a canonical ASCII token such as b9, #11, or m7(b5) to UI text.
-String theoryTokenDisplayLabel(String token) => toGlyphAccidentals(token);
 
 /// Converts a canonical chord symbol to compact UI text.
 String chordSymbolDisplayLabel(
@@ -136,7 +133,7 @@ ChordSymbolDisplayParts chordSymbolDisplayParts(
   NoteNameSystem noteNameSystem = NoteNameSystem.international,
 }) {
   final formatter = _NoteNameFormatter(noteNameSystem);
-  final quality = theoryTokenDisplayLabel(symbol.quality);
+  final quality = toGlyphAccidentals(symbol.quality);
   return ChordSymbolDisplayParts(
     root: formatter.compact(symbol.root),
     quality: quality,

--- a/packages/whatchord/lib/src/models/chord_extension.dart
+++ b/packages/whatchord/lib/src/models/chord_extension.dart
@@ -202,7 +202,7 @@ typedef ExtensionPreference = ({
 /// [sharp11AsNaturalColor] reclassifies a raised eleventh as a natural
 /// (stacked) extension instead of an alteration. Callers set it for qualities
 /// where the #11 is the Lydian color rather than a tension (see
-/// `ChordQualityToken.sharp11IsNaturalColor`).
+/// `ChordQuality.sharp11IsNaturalColor`).
 ExtensionPreference extensionPreference(
   Set<ChordExtension> exts, {
   bool sharp11AsNaturalColor = false,

--- a/packages/whatchord/lib/src/models/chord_identity.dart
+++ b/packages/whatchord/lib/src/models/chord_identity.dart
@@ -22,7 +22,7 @@ class ChordIdentity {
   /// This captures the primary quality used by the analysis engine
   /// (e.g., major, minor, dominant seventh) independent of naming
   /// or display conventions.
-  final ChordQualityToken quality;
+  final ChordQuality quality;
 
   /// Additional chord extensions or alterations, expressed as semitone
   /// offsets above the root (0–11).
@@ -129,7 +129,7 @@ class ChordIdentity {
 /// Each token is a complete base quality (triad, sixth, or seventh chord,
 /// including suspended and altered-fifth variants); colors beyond the base
 /// quality are carried separately as [ChordExtension]s.
-enum ChordQualityToken {
+enum ChordQuality {
   major,
   majorFlat5,
   minor,
@@ -162,26 +162,26 @@ enum ChordQualityToken {
 /// Whether a quality is a triad-like or seventh-bearing chord.
 enum ChordQualityFamily { triad, seventh }
 
-/// Structural predicates over [ChordQualityToken].
-extension ChordQualityTokenSemantics on ChordQualityToken {
+/// Structural predicates over [ChordQuality].
+extension ChordQualitySemantics on ChordQuality {
   /// The [ChordQualityFamily] this quality belongs to.
   ChordQualityFamily get family {
     switch (this) {
-      case ChordQualityToken.dominant7:
-      case ChordQualityToken.dominant7sus2:
-      case ChordQualityToken.dominant7sus4:
-      case ChordQualityToken.dominant7Flat5:
-      case ChordQualityToken.dominant7Sharp5:
-      case ChordQualityToken.major7:
-      case ChordQualityToken.major7sus2:
-      case ChordQualityToken.major7sus4:
-      case ChordQualityToken.major7Flat5:
-      case ChordQualityToken.major7Sharp5:
-      case ChordQualityToken.minor7:
-      case ChordQualityToken.minor7Sharp5:
-      case ChordQualityToken.minorMajor7:
-      case ChordQualityToken.halfDiminished7:
-      case ChordQualityToken.diminished7:
+      case ChordQuality.dominant7:
+      case ChordQuality.dominant7sus2:
+      case ChordQuality.dominant7sus4:
+      case ChordQuality.dominant7Flat5:
+      case ChordQuality.dominant7Sharp5:
+      case ChordQuality.major7:
+      case ChordQuality.major7sus2:
+      case ChordQuality.major7sus4:
+      case ChordQuality.major7Flat5:
+      case ChordQuality.major7Sharp5:
+      case ChordQuality.minor7:
+      case ChordQuality.minor7Sharp5:
+      case ChordQuality.minorMajor7:
+      case ChordQuality.halfDiminished7:
+      case ChordQuality.diminished7:
         return ChordQualityFamily.seventh;
 
       default:
@@ -195,8 +195,8 @@ extension ChordQualityTokenSemantics on ChordQualityToken {
   /// Whether this quality is a sixth chord (major6 or minor6).
   bool get isSixFamily {
     switch (this) {
-      case ChordQualityToken.major6:
-      case ChordQualityToken.minor6:
+      case ChordQuality.major6:
+      case ChordQuality.minor6:
         return true;
       default:
         return false;
@@ -206,13 +206,13 @@ extension ChordQualityTokenSemantics on ChordQualityToken {
   /// Whether this quality suspends its third (sus2, sus4, or both).
   bool get isSus {
     switch (this) {
-      case ChordQualityToken.sus2:
-      case ChordQualityToken.sus4:
-      case ChordQualityToken.sus2sus4:
-      case ChordQualityToken.dominant7sus2:
-      case ChordQualityToken.dominant7sus4:
-      case ChordQualityToken.major7sus2:
-      case ChordQualityToken.major7sus4:
+      case ChordQuality.sus2:
+      case ChordQuality.sus4:
+      case ChordQuality.sus2sus4:
+      case ChordQuality.dominant7sus2:
+      case ChordQuality.dominant7sus4:
+      case ChordQuality.major7sus2:
+      case ChordQuality.major7sus4:
         return true;
       default:
         return false;
@@ -224,12 +224,12 @@ extension ChordQualityTokenSemantics on ChordQualityToken {
   /// pricing tier).
   bool get isRareVocabulary {
     switch (this) {
-      case ChordQualityToken.minorSharp5:
-      case ChordQualityToken.minor7Sharp5:
-      case ChordQualityToken.majorFlat5:
-      case ChordQualityToken.major7Flat5:
-      case ChordQualityToken.dominant7sus2:
-      case ChordQualityToken.major7sus2:
+      case ChordQuality.minorSharp5:
+      case ChordQuality.minor7Sharp5:
+      case ChordQuality.majorFlat5:
+      case ChordQuality.major7Flat5:
+      case ChordQuality.dominant7sus2:
+      case ChordQuality.major7sus2:
         return true;
       default:
         return false;
@@ -249,9 +249,9 @@ extension ChordQualityTokenSemantics on ChordQualityToken {
   /// separately.
   bool get sharp11IsNaturalColor {
     switch (this) {
-      case ChordQualityToken.major:
-      case ChordQualityToken.major6:
-      case ChordQualityToken.major7:
+      case ChordQuality.major:
+      case ChordQuality.major6:
+      case ChordQuality.major7:
         return true;
       default:
         return false;

--- a/packages/whatchord/lib/src/models/key_signature.dart
+++ b/packages/whatchord/lib/src/models/key_signature.dart
@@ -43,7 +43,7 @@ class KeySignature {
   /// The signature for [tonality]; throws for tonalities without a
   /// conventional key signature.
   static KeySignature fromTonality(Tonality tonality) {
-    for (final ks in keySignatureRows) {
+    for (final ks in keySignatures) {
       if (tonality.isMajor && ks.relativeMajor == tonality) {
         return ks;
       }
@@ -56,14 +56,14 @@ class KeySignature {
 }
 
 /// Convenient, non-cyclic access: Tonality -> KeySignature.
-extension TonalityKeySignatureX on Tonality {
+extension TonalityKeySignature on Tonality {
   /// The key signature for this tonality.
   KeySignature get keySignature => KeySignature.fromTonality(this);
 }
 
 /// Circle-of-fifths-ish ordering that also includes the "full" 15 signatures:
 /// 7 flats ... 0 ... 7 sharps
-const keySignatureRows = <KeySignature>[
+const keySignatures = <KeySignature>[
   KeySignature(
     accidentalCount: -7,
     relativeMajor: Tonality(Tonic.cFlat, TonalityMode.major),

--- a/packages/whatchord/lib/src/services/chord_quality_intervals.dart
+++ b/packages/whatchord/lib/src/services/chord_quality_intervals.dart
@@ -1,7 +1,7 @@
 import '../models/chord_identity.dart';
 import 'interval_constants.dart';
 
-/// The interval content that defines one [ChordQualityToken].
+/// The interval content that defines one [ChordQuality].
 class ChordQualityIntervals {
   const ChordQualityIntervals({
     required this.quality,
@@ -10,7 +10,7 @@ class ChordQualityIntervals {
   });
 
   /// The quality these intervals define.
-  final ChordQualityToken quality;
+  final ChordQuality quality;
 
   /// 12-bit mask of the quality's canonical tones, root included.
   final int canonicalMask;
@@ -29,66 +29,66 @@ class ChordQualityIntervals {
   Set<int> get canonicalIntervals => _intervalsFromMask(canonicalMask);
 }
 
-/// The interval definitions for every supported [ChordQualityToken].
+/// The interval definitions for every supported [ChordQuality].
 const chordQualityIntervalSets = <ChordQualityIntervals>[
   ChordQualityIntervals(
-    quality: ChordQualityToken.major,
+    quality: ChordQuality.major,
     canonicalMask:
         chordRootBit | (1 << majorThirdInterval) | (1 << perfectFifthInterval),
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.majorFlat5,
+    quality: ChordQuality.majorFlat5,
     canonicalMask:
         chordRootBit |
         (1 << majorThirdInterval) |
         (1 << diminishedFifthInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.minor,
+    quality: ChordQuality.minor,
     canonicalMask:
         chordRootBit | (1 << minorThirdInterval) | (1 << perfectFifthInterval),
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.minorSharp5,
+    quality: ChordQuality.minorSharp5,
     canonicalMask:
         chordRootBit |
         (1 << minorThirdInterval) |
         (1 << augmentedFifthInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.diminished,
+    quality: ChordQuality.diminished,
     canonicalMask:
         chordRootBit |
         (1 << minorThirdInterval) |
         (1 << diminishedFifthInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.augmented,
+    quality: ChordQuality.augmented,
     canonicalMask:
         chordRootBit |
         (1 << majorThirdInterval) |
         (1 << augmentedFifthInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.power,
+    quality: ChordQuality.power,
     canonicalMask: chordRootBit | (1 << perfectFifthInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.sus2,
+    quality: ChordQuality.sus2,
     canonicalMask:
         chordRootBit | (1 << majorSecondInterval) | (1 << perfectFifthInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.sus4,
+    quality: ChordQuality.sus4,
     canonicalMask:
         chordRootBit |
         (1 << perfectFourthInterval) |
         (1 << perfectFifthInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.sus2sus4,
+    quality: ChordQuality.sus2sus4,
     canonicalMask:
         chordRootBit |
         (1 << majorSecondInterval) |
@@ -96,7 +96,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
         (1 << perfectFifthInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.major6,
+    quality: ChordQuality.major6,
     canonicalMask:
         chordRootBit |
         (1 << majorThirdInterval) |
@@ -105,7 +105,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.minor6,
+    quality: ChordQuality.minor6,
     canonicalMask:
         chordRootBit |
         (1 << minorThirdInterval) |
@@ -114,7 +114,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.dominant7,
+    quality: ChordQuality.dominant7,
     canonicalMask:
         chordRootBit |
         (1 << majorThirdInterval) |
@@ -123,7 +123,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.dominant7sus2,
+    quality: ChordQuality.dominant7sus2,
     canonicalMask:
         chordRootBit |
         (1 << majorSecondInterval) |
@@ -132,7 +132,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.dominant7sus4,
+    quality: ChordQuality.dominant7sus4,
     canonicalMask:
         chordRootBit |
         (1 << perfectFourthInterval) |
@@ -141,7 +141,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.dominant7Flat5,
+    quality: ChordQuality.dominant7Flat5,
     canonicalMask:
         chordRootBit |
         (1 << majorThirdInterval) |
@@ -149,7 +149,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
         (1 << minorSeventhInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.dominant7Sharp5,
+    quality: ChordQuality.dominant7Sharp5,
     canonicalMask:
         chordRootBit |
         (1 << majorThirdInterval) |
@@ -157,7 +157,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
         (1 << minorSeventhInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.major7,
+    quality: ChordQuality.major7,
     canonicalMask:
         chordRootBit |
         (1 << majorThirdInterval) |
@@ -166,7 +166,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.major7sus2,
+    quality: ChordQuality.major7sus2,
     canonicalMask:
         chordRootBit |
         (1 << majorSecondInterval) |
@@ -175,7 +175,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.major7sus4,
+    quality: ChordQuality.major7sus4,
     canonicalMask:
         chordRootBit |
         (1 << perfectFourthInterval) |
@@ -184,7 +184,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.major7Flat5,
+    quality: ChordQuality.major7Flat5,
     canonicalMask:
         chordRootBit |
         (1 << majorThirdInterval) |
@@ -192,7 +192,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
         (1 << majorSeventhInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.major7Sharp5,
+    quality: ChordQuality.major7Sharp5,
     canonicalMask:
         chordRootBit |
         (1 << majorThirdInterval) |
@@ -200,7 +200,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
         (1 << majorSeventhInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.minor7,
+    quality: ChordQuality.minor7,
     canonicalMask:
         chordRootBit |
         (1 << minorThirdInterval) |
@@ -209,7 +209,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.minor7Sharp5,
+    quality: ChordQuality.minor7Sharp5,
     canonicalMask:
         chordRootBit |
         (1 << minorThirdInterval) |
@@ -217,7 +217,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
         (1 << minorSeventhInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.minorMajor7,
+    quality: ChordQuality.minorMajor7,
     canonicalMask:
         chordRootBit |
         (1 << minorThirdInterval) |
@@ -226,7 +226,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
     omittableMask: 1 << perfectFifthInterval,
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.halfDiminished7,
+    quality: ChordQuality.halfDiminished7,
     canonicalMask:
         chordRootBit |
         (1 << minorThirdInterval) |
@@ -234,7 +234,7 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
         (1 << minorSeventhInterval),
   ),
   ChordQualityIntervals(
-    quality: ChordQualityToken.diminished7,
+    quality: ChordQuality.diminished7,
     canonicalMask:
         chordRootBit |
         (1 << minorThirdInterval) |
@@ -244,14 +244,14 @@ const chordQualityIntervalSets = <ChordQualityIntervals>[
 ];
 
 /// [chordQualityIntervalSets] indexed by quality.
-final Map<ChordQualityToken, ChordQualityIntervals>
-chordQualityIntervalsByQuality = {
-  for (final intervals in chordQualityIntervalSets)
-    intervals.quality: intervals,
-};
+final Map<ChordQuality, ChordQualityIntervals> chordQualityIntervalsByQuality =
+    {
+      for (final intervals in chordQualityIntervalSets)
+        intervals.quality: intervals,
+    };
 
-/// Interval lookups on [ChordQualityToken].
-extension ChordQualityTokenIntervals on ChordQualityToken {
+/// Interval lookups on [ChordQuality].
+extension ChordQualityIntervalLookup on ChordQuality {
   /// The interval definition for this quality.
   ChordQualityIntervals get intervals {
     return chordQualityIntervalsByQuality[this]!;

--- a/packages/whatchord/lib/src/services/chord_tone_roles.dart
+++ b/packages/whatchord/lib/src/services/chord_tone_roles.dart
@@ -6,7 +6,7 @@ import '../models/chord_tone_role.dart';
 /// This is the key mechanism that enables "#11 vs b5" spelling decisions.
 abstract final class ChordToneRoles {
   static Map<int, ChordToneRole> build({
-    required ChordQualityToken quality,
+    required ChordQuality quality,
     required Set<ChordExtension> extensions,
     required int
     relMask, // 12-bit mask of intervals above root present in voicing
@@ -24,153 +24,153 @@ abstract final class ChordToneRoles {
     }
 
     switch (quality) {
-      case ChordQualityToken.major:
+      case ChordQuality.major:
         addBase(4, ChordToneRole.major3);
         addBase(7, ChordToneRole.perfect5);
         break;
 
-      case ChordQualityToken.majorFlat5:
+      case ChordQuality.majorFlat5:
         addBase(4, ChordToneRole.major3);
         addBase(6, ChordToneRole.flat5);
         break;
 
-      case ChordQualityToken.minor:
+      case ChordQuality.minor:
         addBase(3, ChordToneRole.minor3);
         addBase(7, ChordToneRole.perfect5);
         break;
 
-      case ChordQualityToken.minorSharp5:
+      case ChordQuality.minorSharp5:
         addBase(3, ChordToneRole.minor3);
         addBase(8, ChordToneRole.sharp5);
         break;
 
-      case ChordQualityToken.diminished:
+      case ChordQuality.diminished:
         addBase(3, ChordToneRole.minor3);
         addBase(6, ChordToneRole.flat5);
         break;
 
-      case ChordQualityToken.augmented:
+      case ChordQuality.augmented:
         addBase(4, ChordToneRole.major3);
         addBase(8, ChordToneRole.sharp5);
         break;
 
-      case ChordQualityToken.power:
+      case ChordQuality.power:
         addBase(7, ChordToneRole.perfect5);
         break;
 
-      case ChordQualityToken.sus2:
+      case ChordQuality.sus2:
         addBase(2, ChordToneRole.sus2);
         addBase(7, ChordToneRole.perfect5);
         break;
 
-      case ChordQualityToken.sus4:
+      case ChordQuality.sus4:
         addBase(5, ChordToneRole.sus4);
         addBase(7, ChordToneRole.perfect5);
         break;
 
-      case ChordQualityToken.sus2sus4:
+      case ChordQuality.sus2sus4:
         addBase(2, ChordToneRole.sus2);
         addBase(5, ChordToneRole.sus4);
         addBase(7, ChordToneRole.perfect5);
         break;
 
-      case ChordQualityToken.major6:
+      case ChordQuality.major6:
         addBase(4, ChordToneRole.major3);
         addBase(7, ChordToneRole.perfect5);
         addBase(9, ChordToneRole.sixth);
         break;
 
-      case ChordQualityToken.minor6:
+      case ChordQuality.minor6:
         addBase(3, ChordToneRole.minor3);
         addBase(7, ChordToneRole.perfect5);
         addBase(9, ChordToneRole.sixth);
         break;
 
-      case ChordQualityToken.dominant7:
+      case ChordQuality.dominant7:
         addBase(4, ChordToneRole.major3);
         addBase(7, ChordToneRole.perfect5);
         addBase(10, ChordToneRole.flat7);
         break;
 
-      case ChordQualityToken.dominant7sus2:
+      case ChordQuality.dominant7sus2:
         addBase(2, ChordToneRole.sus2);
         addBase(7, ChordToneRole.perfect5);
         addBase(10, ChordToneRole.flat7);
         break;
 
-      case ChordQualityToken.dominant7sus4:
+      case ChordQuality.dominant7sus4:
         addBase(5, ChordToneRole.sus4);
         addBase(7, ChordToneRole.perfect5);
         addBase(10, ChordToneRole.flat7);
         break;
 
-      case ChordQualityToken.dominant7Flat5:
+      case ChordQuality.dominant7Flat5:
         addBase(4, ChordToneRole.major3);
         addBase(6, ChordToneRole.flat5);
         addBase(10, ChordToneRole.flat7);
         break;
 
-      case ChordQualityToken.dominant7Sharp5:
+      case ChordQuality.dominant7Sharp5:
         addBase(4, ChordToneRole.major3);
         addBase(8, ChordToneRole.sharp5);
         addBase(10, ChordToneRole.flat7);
         break;
 
-      case ChordQualityToken.major7:
+      case ChordQuality.major7:
         addBase(4, ChordToneRole.major3);
         addBase(7, ChordToneRole.perfect5);
         addBase(11, ChordToneRole.major7);
         break;
 
-      case ChordQualityToken.major7sus2:
+      case ChordQuality.major7sus2:
         addBase(2, ChordToneRole.sus2);
         addBase(7, ChordToneRole.perfect5);
         addBase(11, ChordToneRole.major7);
         break;
 
-      case ChordQualityToken.major7sus4:
+      case ChordQuality.major7sus4:
         addBase(5, ChordToneRole.sus4);
         addBase(7, ChordToneRole.perfect5);
         addBase(11, ChordToneRole.major7);
         break;
 
-      case ChordQualityToken.major7Flat5:
+      case ChordQuality.major7Flat5:
         addBase(4, ChordToneRole.major3);
         addBase(6, ChordToneRole.flat5);
         addBase(11, ChordToneRole.major7);
         break;
 
-      case ChordQualityToken.major7Sharp5:
+      case ChordQuality.major7Sharp5:
         addBase(4, ChordToneRole.major3);
         addBase(8, ChordToneRole.sharp5);
         addBase(11, ChordToneRole.major7);
         break;
 
-      case ChordQualityToken.minor7:
+      case ChordQuality.minor7:
         addBase(3, ChordToneRole.minor3);
         addBase(7, ChordToneRole.perfect5);
         addBase(10, ChordToneRole.flat7);
         break;
 
-      case ChordQualityToken.minor7Sharp5:
+      case ChordQuality.minor7Sharp5:
         addBase(3, ChordToneRole.minor3);
         addBase(8, ChordToneRole.sharp5);
         addBase(10, ChordToneRole.flat7);
         break;
 
-      case ChordQualityToken.minorMajor7:
+      case ChordQuality.minorMajor7:
         addBase(3, ChordToneRole.minor3);
         addBase(7, ChordToneRole.perfect5);
         addBase(11, ChordToneRole.major7);
         break;
 
-      case ChordQualityToken.halfDiminished7:
+      case ChordQuality.halfDiminished7:
         addBase(3, ChordToneRole.minor3);
         addBase(6, ChordToneRole.flat5);
         addBase(10, ChordToneRole.flat7);
         break;
 
-      case ChordQualityToken.diminished7:
+      case ChordQuality.diminished7:
         addBase(3, ChordToneRole.minor3);
         addBase(6, ChordToneRole.flat5);
         // Fully diminished seventh is "bb7" (interval 9 above root).

--- a/packages/whatchord/lib/src/services/note_spelling.dart
+++ b/packages/whatchord/lib/src/services/note_spelling.dart
@@ -9,7 +9,7 @@ import 'pitch_class.dart';
 /// - If [role] and [chordRootName] are provided, the letter is chosen by
 ///   diatonic degree above the chord root (e.g. "#11" uses the 4th letter,
 ///   "b5" uses the 5th letter), then accidentals are computed to hit [pc].
-/// - Otherwise, falls back to tonality-aware [pcToName].
+/// - Otherwise, falls back to tonality-aware [noteNameForPitchClass].
 String spellPitchClass(
   int pc, {
   required Tonality tonality,
@@ -17,14 +17,14 @@ String spellPitchClass(
   ChordToneRole? role,
 }) {
   if (role == null || chordRootName == null || chordRootName.trim().isEmpty) {
-    return pcToName(pc, tonality: tonality);
+    return noteNameForPitchClass(pc, tonality: tonality);
   }
 
   final rootAscii = normalizeNoteNameToAscii(chordRootName);
   final rootLetter = rootAscii[0].toUpperCase();
 
   final rootIndex = _letters.indexOf(rootLetter);
-  if (rootIndex == -1) return pcToName(pc, tonality: tonality);
+  if (rootIndex == -1) return noteNameForPitchClass(pc, tonality: tonality);
 
   final degree = role.degreeFromRoot; // 1..7
   final targetLetter = _letters[(rootIndex + (degree - 1)) % 7];
@@ -38,7 +38,7 @@ String spellPitchClass(
 
   // Keep current system conservative: allow up to double accidentals.
   if (delta < -2 || delta > 2) {
-    return pcToName(pc, tonality: tonality);
+    return noteNameForPitchClass(pc, tonality: tonality);
   }
 
   return targetLetter + _accidentalToAscii(delta);
@@ -75,7 +75,7 @@ String spellSlashBass(
 
   if (_isReadableBassSpelling(functional)) return functional;
 
-  return pcToName(pc, tonality: tonality);
+  return noteNameForPitchClass(pc, tonality: tonality);
 }
 
 /// Roles whose conventional slash spelling should always be preserved, even as
@@ -110,7 +110,7 @@ bool _isReadableBassSpelling(String name) {
 /// chromatic tie. For example, pitch class 8 in C major is ambiguous as G# or
 /// Ab; a major triad rooted there spells cleanly as Ab-C-Eb, not G#-B#-D#.
 String spellChordRoot(ChordIdentity identity, {required Tonality tonality}) {
-  final tonalName = pcToName(identity.rootPc, tonality: tonality);
+  final tonalName = noteNameForPitchClass(identity.rootPc, tonality: tonality);
   if (_isDiatonicName(tonalName, tonality: tonality)) return tonalName;
 
   final candidates = _candidateNamesForPc(identity.rootPc);
@@ -143,7 +143,7 @@ bool _isDiatonicName(String name, {required Tonality tonality}) {
 }
 
 /// Tonality-aware pitch-class spelling (key-signature correct).
-String pcToName(int pc, {required Tonality tonality}) {
+String noteNameForPitchClass(int pc, {required Tonality tonality}) {
   final i = pc % 12;
 
   final ks = tonality.keySignature;
@@ -262,16 +262,16 @@ Map<int, String> _buildDiatonicPcToName({
     growable: false,
   );
 
-  final pcToName = <int, String>{};
+  final noteNameForPitchClass = <int, String>{};
 
   for (final letter in diatonicLetters) {
     final naturalPc = _naturalPcByLetter[letter]!;
     final acc = accByLetter[letter]!;
     final spelledPc = (naturalPc + acc) % 12;
-    pcToName[spelledPc] = letter + _accidentalToAscii(acc);
+    noteNameForPitchClass[spelledPc] = letter + _accidentalToAscii(acc);
   }
 
-  return pcToName;
+  return noteNameForPitchClass;
 }
 
 String _spellChromaticPc(

--- a/packages/whatchord/lib/src/services/scale_degree_classifier.dart
+++ b/packages/whatchord/lib/src/services/scale_degree_classifier.dart
@@ -12,7 +12,7 @@ import 'scale_degree_roman_numerals.dart';
 /// See notes in this file: strict classification requires the real voicing mask.
 abstract final class ScaleDegreeClassifier {
   // Single source of truth: chordTemplates.
-  static final Map<ChordQualityToken, ChordTemplate> _templateByQuality = {
+  static final Map<ChordQuality, ChordTemplate> _templateByQuality = {
     for (final t in chordTemplates) t.quality: t,
   };
 
@@ -271,10 +271,10 @@ abstract final class ScaleDegreeClassifier {
     return _degreeLetters[(start + degree.index) % 7];
   }
 
-  static ChordQualityToken? _baseQualityForSix(ChordQualityToken q) {
+  static ChordQuality? _baseQualityForSix(ChordQuality q) {
     return switch (q) {
-      ChordQualityToken.major6 => ChordQualityToken.major,
-      ChordQualityToken.minor6 => ChordQualityToken.minor,
+      ChordQuality.major6 => ChordQuality.major,
+      ChordQuality.minor6 => ChordQuality.minor,
       _ => null,
     };
   }
@@ -332,103 +332,67 @@ abstract final class ScaleDegreeClassifier {
     return mask & 0xFFF;
   }
 
-  static Set<ChordQualityToken> _allowedQualitiesForDegree(
+  static Set<ChordQuality> _allowedQualitiesForDegree(
     ScaleDegreeSource source,
     ScaleDegree d,
   ) {
     switch (source) {
       case ScaleDegreeSource.major:
         return switch (d) {
-          ScaleDegree.one => const {
-            ChordQualityToken.major,
-            ChordQualityToken.major7,
-          },
-          ScaleDegree.two => const {
-            ChordQualityToken.minor,
-            ChordQualityToken.minor7,
-          },
-          ScaleDegree.three => const {
-            ChordQualityToken.minor,
-            ChordQualityToken.minor7,
-          },
-          ScaleDegree.four => const {
-            ChordQualityToken.major,
-            ChordQualityToken.major7,
-          },
+          ScaleDegree.one => const {ChordQuality.major, ChordQuality.major7},
+          ScaleDegree.two => const {ChordQuality.minor, ChordQuality.minor7},
+          ScaleDegree.three => const {ChordQuality.minor, ChordQuality.minor7},
+          ScaleDegree.four => const {ChordQuality.major, ChordQuality.major7},
           ScaleDegree.five => const {
-            ChordQualityToken.major,
-            ChordQualityToken.dominant7,
+            ChordQuality.major,
+            ChordQuality.dominant7,
           },
-          ScaleDegree.six => const {
-            ChordQualityToken.minor,
-            ChordQualityToken.minor7,
-          },
+          ScaleDegree.six => const {ChordQuality.minor, ChordQuality.minor7},
           ScaleDegree.seven => const {
-            ChordQualityToken.diminished,
-            ChordQualityToken.halfDiminished7,
+            ChordQuality.diminished,
+            ChordQuality.halfDiminished7,
           },
         };
       case ScaleDegreeSource.naturalMinor:
         return switch (d) {
-          ScaleDegree.one => const {
-            ChordQualityToken.minor,
-            ChordQualityToken.minor7,
-          },
+          ScaleDegree.one => const {ChordQuality.minor, ChordQuality.minor7},
           ScaleDegree.two => const {
-            ChordQualityToken.diminished,
-            ChordQualityToken.halfDiminished7,
+            ChordQuality.diminished,
+            ChordQuality.halfDiminished7,
           },
-          ScaleDegree.three => const {
-            ChordQualityToken.major,
-            ChordQualityToken.major7,
-          },
-          ScaleDegree.four => const {
-            ChordQualityToken.minor,
-            ChordQualityToken.minor7,
-          },
-          ScaleDegree.five => const {
-            ChordQualityToken.minor,
-            ChordQualityToken.minor7,
-          },
-          ScaleDegree.six => const {
-            ChordQualityToken.major,
-            ChordQualityToken.major7,
-          },
+          ScaleDegree.three => const {ChordQuality.major, ChordQuality.major7},
+          ScaleDegree.four => const {ChordQuality.minor, ChordQuality.minor7},
+          ScaleDegree.five => const {ChordQuality.minor, ChordQuality.minor7},
+          ScaleDegree.six => const {ChordQuality.major, ChordQuality.major7},
           ScaleDegree.seven => const {
-            ChordQualityToken.major,
-            ChordQualityToken.dominant7,
+            ChordQuality.major,
+            ChordQuality.dominant7,
           },
         };
       case ScaleDegreeSource.harmonicMinor:
         return switch (d) {
           ScaleDegree.one => const {
-            ChordQualityToken.minor,
-            ChordQualityToken.minorMajor7,
+            ChordQuality.minor,
+            ChordQuality.minorMajor7,
           },
           ScaleDegree.two => const {
-            ChordQualityToken.diminished,
-            ChordQualityToken.halfDiminished7,
+            ChordQuality.diminished,
+            ChordQuality.halfDiminished7,
           },
           ScaleDegree.three => const {
-            ChordQualityToken.augmented,
-            ChordQualityToken.major7Sharp5,
+            ChordQuality.augmented,
+            ChordQuality.major7Sharp5,
           },
-          ScaleDegree.four => const {
-            ChordQualityToken.minor,
-            ChordQualityToken.minor7,
-          },
+          ScaleDegree.four => const {ChordQuality.minor, ChordQuality.minor7},
           ScaleDegree.five => const {
-            ChordQualityToken.major,
-            ChordQualityToken.dominant7,
-            ChordQualityToken.dominant7Sharp5,
+            ChordQuality.major,
+            ChordQuality.dominant7,
+            ChordQuality.dominant7Sharp5,
           },
-          ScaleDegree.six => const {
-            ChordQualityToken.major,
-            ChordQualityToken.major7,
-          },
+          ScaleDegree.six => const {ChordQuality.major, ChordQuality.major7},
           ScaleDegree.seven => const {
-            ChordQualityToken.diminished,
-            ChordQualityToken.diminished7,
+            ChordQuality.diminished,
+            ChordQuality.diminished7,
           },
         };
     }
@@ -469,7 +433,7 @@ abstract final class ScaleDegreeClassifier {
   static String _romanNumeralFor(
     ScaleDegree degree,
     ScaleDegreeSource source,
-    ChordQualityToken quality,
+    ChordQuality quality,
   ) {
     final base = degree.romanNumeralForSource(source);
     return romanNumeralForQuality(base, quality);

--- a/packages/whatchord/lib/src/services/scale_degree_roman_numerals.dart
+++ b/packages/whatchord/lib/src/services/scale_degree_roman_numerals.dart
@@ -2,20 +2,20 @@ import '../models/chord_identity.dart';
 
 /// Decorates a triad roman numeral [base] for a seventh-chord [quality]
 /// (e.g. "ii" + minor7 -> "ii7", halfDiminished7 -> "iiø7").
-String romanNumeralForQuality(String base, ChordQualityToken quality) {
+String romanNumeralForQuality(String base, ChordQuality quality) {
   return switch (quality) {
-    ChordQualityToken.dominant7 => '${base}7',
-    ChordQualityToken.dominant7Flat5 => '${base}7b5',
-    ChordQualityToken.dominant7Sharp5 => '${base}7#5',
-    ChordQualityToken.minorSharp5 => '$base#5',
-    ChordQualityToken.major7 => '${base}maj7',
-    ChordQualityToken.major7Flat5 => '${base}maj7b5',
-    ChordQualityToken.major7Sharp5 => '${base}maj7#5',
-    ChordQualityToken.minor7 => '${base}7',
-    ChordQualityToken.minor7Sharp5 => '${base}7#5',
-    ChordQualityToken.minorMajor7 => '$base(maj7)',
-    ChordQualityToken.halfDiminished7 => '${_withoutDiminishedSymbol(base)}ø7',
-    ChordQualityToken.diminished7 => '${base}7',
+    ChordQuality.dominant7 => '${base}7',
+    ChordQuality.dominant7Flat5 => '${base}7b5',
+    ChordQuality.dominant7Sharp5 => '${base}7#5',
+    ChordQuality.minorSharp5 => '$base#5',
+    ChordQuality.major7 => '${base}maj7',
+    ChordQuality.major7Flat5 => '${base}maj7b5',
+    ChordQuality.major7Sharp5 => '${base}maj7#5',
+    ChordQuality.minor7 => '${base}7',
+    ChordQuality.minor7Sharp5 => '${base}7#5',
+    ChordQuality.minorMajor7 => '$base(maj7)',
+    ChordQuality.halfDiminished7 => '${_withoutDiminishedSymbol(base)}ø7',
+    ChordQuality.diminished7 => '${base}7',
     _ => base,
   };
 }

--- a/packages/whatchord/lib/src/services/scale_harmonizer.dart
+++ b/packages/whatchord/lib/src/services/scale_harmonizer.dart
@@ -104,10 +104,10 @@ class ScaleDegreeHarmony {
   final String degreeLabel;
 
   /// Quality of the stacked triad on this degree.
-  final ChordQualityToken triadQuality;
+  final ChordQuality triadQuality;
 
   /// Quality of the stacked seventh chord on this degree.
-  final ChordQualityToken seventhQuality;
+  final ChordQuality seventhQuality;
 
   /// Triad roman numeral, e.g. "ii°", "♭III", "♯iv°".
   final String triadRoman;
@@ -143,7 +143,7 @@ class ScaleHarmony {
 /// canonical chord-quality sets; roman numerals are computed from each degree's
 /// deviation against the parallel major rather than from a per-scale table.
 abstract final class ScaleHarmonizer {
-  static final Map<int, ChordQualityToken> _qualityByMask = {
+  static final Map<int, ChordQuality> _qualityByMask = {
     for (final set in chordQualityIntervalSets) set.canonicalMask: set.quality,
   };
 
@@ -218,7 +218,7 @@ abstract final class ScaleHarmonizer {
     return rel < 0 ? rel + 12 : rel;
   }
 
-  static ChordQualityToken _qualityForMask(int mask, Scale scale, int index) {
+  static ChordQuality _qualityForMask(int mask, Scale scale, int index) {
     final quality = _qualityByMask[mask];
     if (quality == null) {
       throw StateError(
@@ -247,7 +247,7 @@ abstract final class ScaleHarmonizer {
     int index,
     int rootInterval,
     int thirdRel,
-    ChordQualityToken triad,
+    ChordQuality triad,
   ) {
     final prefix = _accidentalPrefix(index, rootInterval);
 
@@ -255,8 +255,8 @@ abstract final class ScaleHarmonizer {
     final base = (upper ? _upperNumerals : _lowerNumerals)[index];
 
     final decoration = switch (triad) {
-      ChordQualityToken.diminished => '°',
-      ChordQualityToken.augmented => '+',
+      ChordQuality.diminished => '°',
+      ChordQuality.augmented => '+',
       _ => '',
     };
 

--- a/packages/whatchord/lib/whatchord.dart
+++ b/packages/whatchord/lib/whatchord.dart
@@ -51,7 +51,7 @@ export 'src/formatting/models/chord_symbol.dart';
 // Formatters
 export 'src/formatting/services/chord_long_form_formatter.dart';
 export 'src/formatting/services/chord_presentation_builder.dart';
-export 'src/formatting/services/chord_quality_token_labels.dart';
+export 'src/formatting/services/chord_quality_labels.dart';
 export 'src/formatting/services/chord_spoken_name_formatter.dart';
 export 'src/formatting/services/chord_symbol_builder.dart';
 export 'src/formatting/services/harte_chord_formatter.dart';

--- a/packages/whatchord/test/chord_analyzer_golden_test.dart
+++ b/packages/whatchord/test/chord_analyzer_golden_test.dart
@@ -15,7 +15,7 @@ void main() {
       expectedSymbol: 'C',
       pcs: ['C', 'E', 'G'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
     ),
 
     golden(
@@ -23,7 +23,7 @@ void main() {
       expectedSymbol: 'Cadd9',
       pcs: ['C', 'E', 'G', 'D'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.add9},
     ),
 
@@ -32,7 +32,7 @@ void main() {
       expectedSymbol: 'Cadd#9',
       pcs: ['C', 'Eb', 'E', 'G'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.addSharp9},
       expectedToneRolesByInterval: {3: ChordToneRole.splitMinor3},
     ),
@@ -42,7 +42,7 @@ void main() {
       expectedSymbol: 'Cadd#9',
       pcs: ['C', 'Eb', 'E'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.addSharp9},
       expectedToneRolesByInterval: {3: ChordToneRole.splitMinor3},
     ),
@@ -52,7 +52,7 @@ void main() {
       expectedSymbol: 'C6add#9',
       pcs: ['C', 'Eb', 'E', 'G', 'A'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major6,
+      expectedQuality: ChordQuality.major6,
       expectedExtensions: {ChordExtension.addSharp9},
       expectedToneRolesByInterval: {3: ChordToneRole.splitMinor3},
     ),
@@ -65,7 +65,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'A',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.addSharp9},
       expectedToneRolesByInterval: {3: ChordToneRole.splitMinor3},
     ),
@@ -78,7 +78,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'A',
       expectedBass: 'C#',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.addSharp9},
       expectedToneRolesByInterval: {3: ChordToneRole.splitMinor3},
     ),
@@ -92,7 +92,7 @@ void main() {
       tonality: const Tonality(Tonic.cSharp, TonalityMode.minor),
       expectedRoot: 'C#',
       expectedBass: 'C#',
-      expectedQuality: ChordQualityToken.minorMajor7,
+      expectedQuality: ChordQuality.minorMajor7,
       expectedExtensions: {ChordExtension.flat13},
     ),
 
@@ -106,7 +106,7 @@ void main() {
       tonality: const Tonality(Tonic.f, TonalityMode.minor),
       expectedRoot: 'F',
       expectedBass: 'F',
-      expectedQuality: ChordQualityToken.minorMajor7,
+      expectedQuality: ChordQuality.minorMajor7,
       expectedExtensions: {ChordExtension.flat13},
     ),
 
@@ -116,7 +116,7 @@ void main() {
       pcs: ['C', 'Db', 'E', 'A'],
       bass: 'C',
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major6,
+      expectedQuality: ChordQuality.major6,
       expectedExtensions: {ChordExtension.flat9},
     ),
 
@@ -125,7 +125,7 @@ void main() {
       expectedSymbol: 'C7',
       pcs: ['C', 'E', 'G', 'Bb'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectNoExtensions: true,
     ),
 
@@ -134,7 +134,7 @@ void main() {
       expectedSymbol: 'C9',
       pcs: ['C', 'E', 'G', 'Bb', 'D'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -145,7 +145,7 @@ void main() {
       pcs: ['C', 'E', 'G', 'Bb', 'F'],
       bass: 'C',
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.eleven},
     ),
 
@@ -154,7 +154,7 @@ void main() {
       expectedSymbol: 'C11',
       pcs: ['C', 'E', 'G', 'Bb', 'D', 'F'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.eleven},
     ),
 
@@ -163,7 +163,7 @@ void main() {
       expectedSymbol: 'Cmaj9',
       pcs: ['C', 'E', 'G', 'B', 'D'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major7,
+      expectedQuality: ChordQuality.major7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -174,7 +174,7 @@ void main() {
       bass: 'A',
       expectedRoot: 'D',
       expectedBass: 'A',
-      expectedQuality: ChordQualityToken.major7,
+      expectedQuality: ChordQuality.major7,
       expectedExtensions: {ChordExtension.sharp9, ChordExtension.flat13},
       expectedToneRolesByInterval: {3: ChordToneRole.sharp9},
     ),
@@ -185,7 +185,7 @@ void main() {
       expectedSymbol: 'C13',
       pcs: ['C', 'E', 'G', 'Bb', 'D', 'A'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.thirteen},
     ),
 
@@ -195,7 +195,7 @@ void main() {
       expectedSymbol: 'C13#11',
       pcs: ['C', 'E', 'Bb', 'D', 'F#', 'A'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -215,7 +215,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'C',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
     ),
 
     golden(
@@ -225,7 +225,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'C',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.major6,
+      expectedQuality: ChordQuality.major6,
     ),
 
     // Doubling the bass does not make a fifthless sixth chord more complete.
@@ -237,7 +237,7 @@ void main() {
       noteCount: 4,
       expectedRoot: 'A',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.minor,
+      expectedQuality: ChordQuality.minor,
     ),
 
     // -------------------------------------------------------------------------
@@ -248,7 +248,7 @@ void main() {
       expectedSymbol: 'C7b9',
       pcs: ['C', 'E', 'G', 'Bb', 'Db'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9},
     ),
 
@@ -258,7 +258,7 @@ void main() {
       expectedAlternatives: ['C#m(maj13)/B#', 'C7(b9,b13)'],
       pcs: ['C', 'Db', 'E', 'Ab', 'Bb'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7Sharp5,
+      expectedQuality: ChordQuality.dominant7Sharp5,
       expectedExtensions: {ChordExtension.flat9},
     ),
 
@@ -272,7 +272,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'C',
       expectedBass: 'Db',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9},
     ),
 
@@ -283,7 +283,7 @@ void main() {
       pcs: ['C', 'Db', 'E', 'Bb'],
       bass: 'Bb',
       expectedRoot: 'A#',
-      expectedQuality: ChordQualityToken.diminished,
+      expectedQuality: ChordQuality.diminished,
       expectedExtensions: {ChordExtension.add9},
     ),
 
@@ -295,7 +295,7 @@ void main() {
       tonality: const Tonality(Tonic.cSharp, TonalityMode.minor),
       expectedRoot: 'Db',
       expectedBass: 'Db',
-      expectedQuality: ChordQualityToken.minorMajor7,
+      expectedQuality: ChordQuality.minorMajor7,
       expectedExtensions: {ChordExtension.thirteen},
     ),
 
@@ -307,7 +307,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'C',
       expectedBass: 'Db',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9, ChordExtension.nine},
     ),
 
@@ -317,7 +317,7 @@ void main() {
       expectedSymbol: 'G7#9',
       pcs: ['G', 'B', 'D', 'F', 'A#'],
       expectedRoot: 'G',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp9},
     ),
 
@@ -330,7 +330,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'D',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -343,7 +343,7 @@ void main() {
       bass: 'F',
       expectedRoot: 'D',
       expectedBass: 'F',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -355,7 +355,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'D',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -367,7 +367,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'D',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -376,7 +376,7 @@ void main() {
       expectedSymbol: 'C7(b9,#11)',
       pcs: ['C', 'E', 'G', 'Bb', 'Db', 'F#'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9, ChordExtension.sharp11},
     ),
 
@@ -385,7 +385,7 @@ void main() {
       expectedSymbol: 'C7(b9,#11,b13)',
       pcs: ['C', 'E', 'G', 'Bb', 'Db', 'F#', 'Ab'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.flat9,
         ChordExtension.sharp11,
@@ -401,7 +401,7 @@ void main() {
       expectedSymbol: 'C13(#9,#11)',
       pcs: ['C', 'E', 'G', 'Bb', 'D#', 'F#', 'A'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.sharp9,
         ChordExtension.sharp11,
@@ -415,7 +415,7 @@ void main() {
       expectedSymbol: 'C9sus4',
       pcs: ['C', 'F', 'G', 'Bb', 'D'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7sus4,
+      expectedQuality: ChordQuality.dominant7sus4,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -424,7 +424,7 @@ void main() {
       expectedSymbol: 'Gm/C',
       pcs: ['C', 'D', 'G', 'Bb'],
       expectedRoot: 'G',
-      expectedQuality: ChordQualityToken.minor,
+      expectedQuality: ChordQuality.minor,
     ),
 
     // Power chord: a bare fifth is named directly rather than borrowing a
@@ -434,7 +434,7 @@ void main() {
       expectedSymbol: 'C5',
       pcs: ['C', 'G'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.power,
+      expectedQuality: ChordQuality.power,
     ),
 
     golden(
@@ -444,7 +444,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'C',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.power,
+      expectedQuality: ChordQuality.power,
     ),
 
     // A sparse fifth-plus-color voicing reads as the power chord carrying that
@@ -454,7 +454,7 @@ void main() {
       expectedSymbol: 'C5addb9',
       pcs: ['C', 'Db', 'G'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.power,
+      expectedQuality: ChordQuality.power,
       expectedExtensions: {ChordExtension.addFlat9},
     ),
 
@@ -465,7 +465,7 @@ void main() {
       expectedSymbol: 'Csus2',
       pcs: ['C', 'D', 'G'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.sus2,
+      expectedQuality: ChordQuality.sus2,
     ),
 
     golden(
@@ -473,7 +473,7 @@ void main() {
       expectedSymbol: 'Cmaj7sus2',
       pcs: ['C', 'D', 'G', 'B'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major7sus2,
+      expectedQuality: ChordQuality.major7sus2,
     ),
 
     golden(
@@ -481,7 +481,7 @@ void main() {
       expectedSymbol: 'Cmaj7sus4',
       pcs: ['C', 'F', 'G', 'B'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major7sus4,
+      expectedQuality: ChordQuality.major7sus4,
     ),
 
     golden(
@@ -490,7 +490,7 @@ void main() {
       pcs: ['C', 'Db', 'Eb', 'F#', 'Ab'],
       bass: 'Db',
       expectedRoot: 'Db',
-      expectedQuality: ChordQualityToken.major7sus4,
+      expectedQuality: ChordQuality.major7sus4,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -500,7 +500,7 @@ void main() {
       expectedSymbol: 'C7#5',
       pcs: ['C', 'E', 'G#', 'Bb'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7Sharp5,
+      expectedQuality: ChordQuality.dominant7Sharp5,
       expectedToneRolesByInterval: {8: ChordToneRole.sharp5},
     ),
 
@@ -512,7 +512,7 @@ void main() {
       pcs: ['C', 'Eb', 'G#'],
       expectedRoot: 'Ab',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
     ),
 
     // The same inversion-over-minorSharp5 preference that produces F#11/A for
@@ -526,7 +526,7 @@ void main() {
       pcs: ['C', 'Eb', 'G#', 'D'],
       expectedRoot: 'Ab',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.sharp11},
       expectedToneRolesByInterval: {6: ChordToneRole.sharp11},
     ),
@@ -539,7 +539,7 @@ void main() {
       expectedSymbol: 'Abadd9/C',
       pcs: ['C', 'Eb', 'G#', 'Bb'],
       expectedRoot: 'Ab',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedToneRolesByInterval: {2: ChordToneRole.add9},
     ),
 
@@ -549,7 +549,7 @@ void main() {
       expectedSymbol: 'C7b5',
       pcs: ['C', 'E', 'Gb', 'Bb'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7Flat5,
+      expectedQuality: ChordQuality.dominant7Flat5,
       expectedToneRolesByInterval: {6: ChordToneRole.flat5},
     ),
 
@@ -559,7 +559,7 @@ void main() {
       expectedSymbol: 'Cmaj7#5',
       pcs: ['C', 'E', 'G#', 'B'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major7Sharp5,
+      expectedQuality: ChordQuality.major7Sharp5,
       expectedToneRolesByInterval: {8: ChordToneRole.sharp5},
     ),
 
@@ -569,7 +569,7 @@ void main() {
       expectedSymbol: 'Cmaj7b5',
       pcs: ['C', 'E', 'Gb', 'B'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major7Flat5,
+      expectedQuality: ChordQuality.major7Flat5,
       expectedToneRolesByInterval: {6: ChordToneRole.flat5},
     ),
 
@@ -583,7 +583,7 @@ void main() {
       expectedSymbol: 'C(b5)',
       pcs: ['C', 'E', 'Gb'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.majorFlat5,
+      expectedQuality: ChordQuality.majorFlat5,
       expectNoExtensions: true,
       expectedToneRolesByInterval: {6: ChordToneRole.flat5},
     ),
@@ -596,7 +596,7 @@ void main() {
       bass: 'Ab',
       tonality: Tonality(Tonic.aFlat, TonalityMode.major),
       expectedRoot: 'Ab',
-      expectedQuality: ChordQualityToken.majorFlat5,
+      expectedQuality: ChordQuality.majorFlat5,
       expectNoExtensions: true,
       expectedToneRolesByInterval: {6: ChordToneRole.flat5},
     ),
@@ -608,7 +608,7 @@ void main() {
       pcs: ['Ab', 'C', 'Eb', 'D'],
       bass: 'Ab',
       expectedRoot: 'Ab',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.sharp11},
     ),
 
@@ -618,7 +618,7 @@ void main() {
       expectedSymbol: 'C7(#5,#9)',
       pcs: ['C', 'E', 'G#', 'Bb', 'D#'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7Sharp5,
+      expectedQuality: ChordQuality.dominant7Sharp5,
       expectedExtensions: {ChordExtension.sharp9},
       expectedToneRolesByInterval: {8: ChordToneRole.sharp5},
     ),
@@ -629,7 +629,7 @@ void main() {
       expectedSymbol: 'C7(b5,#9)',
       pcs: ['C', 'E', 'Gb', 'Bb', 'D#'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7Flat5,
+      expectedQuality: ChordQuality.dominant7Flat5,
       expectedExtensions: {ChordExtension.sharp9},
       expectedToneRolesByInterval: {6: ChordToneRole.flat5},
     ),
@@ -642,7 +642,7 @@ void main() {
       expectedSymbol: 'Csus4',
       pcs: ['C', 'F', 'G'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.sus4,
+      expectedQuality: ChordQuality.sus4,
     ),
 
     golden(
@@ -650,7 +650,7 @@ void main() {
       expectedSymbol: 'Csus2',
       pcs: ['C', 'D', 'G'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.sus2,
+      expectedQuality: ChordQuality.sus2,
     ),
 
     golden(
@@ -658,7 +658,7 @@ void main() {
       expectedSymbol: 'Csus2sus4',
       pcs: ['C', 'D', 'F', 'G'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.sus2sus4,
+      expectedQuality: ChordQuality.sus2sus4,
       expectedToneRolesByInterval: {
         2: ChordToneRole.sus2,
         5: ChordToneRole.sus4,
@@ -673,7 +673,7 @@ void main() {
       expectedSymbol: 'C6',
       pcs: ['C', 'E', 'G', 'A'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major6,
+      expectedQuality: ChordQuality.major6,
     ),
 
     golden(
@@ -681,7 +681,7 @@ void main() {
       expectedSymbol: 'Am6',
       pcs: ['A', 'C', 'E', 'F#'],
       expectedRoot: 'A',
-      expectedQuality: ChordQualityToken.minor6,
+      expectedQuality: ChordQuality.minor6,
     ),
 
     // 6/9 sonority: represented as major6 + add9 in this system.
@@ -690,7 +690,7 @@ void main() {
       expectedSymbol: 'C6/9',
       pcs: ['C', 'E', 'G', 'A', 'D'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major6,
+      expectedQuality: ChordQuality.major6,
       expectedExtensions: {ChordExtension.add9},
     ),
 
@@ -701,7 +701,7 @@ void main() {
       expectedSymbol: 'C13',
       pcs: ['C', 'E', 'G', 'Bb', 'A'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.thirteen},
       unexpectedExtensions: {ChordExtension.add13},
     ),
@@ -714,7 +714,7 @@ void main() {
       expectedSymbol: 'Bm7(b5)',
       pcs: ['B', 'D', 'F', 'A'],
       expectedRoot: 'B',
-      expectedQuality: ChordQualityToken.halfDiminished7,
+      expectedQuality: ChordQuality.halfDiminished7,
     ),
 
     golden(
@@ -722,7 +722,7 @@ void main() {
       expectedSymbol: 'Cm9(b5)',
       pcs: ['C', 'Eb', 'Gb', 'Bb', 'D'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.halfDiminished7,
+      expectedQuality: ChordQuality.halfDiminished7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -734,7 +734,7 @@ void main() {
       expectedSymbol: 'Cdim7(add9)',
       pcs: ['C', 'Eb', 'Gb', 'A', 'D'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.diminished7,
+      expectedQuality: ChordQuality.diminished7,
       expectedExtensions: {ChordExtension.nine},
     ),
     golden(
@@ -743,7 +743,7 @@ void main() {
       pcs: ['C', 'Eb', 'Gb', 'A', 'F'],
       expectedRoot: 'F',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9},
     ),
     golden(
@@ -752,7 +752,7 @@ void main() {
       pcs: ['C', 'Eb', 'Gb', 'A', 'Ab'],
       expectedRoot: 'G#',
       expectedBass: 'B#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9},
     ),
     golden(
@@ -760,7 +760,7 @@ void main() {
       expectedSymbol: 'Cdim7(b9)',
       pcs: ['C', 'Eb', 'Gb', 'A', 'Db'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.diminished7,
+      expectedQuality: ChordQuality.diminished7,
       expectedExtensions: {ChordExtension.flat9},
     ),
 
@@ -772,7 +772,7 @@ void main() {
       expectedSymbol: 'Cm(maj7)',
       pcs: ['C', 'Eb', 'B'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.minorMajor7,
+      expectedQuality: ChordQuality.minorMajor7,
     ),
   ];
 
@@ -792,7 +792,7 @@ void main() {
         );
 
         expect(results.first.identity.rootPc, pc('F'));
-        expect(results.first.identity.quality, ChordQualityToken.dominant7);
+        expect(results.first.identity.quality, ChordQuality.dominant7);
         expect(
           results.first.identity.extensions,
           contains(ChordExtension.flat13),
@@ -807,7 +807,7 @@ void main() {
                 .having(
                   (c) => c.identity.quality,
                   'quality',
-                  ChordQualityToken.major7Sharp5,
+                  ChordQuality.major7Sharp5,
                 ),
           ),
           reason: 'Dbmaj9#5 should stay a ranked reading for bass $bass',

--- a/packages/whatchord/test/chord_analyzer_ranking_golden_test.dart
+++ b/packages/whatchord/test/chord_analyzer_ranking_golden_test.dart
@@ -15,7 +15,7 @@ void main() {
       expectedSymbol: 'C9#11',
       pcs: ['C', 'E', 'G', 'Bb', 'D', 'F#'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.sharp11},
     ),
 
@@ -26,7 +26,7 @@ void main() {
       bass: 'Bb',
       expectedRoot: 'C',
       expectedBass: 'Bb',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.sharp11},
     ),
 
@@ -35,7 +35,7 @@ void main() {
       expectedSymbol: 'C13#11',
       pcs: ['C', 'E', 'G', 'Bb', 'D', 'F#', 'A'],
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -53,7 +53,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'A',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.minor,
+      expectedQuality: ChordQuality.minor,
       expectedExtensions: {ChordExtension.sharp11},
     ),
 
@@ -66,7 +66,7 @@ void main() {
       tonality: const Tonality(Tonic.d, TonalityMode.major),
       expectedRoot: 'E',
       expectedBass: 'B',
-      expectedQuality: ChordQualityToken.minor,
+      expectedQuality: ChordQuality.minor,
     ),
 
     golden(
@@ -76,7 +76,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'Ab',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
     ),
 
     golden(
@@ -87,7 +87,7 @@ void main() {
       bass: 'Eb',
       expectedRoot: 'Ab',
       expectedBass: 'Eb',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
     ),
 
     golden(
@@ -98,7 +98,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'C',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.add9},
     ),
 
@@ -111,7 +111,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'C',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.addFlat9},
     ),
 
@@ -123,7 +123,7 @@ void main() {
       tonality: const Tonality(Tonic.cSharp, TonalityMode.major),
       expectedRoot: 'C#',
       expectedBass: 'D#',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.add9},
     ),
 
@@ -136,7 +136,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'G',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.dominant7sus4,
+      expectedQuality: ChordQuality.dominant7sus4,
     ),
 
     golden(
@@ -147,7 +147,7 @@ void main() {
       bass: 'D',
       expectedRoot: 'D',
       expectedBass: 'D',
-      expectedQuality: ChordQualityToken.dominant7sus4,
+      expectedQuality: ChordQuality.dominant7sus4,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -158,7 +158,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'C',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.dominant7sus4,
+      expectedQuality: ChordQuality.dominant7sus4,
       expectedExtensions: {ChordExtension.flat9},
     ),
 
@@ -170,7 +170,7 @@ void main() {
       bass: 'D',
       expectedRoot: 'C',
       expectedBass: 'D',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -182,7 +182,7 @@ void main() {
       bass: 'Eb',
       expectedRoot: 'C#',
       expectedBass: 'D#',
-      expectedQuality: ChordQualityToken.minorMajor7,
+      expectedQuality: ChordQuality.minorMajor7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -193,7 +193,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'C#',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.minorMajor7,
+      expectedQuality: ChordQuality.minorMajor7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -205,7 +205,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'C#',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.minorMajor7,
+      expectedQuality: ChordQuality.minorMajor7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.flat13},
     ),
 
@@ -216,7 +216,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'C',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9},
     ),
 
@@ -227,7 +227,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'C',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9},
     ),
 
@@ -240,7 +240,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'C',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9, ChordExtension.sharp9},
     ),
 
@@ -252,7 +252,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'F#',
       expectedBass: 'C#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9, ChordExtension.sharp11},
     ),
 
@@ -264,7 +264,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'C',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9, ChordExtension.sharp11},
     ),
 
@@ -277,7 +277,7 @@ void main() {
       bass: 'Bb',
       expectedRoot: 'C',
       expectedBass: 'Bb',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9, ChordExtension.sharp11},
     ),
 
@@ -289,7 +289,7 @@ void main() {
       expectedSymbol: 'Gm6',
       pcs: ['G', 'Bb', 'D', 'E'],
       expectedRoot: 'G',
-      expectedQuality: ChordQualityToken.minor6,
+      expectedQuality: ChordQuality.minor6,
     ),
 
     golden(
@@ -299,7 +299,7 @@ void main() {
       tonality: const Tonality(Tonic.a, TonalityMode.minor),
       expectedRoot: 'A',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {ChordExtension.eleven},
     ),
 
@@ -313,7 +313,7 @@ void main() {
       tonality: const Tonality(Tonic.a, TonalityMode.minor),
       expectedRoot: 'A',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
     ),
 
     // The symmetric augmented triad has three equal-cost spellings; the
@@ -327,7 +327,7 @@ void main() {
       tonality: const Tonality(Tonic.a, TonalityMode.minor),
       expectedRoot: 'C',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.augmented,
+      expectedQuality: ChordQuality.augmented,
     ),
 
     golden(
@@ -339,7 +339,7 @@ void main() {
       tonality: const Tonality(Tonic.c, TonalityMode.major),
       expectedRoot: 'D',
       expectedBass: 'A',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
     ),
 
     golden(
@@ -351,7 +351,7 @@ void main() {
       tonality: const Tonality(Tonic.c, TonalityMode.major),
       expectedRoot: 'A',
       expectedBass: 'A',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
     ),
 
     golden(
@@ -364,7 +364,7 @@ void main() {
       tonality: const Tonality(Tonic.c, TonalityMode.major),
       expectedRoot: 'A',
       expectedBass: 'A',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {ChordExtension.eleven},
     ),
 
@@ -383,7 +383,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'A',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.minor,
+      expectedQuality: ChordQuality.minor,
       expectedExtensions: {ChordExtension.add11},
     ),
 
@@ -395,7 +395,7 @@ void main() {
       tonality: const Tonality(Tonic.a, TonalityMode.minor),
       expectedRoot: 'A',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.minor,
+      expectedQuality: ChordQuality.minor,
       expectedExtensions: {ChordExtension.add11},
     ),
 
@@ -407,7 +407,7 @@ void main() {
       tonality: const Tonality(Tonic.f, TonalityMode.major),
       expectedRoot: 'D',
       expectedBass: 'A',
-      expectedQuality: ChordQualityToken.minor,
+      expectedQuality: ChordQuality.minor,
       expectedExtensions: {ChordExtension.add11},
     ),
 
@@ -420,7 +420,7 @@ void main() {
       expectedSymbol: 'Fm(maj7,#11)/Ab',
       pcs: ['Ab', 'B', 'C', 'E', 'F'],
       expectedRoot: 'F',
-      expectedQuality: ChordQualityToken.minorMajor7,
+      expectedQuality: ChordQuality.minorMajor7,
       expectedExtensions: {ChordExtension.sharp11},
     ),
 
@@ -438,7 +438,7 @@ void main() {
       bass: 'Ab',
       expectedRoot: 'F',
       expectedBass: 'G#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp9, ChordExtension.flat13},
     ),
 
@@ -450,7 +450,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'C#',
       expectedBass: 'C#',
-      expectedQuality: ChordQualityToken.major7,
+      expectedQuality: ChordQuality.major7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.flat13},
     ),
 
@@ -462,7 +462,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'F',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.flat13},
     ),
 
@@ -474,7 +474,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'Eb',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -489,7 +489,7 @@ void main() {
       bass: 'A',
       expectedRoot: 'F',
       expectedBass: 'A',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.flat13},
     ),
 
@@ -505,7 +505,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'Eb',
       expectedBass: 'Db',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -522,7 +522,7 @@ void main() {
       bass: 'Eb',
       expectedRoot: 'F',
       expectedBass: 'Eb',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9, ChordExtension.flat13},
     ),
 
@@ -535,7 +535,7 @@ void main() {
       bass: 'F#',
       expectedRoot: 'F',
       expectedBass: 'Gb',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9, ChordExtension.flat13},
     ),
 
@@ -546,7 +546,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'A',
       expectedBass: 'C#',
-      expectedQuality: ChordQualityToken.dominant7Sharp5,
+      expectedQuality: ChordQuality.dominant7Sharp5,
       expectedExtensions: {ChordExtension.sharp9},
     ),
 
@@ -558,7 +558,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'A',
       expectedBass: 'B#',
-      expectedQuality: ChordQualityToken.dominant7Sharp5,
+      expectedQuality: ChordQuality.dominant7Sharp5,
       expectedExtensions: {ChordExtension.sharp9},
     ),
 
@@ -569,7 +569,7 @@ void main() {
       bass: 'Eb',
       expectedRoot: 'C',
       expectedBass: 'D#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp9},
     ),
 
@@ -581,7 +581,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'A',
       expectedBass: 'B#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp9, ChordExtension.sharp11},
     ),
 
@@ -593,7 +593,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'A',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp9, ChordExtension.sharp11},
     ),
 
@@ -605,7 +605,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'A',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp9, ChordExtension.sharp11},
     ),
 
@@ -618,7 +618,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'A',
       expectedBass: 'B#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.sharp9,
         ChordExtension.sharp11,
@@ -634,7 +634,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'A',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.sharp9,
         ChordExtension.sharp11,
@@ -650,7 +650,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'A',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.sharp9,
         ChordExtension.sharp11,
@@ -667,7 +667,7 @@ void main() {
       bass: 'F#',
       expectedRoot: 'A',
       expectedBass: 'F#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.sharp9,
         ChordExtension.sharp11,
@@ -683,7 +683,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'F#',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.sharp9,
         ChordExtension.sharp11,
@@ -699,7 +699,7 @@ void main() {
       bass: 'A',
       expectedRoot: 'F#',
       expectedBass: 'Gx',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.sharp9,
         ChordExtension.sharp11,
@@ -715,7 +715,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'Eb',
       expectedBass: 'Db',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp9, ChordExtension.thirteen},
     ),
 
@@ -727,7 +727,7 @@ void main() {
       bass: 'F#',
       expectedRoot: 'Eb',
       expectedBass: 'F#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp9, ChordExtension.thirteen},
     ),
 
@@ -739,7 +739,7 @@ void main() {
       bass: 'Bb',
       expectedRoot: 'Eb',
       expectedBass: 'Bb',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp9, ChordExtension.thirteen},
     ),
 
@@ -750,7 +750,7 @@ void main() {
       bass: 'Bb',
       expectedRoot: 'F#',
       expectedBass: 'A#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp11, ChordExtension.flat13},
     ),
 
@@ -762,7 +762,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'F#',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.sharp11, ChordExtension.flat13},
     ),
 
@@ -774,7 +774,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'D',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.dominant7Flat5,
+      expectedQuality: ChordQuality.dominant7Flat5,
     ),
 
     // -------------------------------------------------------------------------
@@ -787,7 +787,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'C',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.add9},
     ),
 
@@ -798,7 +798,7 @@ void main() {
       pcs: ['C', 'Db', 'D', 'E', 'G'],
       bass: 'C',
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.addFlat9, ChordExtension.add9},
     ),
 
@@ -810,7 +810,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'C',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.addFlat9, ChordExtension.add9},
     ),
 
@@ -823,7 +823,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'Bb',
       expectedBass: 'Db',
-      expectedQuality: ChordQualityToken.minor,
+      expectedQuality: ChordQuality.minor,
       expectedExtensions: {ChordExtension.add9},
     ),
 
@@ -834,7 +834,7 @@ void main() {
       pcs: ['C', 'E', 'Ab', 'Bb'],
       bass: 'Ab',
       expectedRoot: 'Ab',
-      expectedQuality: ChordQualityToken.augmented,
+      expectedQuality: ChordQuality.augmented,
       expectedExtensions: {ChordExtension.add9},
     ),
 
@@ -846,7 +846,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'C',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.dominant7Sharp5,
+      expectedQuality: ChordQuality.dominant7Sharp5,
     ),
 
     golden(
@@ -856,7 +856,7 @@ void main() {
       bass: 'G',
       tonality: const Tonality(Tonic.d, TonalityMode.major),
       expectedRoot: 'G',
-      expectedQuality: ChordQualityToken.sus2sus4,
+      expectedQuality: ChordQuality.sus2sus4,
       expectedToneRolesByInterval: {
         2: ChordToneRole.sus2,
         5: ChordToneRole.sus4,
@@ -869,7 +869,7 @@ void main() {
       pcs: ['C', 'D', 'F', 'G'],
       bass: 'D',
       expectedRoot: 'D',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {ChordExtension.eleven},
     ),
 
@@ -883,7 +883,7 @@ void main() {
       bass: 'Bb',
       expectedRoot: 'C',
       expectedBass: 'Bb',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {ChordExtension.eleven},
     ),
 
@@ -893,7 +893,7 @@ void main() {
       pcs: ['C', 'Db', 'F', 'G', 'Bb'],
       bass: 'Bb',
       expectedRoot: 'Bb',
-      expectedQuality: ChordQualityToken.minor6,
+      expectedQuality: ChordQuality.minor6,
       expectedExtensions: {ChordExtension.add9},
     ),
 
@@ -905,7 +905,7 @@ void main() {
       bass: 'A',
       expectedRoot: 'C',
       expectedBass: 'A',
-      expectedQuality: ChordQualityToken.minor6,
+      expectedQuality: ChordQuality.minor6,
       expectedExtensions: {ChordExtension.flat9},
     ),
 
@@ -918,7 +918,7 @@ void main() {
       pcs: ['C', 'Db', 'Eb', 'F#', 'Ab', 'Bb'],
       bass: 'Eb',
       expectedRoot: 'Eb',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {ChordExtension.eleven, ChordExtension.thirteen},
     ),
 
@@ -933,7 +933,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'Db',
       expectedBass: 'Db',
-      expectedQuality: ChordQualityToken.major7sus4,
+      expectedQuality: ChordQuality.major7sus4,
       expectedExtensions: {ChordExtension.nine, ChordExtension.thirteen},
     ),
 
@@ -948,7 +948,7 @@ void main() {
       bass: 'Bb',
       expectedRoot: 'Eb',
       expectedBass: 'Bb',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {ChordExtension.eleven, ChordExtension.thirteen},
     ),
 
@@ -959,7 +959,7 @@ void main() {
       pcs: ['C', 'Eb', 'G', 'A', 'Bb'],
       bass: 'Eb',
       expectedRoot: 'Eb',
-      expectedQuality: ChordQualityToken.major6,
+      expectedQuality: ChordQuality.major6,
       expectedExtensions: {ChordExtension.sharp11},
     ),
 
@@ -973,7 +973,7 @@ void main() {
       bass: 'B',
       expectedRoot: 'G#',
       expectedBass: 'B',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {ChordExtension.eleven, ChordExtension.thirteen},
     ),
 
@@ -985,7 +985,7 @@ void main() {
       pcs: ['C', 'Db', 'Eb', 'F', 'G'],
       bass: 'Db',
       expectedRoot: 'Db',
-      expectedQuality: ChordQualityToken.major7,
+      expectedQuality: ChordQuality.major7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.sharp11},
       expectedToneRolesByInterval: {6: ChordToneRole.sharp11},
     ),
@@ -998,7 +998,7 @@ void main() {
       pcs: ['C', 'Db', 'F', 'G'],
       bass: 'Db',
       expectedRoot: 'Db',
-      expectedQuality: ChordQualityToken.major7,
+      expectedQuality: ChordQuality.major7,
       expectedExtensions: {ChordExtension.sharp11},
       expectedToneRolesByInterval: {6: ChordToneRole.sharp11},
     ),
@@ -1011,7 +1011,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'Ab',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.sharp11},
       expectedToneRolesByInterval: {6: ChordToneRole.sharp11},
     ),
@@ -1025,7 +1025,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'Gb',
       expectedBass: 'Db',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.sharp11},
       expectedToneRolesByInterval: {6: ChordToneRole.sharp11},
     ),
@@ -1039,7 +1039,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'Db',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.major7sus4,
+      expectedQuality: ChordQuality.major7sus4,
       expectedExtensions: {ChordExtension.thirteen},
     ),
 
@@ -1051,7 +1051,7 @@ void main() {
       bass: 'Gb',
       expectedRoot: 'Gb',
       expectedBass: 'Gb',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.sharp11, ChordExtension.add9},
     ),
 
@@ -1062,7 +1062,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'G',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.sus4,
+      expectedQuality: ChordQuality.sus4,
       expectedExtensions: {ChordExtension.sharp11},
       expectedToneRolesByInterval: {6: ChordToneRole.sharp11},
     ),
@@ -1076,7 +1076,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'A',
       expectedBass: 'C#',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.add11},
     ),
 
@@ -1088,7 +1088,7 @@ void main() {
       bass: 'D',
       expectedRoot: 'A',
       expectedBass: 'D',
-      expectedQuality: ChordQualityToken.minor,
+      expectedQuality: ChordQuality.minor,
       expectedExtensions: {ChordExtension.add11},
     ),
 
@@ -1100,7 +1100,7 @@ void main() {
       bass: 'Eb',
       expectedRoot: 'Db',
       expectedBass: 'Eb',
-      expectedQuality: ChordQualityToken.major7,
+      expectedQuality: ChordQuality.major7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -1112,7 +1112,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'Db',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.major7,
+      expectedQuality: ChordQuality.major7,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -1126,7 +1126,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'Eb',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.thirteen},
       expectedToneRolesByInterval: {9: ChordToneRole.thirteen},
     ),
@@ -1140,7 +1140,7 @@ void main() {
       bass: 'G',
       expectedRoot: 'Db',
       expectedBass: 'G',
-      expectedQuality: ChordQualityToken.major7,
+      expectedQuality: ChordQuality.major7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.sharp11},
       expectedToneRolesByInterval: {6: ChordToneRole.sharp11},
     ),
@@ -1153,7 +1153,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'Eb',
       expectedBass: 'Db',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.thirteen},
     ),
 
@@ -1166,7 +1166,7 @@ void main() {
       bass: 'Db',
       expectedRoot: 'Eb',
       expectedBass: 'Db',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.thirteen},
     ),
 
@@ -1178,7 +1178,7 @@ void main() {
       bass: 'F',
       expectedRoot: 'Eb',
       expectedBass: 'F',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.thirteen},
     ),
 
@@ -1189,7 +1189,7 @@ void main() {
       pcs: ['C', 'D', 'E', 'F#', 'Ab'],
       bass: 'D',
       expectedRoot: 'D',
-      expectedQuality: ChordQualityToken.dominant7Flat5,
+      expectedQuality: ChordQuality.dominant7Flat5,
       expectedExtensions: {ChordExtension.nine},
       expectedToneRolesByInterval: {6: ChordToneRole.flat5},
     ),
@@ -1203,7 +1203,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'D',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.dominant7Flat5,
+      expectedQuality: ChordQuality.dominant7Flat5,
       expectedExtensions: {ChordExtension.nine},
       expectedToneRolesByInterval: {6: ChordToneRole.flat5},
     ),
@@ -1214,7 +1214,7 @@ void main() {
       pcs: ['C', 'Db', 'Eb', 'F', 'G'],
       bass: 'Eb',
       expectedRoot: 'Eb',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.thirteen},
     ),
 
@@ -1225,7 +1225,7 @@ void main() {
       pcs: ['C', 'D', 'E', 'F#', 'Ab', 'Bb'],
       bass: 'C',
       expectedRoot: 'C',
-      expectedQuality: ChordQualityToken.dominant7Sharp5,
+      expectedQuality: ChordQuality.dominant7Sharp5,
       expectedExtensions: {ChordExtension.nine, ChordExtension.sharp11},
       expectedToneRolesByInterval: {8: ChordToneRole.sharp5},
     ),
@@ -1238,7 +1238,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'F#',
       expectedBass: 'B#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -1254,7 +1254,7 @@ void main() {
       bass: 'D',
       expectedRoot: 'F#',
       expectedBass: 'D',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -1270,7 +1270,7 @@ void main() {
       bass: 'Bb',
       expectedRoot: 'F#',
       expectedBass: 'A#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -1286,7 +1286,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'F#',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -1302,7 +1302,7 @@ void main() {
       bass: 'Bb',
       expectedRoot: 'F#',
       expectedBass: 'A#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -1319,7 +1319,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'C',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.flat9,
         ChordExtension.nine,
@@ -1336,7 +1336,7 @@ void main() {
       bass: 'D',
       expectedRoot: 'C',
       expectedBass: 'D',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.flat9,
         ChordExtension.nine,
@@ -1352,7 +1352,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'F#',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.flat9,
         ChordExtension.sharp11,
@@ -1368,7 +1368,7 @@ void main() {
       bass: 'Bb',
       expectedRoot: 'F#',
       expectedBass: 'A#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {
         ChordExtension.flat9,
         ChordExtension.sharp11,
@@ -1384,7 +1384,7 @@ void main() {
       bass: 'E',
       expectedRoot: 'F#',
       expectedBass: 'E',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.sharp11},
     ),
 
@@ -1396,7 +1396,7 @@ void main() {
       bass: 'Ab',
       expectedRoot: 'F#',
       expectedBass: 'G#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.sharp11},
     ),
 
@@ -1408,7 +1408,7 @@ void main() {
       bass: 'Bb',
       expectedRoot: 'F#',
       expectedBass: 'A#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.nine, ChordExtension.sharp11},
     ),
 
@@ -1421,7 +1421,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'Eb',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
       expectedExtensions: {
         ChordExtension.nine,
         ChordExtension.eleven,
@@ -1439,7 +1439,7 @@ void main() {
       tonality: const Tonality(Tonic.b, TonalityMode.minor),
       expectedRoot: 'F',
       expectedBass: 'A',
-      expectedQuality: ChordQualityToken.dominant7Flat5,
+      expectedQuality: ChordQuality.dominant7Flat5,
       expectedExtensions: {ChordExtension.nine},
     ),
 
@@ -1452,7 +1452,7 @@ void main() {
       pcs: ['C', 'Eb', 'Ab', 'Bb'],
       bass: 'Ab',
       expectedRoot: 'Ab',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
       expectedExtensions: {ChordExtension.add9},
     ),
 
@@ -1467,7 +1467,7 @@ void main() {
       bass: 'Eb',
       expectedRoot: 'Eb',
       expectedBass: 'Eb',
-      expectedQuality: ChordQualityToken.dominant7sus4,
+      expectedQuality: ChordQuality.dominant7sus4,
       expectedExtensions: {ChordExtension.thirteen},
     ),
   ];

--- a/packages/whatchord/test/chord_analyzer_spelling_golden_test.dart
+++ b/packages/whatchord/test/chord_analyzer_spelling_golden_test.dart
@@ -15,7 +15,7 @@ void main() {
       pcs: ['E#', 'G#', 'B'],
       tonality: const Tonality(Tonic.fSharp, TonalityMode.major),
       expectedRoot: 'E#',
-      expectedQuality: ChordQualityToken.diminished,
+      expectedQuality: ChordQuality.diminished,
     ),
 
     // In Cb major (7 flats), we should prefer Fb over E for the subdominant chord.
@@ -25,7 +25,7 @@ void main() {
       pcs: ['Fb', 'Ab', 'Cb'],
       tonality: const Tonality(Tonic.cFlat, TonalityMode.major),
       expectedRoot: 'Fb',
-      expectedQuality: ChordQualityToken.major,
+      expectedQuality: ChordQuality.major,
     ),
 
     // -------------------------------------------------------------------------
@@ -40,7 +40,7 @@ void main() {
       tonality: const Tonality(Tonic.d, TonalityMode.major), // sharp-leaning
       expectedRoot: 'C',
       expectedBass: 'Gb',
-      expectedQuality: ChordQualityToken.diminished,
+      expectedQuality: ChordQuality.diminished,
     ),
 
     // Complete flat-five dominant sevenths should use the core b5 quality.
@@ -51,7 +51,7 @@ void main() {
       tonality: const Tonality(Tonic.dFlat, TonalityMode.major), // flat-leaning
       expectedRoot: 'F#',
       expectedBass: 'F#',
-      expectedQuality: ChordQualityToken.dominant7Flat5,
+      expectedQuality: ChordQuality.dominant7Flat5,
     ),
 
     // Augmented triads are symmetric by pitch class, but root spelling should
@@ -63,7 +63,7 @@ void main() {
       bass: 'Ab',
       expectedRoot: 'Ab',
       expectedBass: 'Ab',
-      expectedQuality: ChordQualityToken.augmented,
+      expectedQuality: ChordQuality.augmented,
     ),
 
     // -------------------------------------------------------------------------
@@ -80,7 +80,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'A',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
     ),
 
     // A #9 in the bass would functionally spell as Cx (double sharp); prefer D.
@@ -91,7 +91,7 @@ void main() {
       bass: 'D',
       expectedRoot: 'B',
       expectedBass: 'D',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
     ),
 
     // Stacked tensions in the bass stay readable while the body names the roles.
@@ -102,7 +102,7 @@ void main() {
       bass: 'C',
       expectedRoot: 'A',
       expectedBass: 'C',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
     ),
 
     // Contrast: a genuine chord-tone inversion keeps its functional spelling
@@ -115,7 +115,7 @@ void main() {
       tonality: const Tonality(Tonic.cSharp, TonalityMode.major),
       expectedRoot: 'C#',
       expectedBass: 'B#',
-      expectedQuality: ChordQualityToken.major7,
+      expectedQuality: ChordQuality.major7,
     ),
 
     // Contrast: the major third in the bass keeps its sharp inversion spelling.
@@ -126,7 +126,7 @@ void main() {
       bass: 'A#',
       expectedRoot: 'F#',
       expectedBass: 'A#',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
     ),
   ];
 

--- a/packages/whatchord/test/chord_candidate_ranking_test.dart
+++ b/packages/whatchord/test/chord_candidate_ranking_test.dart
@@ -9,7 +9,7 @@ import 'package:whatchord/testing.dart';
 void main() {
   test('sharp-nine bass is not treated as a stable inversion', () {
     final candidate = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'Eb',
       presentIntervals: const {0, 3, 4, 7, 10},
@@ -25,7 +25,7 @@ void main() {
 
   test('generic seventh preference requires a sounding seventh', () {
     final missingSeventh = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 4, 7},
@@ -33,7 +33,7 @@ void main() {
     );
 
     final triad = _candidate(
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 4, 7},
@@ -51,7 +51,7 @@ void main() {
 
   test('complete dominant sharp-nine beats sixth flat-nine', () {
     final dominant = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'Eb',
       presentIntervals: const {0, 3, 4, 7, 10},
@@ -60,7 +60,7 @@ void main() {
     );
 
     final sixthFlat9 = _candidate(
-      quality: ChordQualityToken.major6,
+      quality: ChordQuality.major6,
       root: 'Eb',
       bass: 'Eb',
       presentIntervals: const {0, 1, 4, 7, 9},
@@ -77,7 +77,7 @@ void main() {
 
   test('complete sharp-nine sharp-eleven dominant beats split-third sixth', () {
     final dominant = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'A',
       bass: 'C',
       presentIntervals: const {0, 3, 4, 6, 7, 10},
@@ -86,7 +86,7 @@ void main() {
     );
 
     final splitThirdSixth = _candidate(
-      quality: ChordQualityToken.major6,
+      quality: ChordQuality.major6,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 1, 3, 4, 7, 9},
@@ -105,7 +105,7 @@ void main() {
     'complete thirteenth sharp-nine dominant beats colored split-third sixth',
     () {
       final dominant = _candidate(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         root: 'A',
         bass: 'C',
         presentIntervals: const {0, 3, 4, 6, 7, 9, 10},
@@ -118,7 +118,7 @@ void main() {
       );
 
       final splitThirdSixth = _candidate(
-        quality: ChordQualityToken.major6,
+        quality: ChordQuality.major6,
         root: 'C',
         bass: 'C',
         presentIntervals: const {0, 1, 3, 4, 6, 7, 9},
@@ -142,7 +142,7 @@ void main() {
     'complete flat-thirteenth sharp-nine dominant beats add-eleven split-third sixth',
     () {
       final dominant = _candidate(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         root: 'F#',
         bass: 'E',
         presentIntervals: const {0, 3, 4, 6, 7, 8, 10},
@@ -155,7 +155,7 @@ void main() {
       );
 
       final splitThirdSixth = _candidate(
-        quality: ChordQualityToken.major6,
+        quality: ChordQuality.major6,
         root: 'A',
         bass: 'E',
         presentIntervals: const {0, 1, 3, 4, 5, 7, 9},
@@ -177,7 +177,7 @@ void main() {
 
   test('complete sharp-five sharp-nine dominant beats sus flat-nine color', () {
     final dominant = _candidate(
-      quality: ChordQualityToken.dominant7Sharp5,
+      quality: ChordQuality.dominant7Sharp5,
       root: 'A',
       bass: 'C',
       presentIntervals: const {0, 3, 4, 8, 10},
@@ -186,7 +186,7 @@ void main() {
     );
 
     final susColor = _candidate(
-      quality: ChordQualityToken.sus4,
+      quality: ChordQuality.sus4,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 1, 5, 7, 9},
@@ -205,7 +205,7 @@ void main() {
     'complete flat-nine flat-thirteen dominant beats remote seventh spelling',
     () {
       final dominant = _candidate(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         root: 'F',
         bass: 'Eb',
         presentIntervals: const {0, 1, 4, 7, 8, 10},
@@ -214,7 +214,7 @@ void main() {
       );
 
       final remoteMinor = _candidate(
-        quality: ChordQualityToken.halfDiminished7,
+        quality: ChordQuality.halfDiminished7,
         root: 'D#',
         bass: 'D#',
         presentIntervals: const {0, 2, 3, 6, 9, 10},
@@ -233,7 +233,7 @@ void main() {
   test('split-nine tritone dominants follow the conventional bass role', () {
     ChordCandidate splitNine({required String bass, required double cost}) =>
         _candidate(
-          quality: ChordQualityToken.dominant7Flat5,
+          quality: ChordQuality.dominant7Flat5,
           root: 'C',
           bass: bass,
           presentIntervals: const {0, 1, 2, 4, 6, 10},
@@ -242,7 +242,7 @@ void main() {
         );
     ChordCandidate tritoneColor({required String bass, required double cost}) =>
         _candidate(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           root: 'F#',
           bass: bass,
           presentIntervals: const {0, 4, 6, 7, 8, 10},
@@ -268,7 +268,7 @@ void main() {
 
   test('complete dominant flat-nine beats colored diminished7', () {
     final dominant = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'G',
       presentIntervals: const {0, 1, 4, 7, 10},
@@ -277,7 +277,7 @@ void main() {
     );
 
     final diminished = _candidate(
-      quality: ChordQualityToken.diminished7,
+      quality: ChordQuality.diminished7,
       root: 'G',
       bass: 'G',
       presentIntervals: const {0, 3, 5, 6, 9},
@@ -296,7 +296,7 @@ void main() {
     'complete dominant flat-nine sharp-eleven beats colored diminished7',
     () {
       final dominant = _candidate(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         root: 'F#',
         bass: 'Db',
         presentIntervals: const {0, 1, 4, 6, 7, 10},
@@ -305,7 +305,7 @@ void main() {
       );
 
       final diminished = _candidate(
-        quality: ChordQualityToken.diminished7,
+        quality: ChordQuality.diminished7,
         root: 'A#',
         bass: 'Db',
         presentIntervals: const {0, 2, 3, 6, 8},
@@ -323,7 +323,7 @@ void main() {
 
   test('third-inversion dominant flat-nine does not override diminished7', () {
     final dominant = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'Bb',
       presentIntervals: const {0, 1, 4, 7, 10},
@@ -332,7 +332,7 @@ void main() {
     );
 
     final diminished = _candidate(
-      quality: ChordQualityToken.diminished7,
+      quality: ChordQuality.diminished7,
       root: 'Bb',
       bass: 'Bb',
       presentIntervals: const {0, 2, 3, 6, 9},
@@ -356,7 +356,7 @@ void main() {
 
   test('complete dominant flat-nine beats diminished add-nine', () {
     final dominant = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'E',
       presentIntervals: const {0, 1, 4, 10},
@@ -365,7 +365,7 @@ void main() {
     );
 
     final diminished = _candidate(
-      quality: ChordQualityToken.diminished,
+      quality: ChordQuality.diminished,
       root: 'A#',
       bass: 'E',
       presentIntervals: const {0, 2, 3, 6},
@@ -382,7 +382,7 @@ void main() {
 
   group('fifthless flat-nine-bass dominant ambiguity', () {
     final dominant = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'Db',
       presentIntervals: const {0, 1, 4, 10},
@@ -391,7 +391,7 @@ void main() {
     );
 
     final minorMajor7 = _candidate(
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       root: 'Db',
       bass: 'Db',
       presentIntervals: const {0, 3, 9, 11},
@@ -400,7 +400,7 @@ void main() {
     );
 
     final diminishedTriad = _candidate(
-      quality: ChordQualityToken.diminished,
+      quality: ChordQuality.diminished,
       root: 'Bb',
       bass: 'Db',
       presentIntervals: const {0, 2, 3, 6},
@@ -425,7 +425,7 @@ void main() {
       'also applies when the dominant has split flat and natural ninths',
       () {
         final splitNinthDominant = _candidate(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           root: 'C',
           bass: 'Db',
           presentIntervals: const {0, 1, 2, 4, 10},
@@ -433,7 +433,7 @@ void main() {
           cost: 1.70,
         );
         final splitNinthMinorMajor = _candidate(
-          quality: ChordQualityToken.minorMajor7,
+          quality: ChordQuality.minorMajor7,
           root: 'Db',
           bass: 'Db',
           presentIntervals: const {0, 1, 3, 9, 11},
@@ -481,7 +481,7 @@ void main() {
 
     test('does not apply when the dominant fifth is present', () {
       final completeDominant = _candidate(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         root: 'C',
         bass: 'Db',
         presentIntervals: const {0, 1, 4, 7, 10},
@@ -503,7 +503,7 @@ void main() {
 
   test('altered dominant7 beats dim7 slash outside the near-tie window', () {
     final dominant = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 1, 4, 10},
@@ -512,7 +512,7 @@ void main() {
     );
 
     final diminishedSlash = _candidate(
-      quality: ChordQualityToken.diminished7,
+      quality: ChordQuality.diminished7,
       root: 'Bb',
       bass: 'C',
       presentIntervals: const {0, 2, 3, 6, 9},
@@ -534,7 +534,7 @@ void main() {
 
   test('conventional altered seventh beats non-dominant add11 slash', () {
     final conventional = _candidate(
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       root: 'F',
       bass: 'Ab',
       presentIntervals: const {0, 3, 6, 7, 11},
@@ -543,7 +543,7 @@ void main() {
     );
 
     final add11Slash = _candidate(
-      quality: ChordQualityToken.major7Sharp5,
+      quality: ChordQuality.major7Sharp5,
       root: 'C',
       bass: 'Ab',
       presentIntervals: const {0, 4, 5, 8, 11},
@@ -562,7 +562,7 @@ void main() {
     'natural dominant color does not trigger altered seventh add11 rule',
     () {
       final naturalDominant = _candidate(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         root: 'Eb',
         bass: 'Db',
         presentIntervals: const {0, 4, 5, 9, 10},
@@ -571,7 +571,7 @@ void main() {
       );
 
       final add11Slash = _candidate(
-        quality: ChordQualityToken.major7,
+        quality: ChordQuality.major7,
         root: 'Ab',
         bass: 'Db',
         presentIntervals: const {0, 4, 5, 7, 11},
@@ -595,7 +595,7 @@ void main() {
 
   test('root-position dominant7 beats close non-dominant slash', () {
     final dominant = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 1, 4, 6, 8, 10},
@@ -608,7 +608,7 @@ void main() {
     );
 
     final remoteSlash = _candidate(
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       root: 'Db',
       bass: 'C',
       presentIntervals: const {0, 3, 7, 11},
@@ -624,7 +624,7 @@ void main() {
 
   test('root-position altered-fifth dominant beats close slash reading', () {
     final rootPosition = _candidate(
-      quality: ChordQualityToken.dominant7Flat5,
+      quality: ChordQuality.dominant7Flat5,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 3, 4, 6, 10},
@@ -633,7 +633,7 @@ void main() {
     );
 
     final slash = _candidate(
-      quality: ChordQualityToken.dominant7Flat5,
+      quality: ChordQuality.dominant7Flat5,
       root: 'F#',
       bass: 'C',
       presentIntervals: const {0, 2, 4, 6, 10},
@@ -652,7 +652,7 @@ void main() {
     'ninth altered-fifth slash can beat whole-tone root-position spelling',
     () {
       final ninthSlash = _candidate(
-        quality: ChordQualityToken.dominant7Sharp5,
+        quality: ChordQuality.dominant7Sharp5,
         root: 'E',
         bass: 'G#',
         presentIntervals: const {0, 2, 4, 8, 10},
@@ -661,7 +661,7 @@ void main() {
       );
 
       final rootPosition = _candidate(
-        quality: ChordQualityToken.dominant7Sharp5,
+        quality: ChordQuality.dominant7Sharp5,
         root: 'G#',
         bass: 'G#',
         presentIntervals: const {0, 4, 6, 8, 10},
@@ -681,7 +681,7 @@ void main() {
     'lower-cost major-seventh-bass inversion beats remote color-bass slash',
     () {
       final conventionalInversion = _candidate(
-        quality: ChordQualityToken.major7,
+        quality: ChordQuality.major7,
         root: 'Ab',
         bass: 'G',
         presentIntervals: const {0, 4, 5, 7, 8, 11},
@@ -690,7 +690,7 @@ void main() {
       );
 
       final colorBassSlash = _candidate(
-        quality: ChordQualityToken.minorMajor7,
+        quality: ChordQuality.minorMajor7,
         root: 'Db',
         bass: 'G',
         presentIntervals: const {0, 2, 3, 6, 7, 11},
@@ -710,7 +710,7 @@ void main() {
     'root-position extended dominant beats altered-fifth slash near-tie',
     () {
       final rootPosition = _candidate(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         root: 'C',
         bass: 'C',
         presentIntervals: const {0, 2, 4, 6, 7, 10},
@@ -719,7 +719,7 @@ void main() {
       );
 
       final slash = _candidate(
-        quality: ChordQualityToken.dominant7Sharp5,
+        quality: ChordQuality.dominant7Sharp5,
         root: 'D',
         bass: 'C',
         presentIntervals: const {0, 2, 4, 5, 8, 10},
@@ -739,7 +739,7 @@ void main() {
     'complete altered thirteenth dominant beats altered minor thirteenth near-tie',
     () {
       final dominant = _candidate(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         root: 'A',
         bass: 'F#',
         presentIntervals: const {0, 3, 4, 6, 7, 9, 10},
@@ -752,7 +752,7 @@ void main() {
       );
 
       final minor = _candidate(
-        quality: ChordQualityToken.minor7,
+        quality: ChordQuality.minor7,
         root: 'F#',
         bass: 'F#',
         presentIntervals: const {0, 1, 3, 6, 7, 9, 10},
@@ -776,7 +776,7 @@ void main() {
     'altered sharp-five dominant beats natural-eleventh sharp-five near-tie',
     () {
       final alteredDominant = _candidate(
-        quality: ChordQualityToken.dominant7Sharp5,
+        quality: ChordQuality.dominant7Sharp5,
         root: 'C',
         bass: 'Ab',
         presentIntervals: const {0, 1, 4, 6, 8, 10},
@@ -785,7 +785,7 @@ void main() {
       );
 
       final naturalEleventhSharpFive = _candidate(
-        quality: ChordQualityToken.dominant7Sharp5,
+        quality: ChordQuality.dominant7Sharp5,
         root: 'Ab',
         bass: 'Ab',
         presentIntervals: const {0, 2, 4, 5, 8, 10},
@@ -803,7 +803,7 @@ void main() {
 
   test('flat-nine sharp-five dominant beats remote minor-major thirteenth', () {
     final alteredDominant = _candidate(
-      quality: ChordQualityToken.dominant7Sharp5,
+      quality: ChordQuality.dominant7Sharp5,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 1, 4, 8, 10},
@@ -812,7 +812,7 @@ void main() {
     );
 
     final remoteMinorMajor = _candidate(
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       root: 'C#',
       bass: 'C',
       presentIntervals: const {0, 3, 7, 9, 11},
@@ -829,7 +829,7 @@ void main() {
 
   test('root-position dominant sus beats slash reinterpretation near-tie', () {
     final rootPositionSus = _candidate(
-      quality: ChordQualityToken.dominant7sus4,
+      quality: ChordQuality.dominant7sus4,
       root: 'D',
       bass: 'D',
       presentIntervals: const {0, 2, 5, 7, 10},
@@ -838,7 +838,7 @@ void main() {
     );
 
     final alteredSlash = _candidate(
-      quality: ChordQualityToken.minor7Sharp5,
+      quality: ChordQuality.minor7Sharp5,
       root: 'E',
       bass: 'D',
       presentIntervals: const {0, 3, 5, 8, 10},
@@ -855,7 +855,7 @@ void main() {
 
   test('major-seventh upper-structure slash beats dominant sus label', () {
     final upperStructureSlash = _candidate(
-      quality: ChordQualityToken.major7,
+      quality: ChordQuality.major7,
       root: 'Db',
       bass: 'Eb',
       presentIntervals: const {0, 2, 4, 7, 11},
@@ -864,7 +864,7 @@ void main() {
     );
 
     final rootPositionSus = _candidate(
-      quality: ChordQualityToken.dominant7sus4,
+      quality: ChordQuality.dominant7sus4,
       root: 'Eb',
       bass: 'Eb',
       presentIntervals: const {0, 2, 5, 9, 10},
@@ -881,7 +881,7 @@ void main() {
 
   test('root-position minor-eleventh shell beats inverted sus readings', () {
     final minor11Shell = _candidate(
-      quality: ChordQualityToken.minor7,
+      quality: ChordQuality.minor7,
       root: 'D',
       bass: 'D',
       presentIntervals: const {0, 3, 5, 10},
@@ -890,14 +890,14 @@ void main() {
     );
 
     final dominantSusSlash = _candidate(
-      quality: ChordQualityToken.dominant7sus4,
+      quality: ChordQuality.dominant7sus4,
       root: 'G',
       bass: 'D',
       presentIntervals: const {0, 5, 7, 10},
       cost: 2.63,
     );
     final doubleSusSlash = _candidate(
-      quality: ChordQualityToken.sus2sus4,
+      quality: ChordQuality.sus2sus4,
       root: 'C',
       bass: 'D',
       presentIntervals: const {0, 2, 5, 7},
@@ -915,7 +915,7 @@ void main() {
 
   test('ninth-bass seventh chord beats altered slash outside near-tie', () {
     final ninthBassSeventh = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'D',
       presentIntervals: const {0, 2, 4, 7, 10},
@@ -924,7 +924,7 @@ void main() {
     );
 
     final alteredSlash = _candidate(
-      quality: ChordQualityToken.minor7Sharp5,
+      quality: ChordQuality.minor7Sharp5,
       root: 'E',
       bass: 'D',
       presentIntervals: const {0, 3, 6, 8, 10},
@@ -941,7 +941,7 @@ void main() {
 
   test('minor-major ninth bass chord beats altered major7 slash', () {
     final ninthBassSeventh = _candidate(
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       root: 'C#',
       bass: 'D#',
       presentIntervals: const {0, 2, 3, 7, 11},
@@ -950,7 +950,7 @@ void main() {
     );
 
     final alteredSlash = _candidate(
-      quality: ChordQualityToken.major7Sharp5,
+      quality: ChordQuality.major7Sharp5,
       root: 'E',
       bass: 'D#',
       presentIntervals: const {0, 4, 8, 9, 11},
@@ -967,7 +967,7 @@ void main() {
 
   test('ninth-bass seventh chord does not override conventional slash', () {
     final ninthBassSeventh = _candidate(
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       root: 'C#',
       bass: 'D#',
       presentIntervals: const {0, 2, 3, 7, 11},
@@ -976,7 +976,7 @@ void main() {
     );
 
     final conventionalSlash = _candidate(
-      quality: ChordQualityToken.minor7,
+      quality: ChordQuality.minor7,
       root: 'E',
       bass: 'D#',
       presentIntervals: const {0, 3, 7, 10},
@@ -996,7 +996,7 @@ void main() {
 
   test('complete triad beats incomplete 6th in a near-tie', () {
     final completeTriad = _candidate(
-      quality: ChordQualityToken.minor,
+      quality: ChordQuality.minor,
       root: 'E',
       bass: 'B',
       presentIntervals: const {0, 3, 7},
@@ -1004,7 +1004,7 @@ void main() {
     );
 
     final incompleteSixth = _candidate(
-      quality: ChordQualityToken.major6,
+      quality: ChordQuality.major6,
       root: 'G',
       bass: 'B',
       presentIntervals: const {0, 4, 9},
@@ -1020,7 +1020,7 @@ void main() {
 
   test('complete diminished triad beats root-position fifthless minor 6th', () {
     final diminishedTriad = _candidate(
-      quality: ChordQualityToken.diminished,
+      quality: ChordQuality.diminished,
       root: 'C',
       bass: 'Eb',
       presentIntervals: const {0, 3, 6},
@@ -1028,7 +1028,7 @@ void main() {
     );
 
     final fifthlessMinorSixth = _candidate(
-      quality: ChordQualityToken.minor6,
+      quality: ChordQuality.minor6,
       root: 'Eb',
       bass: 'Eb',
       presentIntervals: const {0, 3, 9},
@@ -1044,7 +1044,7 @@ void main() {
 
   test('complete triad rule preserves root-position six-nine color', () {
     final rootSixNine = _candidate(
-      quality: ChordQualityToken.major6,
+      quality: ChordQuality.major6,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 2, 4, 9},
@@ -1053,7 +1053,7 @@ void main() {
     );
 
     final completeTriad = _candidate(
-      quality: ChordQualityToken.minor,
+      quality: ChordQuality.minor,
       root: 'A',
       bass: 'C',
       presentIntervals: const {0, 3, 5, 7},
@@ -1076,7 +1076,7 @@ void main() {
 
   group('harmonic-minor tonic versus split-third inversion', () {
     final tonicMinorMajor7 = _candidate(
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       root: 'C#',
       bass: 'C#',
       presentIntervals: const {0, 3, 8, 11},
@@ -1084,7 +1084,7 @@ void main() {
       cost: 3.84,
     );
     final splitThirdInversion = _candidate(
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       root: 'A',
       bass: 'C#',
       presentIntervals: const {0, 3, 4, 7},
@@ -1139,7 +1139,7 @@ void main() {
     // The sus reading earns a lower raw cost (clean template fit with 3
     // required tones) but is a remote, convoluted name for a simple voicing.
     final addChord = _candidate(
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 4, 5, 7},
@@ -1148,7 +1148,7 @@ void main() {
     );
 
     final susSlash = _candidate(
-      quality: ChordQualityToken.major7sus2,
+      quality: ChordQuality.major7sus2,
       root: 'F',
       bass: 'C',
       presentIntervals: const {0, 2, 7, 11},
@@ -1164,7 +1164,7 @@ void main() {
 
   test('common naming prior can resolve full near-tie cost gap', () {
     final commonMinorNinth = _candidate(
-      quality: ChordQualityToken.minor7,
+      quality: ChordQuality.minor7,
       root: 'Bb',
       bass: 'F',
       presentIntervals: const {0, 2, 3, 7, 10},
@@ -1173,7 +1173,7 @@ void main() {
     );
 
     final rarerMajorThirteenth = _candidate(
-      quality: ChordQualityToken.major7,
+      quality: ChordQuality.major7,
       root: 'Db',
       bass: 'F',
       presentIntervals: const {0, 4, 7, 9, 11},
@@ -1192,7 +1192,7 @@ void main() {
     'common naming prior does not promote sharp-five dominant over flat-five',
     () {
       final alteredFifthDominant = _candidate(
-        quality: ChordQualityToken.dominant7Sharp5,
+        quality: ChordQuality.dominant7Sharp5,
         root: 'G',
         bass: 'A',
         presentIntervals: const {0, 2, 4, 8, 10},
@@ -1201,7 +1201,7 @@ void main() {
       );
 
       final flatFiveDominant = _candidate(
-        quality: ChordQualityToken.dominant7Flat5,
+        quality: ChordQuality.dominant7Flat5,
         root: 'F',
         bass: 'A',
         presentIntervals: const {0, 2, 4, 6, 10},
@@ -1225,7 +1225,7 @@ void main() {
 
   test('clean spelling beats awkward tritone flat-five dominant inversion', () {
     final cleanSeventhBass = _candidate(
-      quality: ChordQualityToken.dominant7Flat5,
+      quality: ChordQuality.dominant7Flat5,
       root: 'D',
       bass: 'C',
       presentIntervals: const {0, 4, 6, 10},
@@ -1233,7 +1233,7 @@ void main() {
     );
 
     final awkwardThirdBass = _candidate(
-      quality: ChordQualityToken.dominant7Flat5,
+      quality: ChordQuality.dominant7Flat5,
       root: 'Ab',
       bass: 'C',
       presentIntervals: const {0, 4, 6, 10},
@@ -1249,7 +1249,7 @@ void main() {
 
   test('common naming preference breaks complete sixth and minor7 tie', () {
     final minor7 = _candidate(
-      quality: ChordQualityToken.minor7,
+      quality: ChordQuality.minor7,
       root: 'D',
       bass: 'A',
       presentIntervals: const {0, 3, 7, 10},
@@ -1257,7 +1257,7 @@ void main() {
     );
 
     final major6 = _candidate(
-      quality: ChordQualityToken.major6,
+      quality: ChordQuality.major6,
       root: 'F',
       bass: 'A',
       presentIntervals: const {0, 4, 7, 9},
@@ -1271,7 +1271,7 @@ void main() {
     // Same root, same extension load, nothing structural separates them; the
     // C#maj7 reading spells its third as E# while the minor reading uses E.
     final minorMajor = _candidate(
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       root: 'C#',
       bass: 'C#',
       presentIntervals: const {0, 1, 3, 11},
@@ -1280,7 +1280,7 @@ void main() {
     );
 
     final major7 = _candidate(
-      quality: ChordQualityToken.major7,
+      quality: ChordQuality.major7,
       root: 'C#',
       bass: 'C#',
       presentIntervals: const {0, 1, 4, 11},
@@ -1296,7 +1296,7 @@ void main() {
     // settles it toward the major6 (its #11 is natural; the minor7's add13 is
     // an add tone).
     final major6Sharp11 = _candidate(
-      quality: ChordQualityToken.major6,
+      quality: ChordQuality.major6,
       root: 'Eb',
       bass: 'Eb',
       presentIntervals: const {0, 4, 6, 7, 9},
@@ -1304,7 +1304,7 @@ void main() {
       cost: 2.92,
     );
     final minor7Add13 = _candidate(
-      quality: ChordQualityToken.minor7,
+      quality: ChordQuality.minor7,
       root: 'C',
       bass: 'Eb',
       presentIntervals: const {0, 3, 7, 9, 10},
@@ -1321,7 +1321,7 @@ void main() {
 
   test('does not use natural extensions to promote deficient slash chords', () {
     final diminishedAdd9 = _candidate(
-      quality: ChordQualityToken.diminished,
+      quality: ChordQuality.diminished,
       root: 'A#',
       bass: 'A#',
       presentIntervals: const {0, 2, 3, 6},
@@ -1330,7 +1330,7 @@ void main() {
     );
 
     final minorMajor13Slash = _candidate(
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       root: 'C#',
       bass: 'A#',
       presentIntervals: const {0, 3, 9, 11},
@@ -1343,7 +1343,7 @@ void main() {
 
   test('allows natural extensions for fifthless dominant shell slash', () {
     final dominant9Slash = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'D',
       bass: 'C',
       presentIntervals: const {0, 2, 4, 10},
@@ -1352,7 +1352,7 @@ void main() {
     );
 
     final majorFlat5Add9 = _candidate(
-      quality: ChordQualityToken.majorFlat5,
+      quality: ChordQuality.majorFlat5,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 2, 4, 6},
@@ -1371,7 +1371,7 @@ void main() {
     'full coverage does not promote altered major7 over lower-cost minor ninth shell',
     () {
       final minorNinthShell = _candidate(
-        quality: ChordQualityToken.minor7,
+        quality: ChordQuality.minor7,
         root: 'D',
         bass: 'C',
         presentIntervals: const {0, 2, 3, 10},
@@ -1380,7 +1380,7 @@ void main() {
       );
 
       final majorSeventhSplitNinth = _candidate(
-        quality: ChordQualityToken.major7,
+        quality: ChordQuality.major7,
         root: 'Db',
         bass: 'C',
         presentIntervals: const {0, 1, 3, 4, 11},
@@ -1406,7 +1406,7 @@ void main() {
     'decorated seventh reading does not promote over lower-cost dominant ninth shell',
     () {
       final dominantNinthShell = _candidate(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         root: 'D',
         bass: 'E',
         presentIntervals: const {0, 2, 4, 10},
@@ -1415,7 +1415,7 @@ void main() {
       );
 
       final alteredThirteenth = _candidate(
-        quality: ChordQualityToken.dominant7Sharp5,
+        quality: ChordQuality.dominant7Sharp5,
         root: 'E',
         bass: 'E',
         presentIntervals: const {0, 2, 8, 9, 10},
@@ -1440,14 +1440,14 @@ void main() {
 
   group('root-position relative minor7 versus major6 slash', () {
     final minor7 = _candidate(
-      quality: ChordQualityToken.minor7,
+      quality: ChordQuality.minor7,
       root: 'A',
       bass: 'A',
       presentIntervals: const {0, 3, 7, 10},
       cost: 2.63,
     );
     final major6Slash = _candidate(
-      quality: ChordQualityToken.major6,
+      quality: ChordQuality.major6,
       root: 'C',
       bass: 'A',
       presentIntervals: const {0, 4, 7, 9},
@@ -1470,7 +1470,7 @@ void main() {
 
     test('extends to matching add11 and add9 color', () {
       final coloredMinor7 = _candidate(
-        quality: ChordQualityToken.minor7,
+        quality: ChordQuality.minor7,
         root: 'A',
         bass: 'A',
         presentIntervals: const {0, 3, 5, 7, 10},
@@ -1478,7 +1478,7 @@ void main() {
         cost: 2.92,
       );
       final coloredMajor6Slash = _candidate(
-        quality: ChordQualityToken.major6,
+        quality: ChordQuality.major6,
         root: 'C',
         bass: 'A',
         presentIntervals: const {0, 2, 4, 7, 9},
@@ -1501,14 +1501,14 @@ void main() {
 
     test('does not override a root-position major6', () {
       final rootMajor6 = _candidate(
-        quality: ChordQualityToken.major6,
+        quality: ChordQuality.major6,
         root: 'C',
         bass: 'C',
         presentIntervals: const {0, 4, 7, 9},
         cost: 2.63,
       );
       final minor7Slash = _candidate(
-        quality: ChordQualityToken.minor7,
+        quality: ChordQuality.minor7,
         root: 'A',
         bass: 'C',
         presentIntervals: const {0, 3, 7, 10},
@@ -1536,7 +1536,7 @@ void main() {
       // C# has a lower raw cost but the F dominant reading is what musicians
       // expect for this voicing.
       final dom7Slash = _candidate(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         root: 'F',
         bass: 'G#',
         // intervals: root=0, sharp9=3, major3=4, perfect5=7, flat13=8, flat7=10
@@ -1546,7 +1546,7 @@ void main() {
       );
 
       final maj7Slash = _candidate(
-        quality: ChordQualityToken.major7,
+        quality: ChordQuality.major7,
         root: 'C#',
         bass: 'G#',
         // intervals: root=0, nine=2, major3=4, perfect5=7, flat13=8, major7=11
@@ -1567,7 +1567,7 @@ void main() {
     'complete add-nine triad inversion beats sparse major-thirteenth shell',
     () {
       final triadAddNine = _candidate(
-        quality: ChordQualityToken.minor,
+        quality: ChordQuality.minor,
         root: 'Bb',
         bass: 'Db',
         presentIntervals: const {0, 2, 3, 7},
@@ -1576,7 +1576,7 @@ void main() {
       );
 
       final sparseMajorThirteenth = _candidate(
-        quality: ChordQualityToken.major7,
+        quality: ChordQuality.major7,
         root: 'Db',
         bass: 'Db',
         presentIntervals: const {0, 4, 9, 11},
@@ -1596,7 +1596,7 @@ void main() {
     'root-position split-ninth add triad beats remote unusual seventh slash',
     () {
       final splitNinthTriad = _candidate(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         root: 'C',
         bass: 'C',
         presentIntervals: const {0, 1, 2, 4, 7},
@@ -1605,7 +1605,7 @@ void main() {
       );
 
       final remoteMinorSharpFive = _candidate(
-        quality: ChordQualityToken.minor7Sharp5,
+        quality: ChordQuality.minor7Sharp5,
         root: 'E',
         bass: 'C',
         presentIntervals: const {0, 3, 8, 9, 10},
@@ -1628,7 +1628,7 @@ void main() {
     // being cheaper; B beats C and C beats A on cost alone (gaps exceed the
     // near-tie window). That is a cycle: A > B > C > A.
     final a = _candidate(
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       root: 'C',
       bass: 'C',
       presentIntervals: const {0, 1, 4, 10},
@@ -1636,7 +1636,7 @@ void main() {
       cost: 10.0,
     );
     final b = _candidate(
-      quality: ChordQualityToken.diminished7,
+      quality: ChordQuality.diminished7,
       root: 'Bb',
       bass: 'C',
       presentIntervals: const {0, 2, 3, 6, 9},
@@ -1644,7 +1644,7 @@ void main() {
       cost: 1.0,
     );
     final c = _candidate(
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       root: 'E',
       bass: 'E',
       presentIntervals: const {0, 4, 7},
@@ -1710,7 +1710,7 @@ void main() {
     });
 
     ChordCandidate plain(String root, double cost) => _candidate(
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       root: root,
       bass: root,
       presentIntervals: const {0, 4, 7},
@@ -1803,7 +1803,7 @@ void _expectTieRule(
 }
 
 ChordCandidate _candidate({
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required String root,
   required String bass,
   required Set<int> presentIntervals,
@@ -1823,7 +1823,7 @@ ChordCandidate _candidate({
 }
 
 ChordIdentity _identity({
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required int rootPc,
   required int bassPc,
   required Set<int> presentIntervals,

--- a/packages/whatchord/test/chord_presentation_builder_test.dart
+++ b/packages/whatchord/test/chord_presentation_builder_test.dart
@@ -9,7 +9,7 @@ void main() {
   test('builds presentation for a diatonic triad', () {
     final identity = _identity(
       root: 'C',
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       intervals: const [0, 4, 7],
     );
 
@@ -31,7 +31,7 @@ void main() {
     final identity = _identity(
       root: 'C',
       bass: 'E',
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       intervals: const [0, 4, 7],
     );
 
@@ -50,7 +50,7 @@ void main() {
     final identity = _identity(
       root: 'C',
       bass: 'G',
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       intervals: const [0, 4, 7],
     );
 
@@ -67,7 +67,7 @@ void main() {
     final identity = _identity(
       root: 'C',
       bass: 'Bb',
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       intervals: const [0, 4, 7, 10],
     );
 
@@ -84,7 +84,7 @@ void main() {
     final identity = _identity(
       root: 'C',
       bass: 'E',
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       extensions: const {ChordExtension.nine},
       intervals: const [0, 2, 4, 7, 10],
     );
@@ -102,7 +102,7 @@ void main() {
     final identity = _identity(
       root: 'G',
       bass: 'A',
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       extensions: const {ChordExtension.add9},
       intervals: const [0, 2, 4, 7],
     );
@@ -124,7 +124,7 @@ void main() {
   test('keeps root-position add9 triads explicit', () {
     final identity = _identity(
       root: 'G',
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       extensions: const {ChordExtension.add9},
       intervals: const [0, 2, 4, 7],
     );
@@ -144,7 +144,7 @@ void main() {
     final identity = _identity(
       root: 'C',
       bass: 'D',
-      quality: ChordQualityToken.major6,
+      quality: ChordQuality.major6,
       extensions: const {ChordExtension.add9},
       intervals: const [0, 2, 4, 7, 9],
     );
@@ -168,14 +168,14 @@ void main() {
       final dominant = _identity(
         root: 'C',
         bass: 'D',
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         extensions: const {ChordExtension.nine},
         intervals: const [0, 2, 4, 7, 10],
       );
       final major = _identity(
         root: 'C',
         bass: 'D',
-        quality: ChordQualityToken.major7,
+        quality: ChordQuality.major7,
         extensions: const {ChordExtension.nine},
         intervals: const [0, 2, 4, 7, 11],
       );
@@ -209,7 +209,7 @@ void main() {
       final identity = _identity(
         root: 'A',
         bass: 'D',
-        quality: ChordQualityToken.minor7,
+        quality: ChordQuality.minor7,
         extensions: const {ChordExtension.add11},
         intervals: const [0, 3, 5, 7, 10],
       );
@@ -230,13 +230,13 @@ void main() {
   test('uses conventional long labels for root-position six-nine chords', () {
     final major = _identity(
       root: 'C',
-      quality: ChordQualityToken.major6,
+      quality: ChordQuality.major6,
       extensions: const {ChordExtension.add9},
       intervals: const [0, 2, 4, 7, 9],
     );
     final minor = _identity(
       root: 'C',
-      quality: ChordQualityToken.minor6,
+      quality: ChordQuality.minor6,
       extensions: const {ChordExtension.add9},
       intervals: const [0, 2, 3, 7, 9],
     );
@@ -262,7 +262,7 @@ void main() {
     final identity = _identity(
       root: 'G',
       bass: 'A',
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       extensions: const {ChordExtension.add9},
       intervals: const [0, 2, 4],
     );
@@ -284,7 +284,7 @@ void main() {
   test('stacks root-position seventh extensions above the core chord', () {
     final identity = _identity(
       root: 'C',
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       extensions: const {ChordExtension.nine},
       intervals: const [0, 2, 4, 7, 10],
     );
@@ -301,7 +301,7 @@ void main() {
   test('includes extension labels and altered member degrees', () {
     final identity = _identity(
       root: 'G',
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       extensions: const {ChordExtension.flat9, ChordExtension.sharp11},
       intervals: const [0, 4, 6, 7, 10, 1],
     );
@@ -334,7 +334,7 @@ void main() {
   test('promotes symbolic major seventh sus ninths into the headline', () {
     final identity = _identity(
       root: 'C',
-      quality: ChordQualityToken.major7sus4,
+      quality: ChordQuality.major7sus4,
       extensions: const {ChordExtension.nine},
       intervals: const [0, 2, 5, 7, 11],
     );
@@ -351,12 +351,12 @@ void main() {
   test('groups textual minor-major markers with other modifiers', () {
     final minorMajorSeventh = _identity(
       root: 'C',
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       intervals: const [0, 3, 7, 11],
     );
     final minorMajorNinthFlatThirteenth = _identity(
       root: 'C',
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       extensions: const {ChordExtension.nine, ChordExtension.flat13},
       intervals: const [0, 2, 3, 7, 8, 11],
     );
@@ -379,7 +379,7 @@ void main() {
   test('groups lone modifiers after dense promoted major-family labels', () {
     final majorEleventhFlatThirteenth = _identity(
       root: 'C',
-      quality: ChordQualityToken.major7,
+      quality: ChordQuality.major7,
       extensions: const {
         ChordExtension.nine,
         ChordExtension.eleven,
@@ -389,7 +389,7 @@ void main() {
     );
     final majorThirteenthSharpEleventh = _identity(
       root: 'C',
-      quality: ChordQualityToken.major7,
+      quality: ChordQuality.major7,
       extensions: const {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -399,7 +399,7 @@ void main() {
     );
     final dominantThirteenthSharpEleventh = _identity(
       root: 'C',
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       extensions: const {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -435,7 +435,7 @@ void main() {
       final identity = _identity(
         root: 'G',
         bass: 'B',
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         extensions: const {ChordExtension.flat9, ChordExtension.sharp11},
         intervals: const [0, 4, 6, 7, 10, 1],
       );
@@ -454,19 +454,19 @@ void main() {
   test('promotes seventh-family natural extensions in long labels', () {
     final dominantNinth = _identity(
       root: 'C',
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       extensions: const {ChordExtension.nine},
       intervals: const [0, 2, 4, 7, 10],
     );
     final minorEleventh = _identity(
       root: 'D',
-      quality: ChordQualityToken.minor7,
+      quality: ChordQuality.minor7,
       extensions: const {ChordExtension.nine, ChordExtension.eleven},
       intervals: const [0, 2, 3, 5, 7, 10],
     );
     final majorThirteenth = _identity(
       root: 'F',
-      quality: ChordQualityToken.major7,
+      quality: ChordQuality.major7,
       extensions: const {
         ChordExtension.nine,
         ChordExtension.eleven,
@@ -501,13 +501,13 @@ void main() {
   test('keeps added tones and alterations as long-label modifiers', () {
     final minorAddEleventh = _identity(
       root: 'D',
-      quality: ChordQualityToken.minor7,
+      quality: ChordQuality.minor7,
       extensions: const {ChordExtension.add11},
       intervals: const [0, 3, 5, 7, 10],
     );
     final dominantSharpEleventh = _identity(
       root: 'G',
-      quality: ChordQualityToken.dominant7,
+      quality: ChordQuality.dominant7,
       extensions: const {
         ChordExtension.nine,
         ChordExtension.sharp11,
@@ -535,7 +535,7 @@ void main() {
   test('returns null scale degree for non-diatonic presentation', () {
     final identity = _identity(
       root: 'Db',
-      quality: ChordQualityToken.major,
+      quality: ChordQuality.major,
       intervals: const [0, 4, 7],
     );
 
@@ -553,7 +553,7 @@ void main() {
 
 ChordIdentity _identity({
   required String root,
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required List<int> intervals,
   String? bass,
   Set<ChordExtension> extensions = const {},

--- a/packages/whatchord/test/chord_quality_intervals_test.dart
+++ b/packages/whatchord/test/chord_quality_intervals_test.dart
@@ -7,7 +7,7 @@ void main() {
   test('canonical interval definitions cover every chord quality', () {
     expect(
       chordQualityIntervalSets.map((intervals) => intervals.quality).toSet(),
-      ChordQualityToken.values.toSet(),
+      ChordQuality.values.toSet(),
     );
   });
 

--- a/packages/whatchord/test/chord_spoken_name_formatter_test.dart
+++ b/packages/whatchord/test/chord_spoken_name_formatter_test.dart
@@ -14,7 +14,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.major,
+          quality: ChordQuality.major,
           intervals: const [0, 4, 7],
         ),
       ),
@@ -24,7 +24,7 @@ void main() {
       spoken(
         _identity(
           root: 'A',
-          quality: ChordQualityToken.minor,
+          quality: ChordQuality.minor,
           intervals: const [0, 3, 7],
         ),
       ),
@@ -34,7 +34,7 @@ void main() {
       spoken(
         _identity(
           root: 'B',
-          quality: ChordQualityToken.diminished,
+          quality: ChordQuality.diminished,
           intervals: const [0, 3, 6],
         ),
       ),
@@ -44,7 +44,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.augmented,
+          quality: ChordQuality.augmented,
           intervals: const [0, 4, 8],
         ),
       ),
@@ -57,7 +57,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.sus2,
+          quality: ChordQuality.sus2,
           intervals: const [0, 2, 7],
         ),
       ),
@@ -67,7 +67,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.sus4,
+          quality: ChordQuality.sus4,
           intervals: const [0, 5, 7],
         ),
       ),
@@ -77,7 +77,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.sus2sus4,
+          quality: ChordQuality.sus2sus4,
           intervals: const [0, 2, 5, 7],
         ),
       ),
@@ -90,7 +90,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.major6,
+          quality: ChordQuality.major6,
           intervals: const [0, 4, 7, 9],
         ),
       ),
@@ -100,7 +100,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.minor6,
+          quality: ChordQuality.minor6,
           intervals: const [0, 3, 7, 9],
         ),
       ),
@@ -113,7 +113,7 @@ void main() {
       spoken(
         _identity(
           root: 'G',
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           intervals: const [0, 4, 7, 10],
         ),
       ),
@@ -126,7 +126,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.major7,
+          quality: ChordQuality.major7,
           intervals: const [0, 4, 7, 11],
         ),
       ),
@@ -136,7 +136,7 @@ void main() {
       spoken(
         _identity(
           root: 'D',
-          quality: ChordQualityToken.minor7,
+          quality: ChordQuality.minor7,
           intervals: const [0, 3, 7, 10],
         ),
       ),
@@ -146,7 +146,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.halfDiminished7,
+          quality: ChordQuality.halfDiminished7,
           intervals: const [0, 3, 6, 10],
         ),
       ),
@@ -156,7 +156,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.diminished7,
+          quality: ChordQuality.diminished7,
           intervals: const [0, 3, 6, 9],
         ),
       ),
@@ -166,7 +166,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.minorMajor7,
+          quality: ChordQuality.minorMajor7,
           intervals: const [0, 3, 7, 11],
         ),
       ),
@@ -179,7 +179,7 @@ void main() {
       spoken(
         _identity(
           root: 'G',
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           extensions: const {ChordExtension.flat9, ChordExtension.sharp11},
           intervals: const [0, 4, 6, 7, 10, 1],
         ),
@@ -195,7 +195,7 @@ void main() {
         spoken(
           _identity(
             root: 'C',
-            quality: ChordQualityToken.dominant7,
+            quality: ChordQuality.dominant7,
             extensions: const {ChordExtension.nine},
             intervals: const [0, 2, 4, 7, 10],
           ),
@@ -206,7 +206,7 @@ void main() {
         spoken(
           _identity(
             root: 'D',
-            quality: ChordQualityToken.minor7,
+            quality: ChordQuality.minor7,
             extensions: const {ChordExtension.nine, ChordExtension.eleven},
             intervals: const [0, 2, 3, 5, 7, 10],
           ),
@@ -217,7 +217,7 @@ void main() {
         spoken(
           _identity(
             root: 'F',
-            quality: ChordQualityToken.major7,
+            quality: ChordQuality.major7,
             extensions: const {
               ChordExtension.nine,
               ChordExtension.eleven,
@@ -236,7 +236,7 @@ void main() {
       spoken(
         _identity(
           root: 'G',
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           extensions: const {
             ChordExtension.nine,
             ChordExtension.sharp11,
@@ -254,7 +254,7 @@ void main() {
       spoken(
         _identity(
           root: 'G',
-          quality: ChordQualityToken.major,
+          quality: ChordQuality.major,
           extensions: const {ChordExtension.add9},
           intervals: const [0, 2, 4, 7],
         ),
@@ -265,7 +265,7 @@ void main() {
       spoken(
         _identity(
           root: 'D',
-          quality: ChordQualityToken.minor7,
+          quality: ChordQuality.minor7,
           extensions: const {ChordExtension.add11},
           intervals: const [0, 3, 5, 7, 10],
         ),
@@ -279,7 +279,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.major6,
+          quality: ChordQuality.major6,
           extensions: const {ChordExtension.add9},
           intervals: const [0, 2, 4, 7, 9],
         ),
@@ -290,7 +290,7 @@ void main() {
       spoken(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.minor6,
+          quality: ChordQuality.minor6,
           extensions: const {ChordExtension.add9},
           intervals: const [0, 2, 3, 7, 9],
         ),
@@ -305,7 +305,7 @@ void main() {
         _identity(
           root: 'C',
           bass: 'E',
-          quality: ChordQualityToken.major7,
+          quality: ChordQuality.major7,
           intervals: const [0, 4, 7, 11],
         ),
       ),
@@ -316,7 +316,7 @@ void main() {
         _identity(
           root: 'G',
           bass: 'F',
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           extensions: const {ChordExtension.flat9, ChordExtension.sharp11},
           intervals: const [0, 4, 6, 7, 10, 1],
         ),
@@ -328,7 +328,7 @@ void main() {
 
 ChordIdentity _identity({
   required String root,
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required List<int> intervals,
   String? bass,
   Set<ChordExtension> extensions = const {},

--- a/packages/whatchord/test/chord_tone_ordering_test.dart
+++ b/packages/whatchord/test/chord_tone_ordering_test.dart
@@ -7,7 +7,7 @@ void main() {
     const identity = ChordIdentity(
       rootPc: 1,
       bassPc: 7,
-      quality: ChordQualityToken.minorMajor7,
+      quality: ChordQuality.minorMajor7,
       toneRolesByInterval: {
         0: ChordToneRole.root,
         2: ChordToneRole.nine,

--- a/packages/whatchord/test/extension_options_test.dart
+++ b/packages/whatchord/test/extension_options_test.dart
@@ -9,7 +9,7 @@ void main() {
     test(
       'round-trips analyzer quality seeds through compositional controls',
       () {
-        for (final quality in ChordQualityToken.values) {
+        for (final quality in ChordQuality.values) {
           final spec = ChordSpec.fromQuality(quality);
 
           expect(spec.quality, quality, reason: quality.name);
@@ -36,7 +36,7 @@ void main() {
         expect(minor.baseQuality, BaseQuality.minor);
         expect(minor.seventhKind, SeventhKind.none);
         expect(minor.fifthAlteration, FifthAlteration.natural);
-        expect(minor.quality, ChordQualityToken.minor);
+        expect(minor.quality, ChordQuality.minor);
       },
     );
 
@@ -52,8 +52,8 @@ void main() {
         fifthAlteration: FifthAlteration.flat,
       ).quality;
 
-      expect(dominantSharpFive, ChordQualityToken.dominant7Sharp5);
-      expect(majorFlatFive, ChordQualityToken.major7Flat5);
+      expect(dominantSharpFive, ChordQuality.dominant7Sharp5);
+      expect(majorFlatFive, ChordQuality.major7Flat5);
     });
 
     test('allows sharp-five choices for minor and minor seventh qualities', () {
@@ -90,8 +90,8 @@ void main() {
         fifthAlteration: FifthAlteration.sharp,
       ).quality;
 
-      expect(minorSharpFive, ChordQualityToken.minorSharp5);
-      expect(minor7SharpFive, ChordQualityToken.minor7Sharp5);
+      expect(minorSharpFive, ChordQuality.minorSharp5);
+      expect(minor7SharpFive, ChordQuality.minor7Sharp5);
     });
 
     test('keeps augmented quality triad-only', () {
@@ -100,11 +100,9 @@ void main() {
       ]);
 
       final dominantSharpFive = ChordSpec.fromQuality(
-        ChordQualityToken.dominant7Sharp5,
+        ChordQuality.dominant7Sharp5,
       );
-      final majorSharpFive = ChordSpec.fromQuality(
-        ChordQualityToken.major7Sharp5,
-      );
+      final majorSharpFive = ChordSpec.fromQuality(ChordQuality.major7Sharp5);
 
       expect(dominantSharpFive.baseQuality, BaseQuality.major);
       expect(dominantSharpFive.seventhKind, SeventhKind.dominant7);
@@ -115,19 +113,19 @@ void main() {
     });
   });
 
-  group('buildExtensionControlGroups', () {
+  group('buildExtensionOptionGroups', () {
     test(
       'major qualities expose segmented extensions with sharp-eleventh color',
       () {
-        final groups = buildExtensionControlGroups(ChordQualityToken.major);
+        final groups = buildExtensionOptionGroups(ChordQuality.major);
 
         expect(groups.map((group) => group.label), [
           'Added tones',
           'Alterations',
         ]);
         expect(groups.map((group) => group.role), [
-          ExtensionControlRole.addedTones,
-          ExtensionControlRole.alterations,
+          ExtensionOptionRole.addedTones,
+          ExtensionOptionRole.alterations,
         ]);
         expect(groups.map((group) => group.allowsMultiple), [true, true]);
         expect(groups[0].choices.map((choice) => choice.extension), [
@@ -156,15 +154,15 @@ void main() {
     test(
       'minor qualities expose segmented add tones with sharp-eleventh color',
       () {
-        final groups = buildExtensionControlGroups(ChordQualityToken.minor);
+        final groups = buildExtensionOptionGroups(ChordQuality.minor);
 
         expect(groups.map((group) => group.label), [
           'Added tones',
           'Alterations',
         ]);
         expect(groups.map((group) => group.role), [
-          ExtensionControlRole.addedTones,
-          ExtensionControlRole.alterations,
+          ExtensionOptionRole.addedTones,
+          ExtensionOptionRole.alterations,
         ]);
         expect(groups.map((group) => group.allowsMultiple), [true, true]);
         expect(groups[0].choices.map((choice) => choice.extension), [
@@ -180,7 +178,7 @@ void main() {
     );
 
     test('augmented qualities expose sharp-eleventh color', () {
-      final groups = buildExtensionControlGroups(ChordQualityToken.augmented);
+      final groups = buildExtensionOptionGroups(ChordQuality.augmented);
 
       expect(groups.map((group) => group.label), [
         'Added tones',
@@ -198,7 +196,7 @@ void main() {
     });
 
     test('sixth qualities omit redundant add13', () {
-      final groups = buildExtensionControlGroups(ChordQualityToken.major6);
+      final groups = buildExtensionOptionGroups(ChordQuality.major6);
 
       expect(groups.map((group) => group.label), [
         'Added tones',
@@ -216,7 +214,7 @@ void main() {
     });
 
     test('seventh qualities expose a headline tier and color choices', () {
-      final groups = buildExtensionControlGroups(ChordQualityToken.dominant7);
+      final groups = buildExtensionOptionGroups(ChordQuality.dominant7);
 
       expect(groups.map((group) => group.label), [
         'Stacked extension',
@@ -224,9 +222,9 @@ void main() {
         'Alterations',
       ]);
       expect(groups.map((group) => group.role), [
-        ExtensionControlRole.highestExtension,
-        ExtensionControlRole.addedTones,
-        ExtensionControlRole.alterations,
+        ExtensionOptionRole.highestExtension,
+        ExtensionOptionRole.addedTones,
+        ExtensionOptionRole.alterations,
       ]);
       expect(groups.map((group) => group.allowsMultiple), [false, true, true]);
       expect(groups[0].choices.map((choice) => choice.extension), [
@@ -260,7 +258,7 @@ void main() {
     });
 
     test('diminished seventh omits extensions already in the chord', () {
-      final groups = buildExtensionControlGroups(ChordQualityToken.diminished7);
+      final groups = buildExtensionOptionGroups(ChordQuality.diminished7);
 
       expect(groups[0].choices.map((choice) => choice.extension), [
         null,
@@ -277,9 +275,7 @@ void main() {
     });
 
     test('suspended seventh omits the redundant natural eleventh', () {
-      final groups = buildExtensionControlGroups(
-        ChordQualityToken.dominant7sus4,
-      );
+      final groups = buildExtensionOptionGroups(ChordQuality.dominant7sus4);
 
       expect(groups.first.choices.map((choice) => choice.extension), [
         null,
@@ -300,7 +296,7 @@ void main() {
     test(
       'minor seventh qualities expose add-style natural headline labels',
       () {
-        final groups = buildExtensionControlGroups(ChordQualityToken.minor7);
+        final groups = buildExtensionOptionGroups(ChordQuality.minor7);
 
         expect(groups.first.choices.map((choice) => choice.extension), [
           null,
@@ -319,7 +315,7 @@ void main() {
 
     test('all non-seventh qualities have intentional extension choices', () {
       final expectations = {
-        ChordQualityToken.major: [
+        ChordQuality.major: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.addFlat9,
@@ -327,54 +323,51 @@ void main() {
           ChordExtension.sharp11,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.minor: [
+        ChordQuality.minor: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.addFlat9,
           ChordExtension.sharp11,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.minorSharp5: [
+        ChordQuality.minorSharp5: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.add13,
           ChordExtension.sharp11,
         ],
-        ChordQualityToken.diminished: [
+        ChordQuality.diminished: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.augmented: [
+        ChordQuality.augmented: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.add13,
           ChordExtension.addSharp9,
           ChordExtension.sharp11,
         ],
-        ChordQualityToken.sus2: [
+        ChordQuality.sus2: [
           ChordExtension.add11,
           ChordExtension.add13,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.sus4: [
+        ChordQuality.sus4: [
           ChordExtension.add9,
           ChordExtension.add13,
           ChordExtension.addFlat9,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.sus2sus4: [
-          ChordExtension.add13,
-          ChordExtension.flat13,
-        ],
-        ChordQualityToken.major6: [
+        ChordQuality.sus2sus4: [ChordExtension.add13, ChordExtension.flat13],
+        ChordQuality.major6: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.flat9,
           ChordExtension.addSharp9,
           ChordExtension.sharp11,
         ],
-        ChordQualityToken.minor6: [
+        ChordQuality.minor6: [
           ChordExtension.add9,
           ChordExtension.add11,
           ChordExtension.flat9,
@@ -383,7 +376,7 @@ void main() {
       };
 
       for (final entry in expectations.entries) {
-        final groups = buildExtensionControlGroups(entry.key);
+        final groups = buildExtensionOptionGroups(entry.key);
         final choices = [
           for (final group in groups)
             for (final choice in group.choices) choice.extension,
@@ -399,7 +392,7 @@ void main() {
 
     test('all seventh-family qualities have intentional extension choices', () {
       final expectations = {
-        ChordQualityToken.dominant7: [
+        ChordQuality.dominant7: [
           null,
           ChordExtension.nine,
           ChordExtension.eleven,
@@ -410,7 +403,7 @@ void main() {
           ChordExtension.sharp11,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.dominant7sus2: [
+        ChordQuality.dominant7sus2: [
           null,
           ChordExtension.eleven,
           ChordExtension.thirteen,
@@ -420,7 +413,7 @@ void main() {
           ChordExtension.sharp11,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.dominant7sus4: [
+        ChordQuality.dominant7sus4: [
           null,
           ChordExtension.nine,
           ChordExtension.thirteen,
@@ -429,57 +422,7 @@ void main() {
           ChordExtension.sharp11,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.dominant7Flat5: [
-          null,
-          ChordExtension.nine,
-          ChordExtension.eleven,
-          ChordExtension.thirteen,
-          ChordExtension.add11,
-          ChordExtension.flat9,
-          ChordExtension.sharp9,
-          ChordExtension.flat13,
-        ],
-        ChordQualityToken.dominant7Sharp5: [
-          null,
-          ChordExtension.nine,
-          ChordExtension.eleven,
-          ChordExtension.thirteen,
-          ChordExtension.add11,
-          ChordExtension.flat9,
-          ChordExtension.sharp9,
-          ChordExtension.sharp11,
-        ],
-        ChordQualityToken.major7: [
-          null,
-          ChordExtension.nine,
-          ChordExtension.eleven,
-          ChordExtension.thirteen,
-          ChordExtension.add11,
-          ChordExtension.flat9,
-          ChordExtension.sharp9,
-          ChordExtension.sharp11,
-          ChordExtension.flat13,
-        ],
-        ChordQualityToken.major7sus2: [
-          null,
-          ChordExtension.eleven,
-          ChordExtension.thirteen,
-          ChordExtension.add11,
-          ChordExtension.flat9,
-          ChordExtension.sharp9,
-          ChordExtension.sharp11,
-          ChordExtension.flat13,
-        ],
-        ChordQualityToken.major7sus4: [
-          null,
-          ChordExtension.nine,
-          ChordExtension.thirteen,
-          ChordExtension.flat9,
-          ChordExtension.sharp9,
-          ChordExtension.sharp11,
-          ChordExtension.flat13,
-        ],
-        ChordQualityToken.major7Flat5: [
+        ChordQuality.dominant7Flat5: [
           null,
           ChordExtension.nine,
           ChordExtension.eleven,
@@ -489,7 +432,7 @@ void main() {
           ChordExtension.sharp9,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.major7Sharp5: [
+        ChordQuality.dominant7Sharp5: [
           null,
           ChordExtension.nine,
           ChordExtension.eleven,
@@ -499,7 +442,57 @@ void main() {
           ChordExtension.sharp9,
           ChordExtension.sharp11,
         ],
-        ChordQualityToken.minor7: [
+        ChordQuality.major7: [
+          null,
+          ChordExtension.nine,
+          ChordExtension.eleven,
+          ChordExtension.thirteen,
+          ChordExtension.add11,
+          ChordExtension.flat9,
+          ChordExtension.sharp9,
+          ChordExtension.sharp11,
+          ChordExtension.flat13,
+        ],
+        ChordQuality.major7sus2: [
+          null,
+          ChordExtension.eleven,
+          ChordExtension.thirteen,
+          ChordExtension.add11,
+          ChordExtension.flat9,
+          ChordExtension.sharp9,
+          ChordExtension.sharp11,
+          ChordExtension.flat13,
+        ],
+        ChordQuality.major7sus4: [
+          null,
+          ChordExtension.nine,
+          ChordExtension.thirteen,
+          ChordExtension.flat9,
+          ChordExtension.sharp9,
+          ChordExtension.sharp11,
+          ChordExtension.flat13,
+        ],
+        ChordQuality.major7Flat5: [
+          null,
+          ChordExtension.nine,
+          ChordExtension.eleven,
+          ChordExtension.thirteen,
+          ChordExtension.add11,
+          ChordExtension.flat9,
+          ChordExtension.sharp9,
+          ChordExtension.flat13,
+        ],
+        ChordQuality.major7Sharp5: [
+          null,
+          ChordExtension.nine,
+          ChordExtension.eleven,
+          ChordExtension.thirteen,
+          ChordExtension.add11,
+          ChordExtension.flat9,
+          ChordExtension.sharp9,
+          ChordExtension.sharp11,
+        ],
+        ChordQuality.minor7: [
           null,
           ChordExtension.nine,
           ChordExtension.eleven,
@@ -509,7 +502,7 @@ void main() {
           ChordExtension.sharp11,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.minor7Sharp5: [
+        ChordQuality.minor7Sharp5: [
           null,
           ChordExtension.nine,
           ChordExtension.eleven,
@@ -518,7 +511,7 @@ void main() {
           ChordExtension.flat9,
           ChordExtension.sharp11,
         ],
-        ChordQualityToken.minorMajor7: [
+        ChordQuality.minorMajor7: [
           null,
           ChordExtension.nine,
           ChordExtension.eleven,
@@ -528,7 +521,7 @@ void main() {
           ChordExtension.sharp11,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.halfDiminished7: [
+        ChordQuality.halfDiminished7: [
           null,
           ChordExtension.nine,
           ChordExtension.eleven,
@@ -537,7 +530,7 @@ void main() {
           ChordExtension.flat9,
           ChordExtension.flat13,
         ],
-        ChordQualityToken.diminished7: [
+        ChordQuality.diminished7: [
           null,
           ChordExtension.nine,
           ChordExtension.eleven,
@@ -548,7 +541,7 @@ void main() {
       };
 
       for (final entry in expectations.entries) {
-        final groups = buildExtensionControlGroups(entry.key);
+        final groups = buildExtensionOptionGroups(entry.key);
         final choices = [
           for (final group in groups)
             for (final choice in group.choices) choice.extension,
@@ -561,34 +554,34 @@ void main() {
   group('normalizeExtensionsForQuality', () {
     test('keeps a major sharp-eleventh slash bass valid for page seeding', () {
       final normalized = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         extensions: const {ChordExtension.sharp11},
       );
       final identity = buildConstructionIdentity(
         ChordConstruction(
           rootPc: 8,
           bassPc: 2,
-          quality: ChordQualityToken.major,
+          quality: ChordQuality.major,
           extensions: normalized,
         ),
       );
 
       expect(identity.rootPc, 8);
       expect(identity.bassPc, 2);
-      expect(identity.quality, ChordQualityToken.major);
+      expect(identity.quality, ChordQuality.major);
       expect(identity.extensions, {ChordExtension.sharp11});
     });
 
     test('keeps a minor flat thirteenth when normalizing a page seed', () {
       final normalized = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.minor,
+        quality: ChordQuality.minor,
         extensions: const {ChordExtension.flat13},
       );
       final identity = buildConstructionIdentity(
         ChordConstruction(
           rootPc: 9,
           bassPc: 2,
-          quality: ChordQualityToken.minor,
+          quality: ChordQuality.minor,
           extensions: normalized,
         ),
       );
@@ -597,21 +590,21 @@ void main() {
       // Bass choices are currently limited to chord members, so the foreign
       // D bass from Amb13/D normalizes to the A root independently of flat13.
       expect(identity.bassPc, 9);
-      expect(identity.quality, ChordQualityToken.minor);
+      expect(identity.quality, ChordQuality.minor);
       expect(identity.extensions, {ChordExtension.flat13});
     });
 
     test('promotes seventh-family add ninth and thirteenth, keeping a skipped '
         'add eleventh', () {
       final ninth = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         extensions: const {ChordExtension.add9},
       );
 
       expect(ninth, {ChordExtension.nine});
 
       final skipped = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         extensions: const {ChordExtension.add11, ChordExtension.add13},
       );
 
@@ -622,7 +615,7 @@ void main() {
       'converts natural extensions to add tones for triad-like qualities',
       () {
         final normalized = normalizeExtensionsForQuality(
-          quality: ChordQualityToken.major,
+          quality: ChordQuality.major,
           extensions: const {
             ChordExtension.nine,
             ChordExtension.eleven,
@@ -641,15 +634,15 @@ void main() {
 
     test('drops triad add thirteenths that duplicate core-tone choices', () {
       final major = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         extensions: const {ChordExtension.add13, ChordExtension.thirteen},
       );
       final minor = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.minor,
+        quality: ChordQuality.minor,
         extensions: const {ChordExtension.add13, ChordExtension.thirteen},
       );
       final diminished = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.diminished,
+        quality: ChordQuality.diminished,
         extensions: const {ChordExtension.add13, ChordExtension.thirteen},
       );
 
@@ -660,23 +653,23 @@ void main() {
 
     test('preserves sharp eleventh for supported triad-like qualities', () {
       final major = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         extensions: const {ChordExtension.sharp11},
       );
       final minor = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.minor,
+        quality: ChordQuality.minor,
         extensions: const {ChordExtension.sharp11},
       );
       final major6 = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.major6,
+        quality: ChordQuality.major6,
         extensions: const {ChordExtension.sharp11},
       );
       final minor6 = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.minor6,
+        quality: ChordQuality.minor6,
         extensions: const {ChordExtension.sharp11},
       );
       final augmented = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.augmented,
+        quality: ChordQuality.augmented,
         extensions: const {ChordExtension.sharp11},
       );
 
@@ -691,15 +684,15 @@ void main() {
       'preserves added sharp ninth for split-third major-family qualities',
       () {
         final major = normalizeExtensionsForQuality(
-          quality: ChordQualityToken.major,
+          quality: ChordQuality.major,
           extensions: const {ChordExtension.addSharp9},
         );
         final major6 = normalizeExtensionsForQuality(
-          quality: ChordQualityToken.major6,
+          quality: ChordQuality.major6,
           extensions: const {ChordExtension.sharp9},
         );
         final minor = normalizeExtensionsForQuality(
-          quality: ChordQualityToken.minor,
+          quality: ChordQuality.minor,
           extensions: const {ChordExtension.addSharp9},
         );
 
@@ -711,15 +704,15 @@ void main() {
 
     test('preserves flat ninth for sixth qualities', () {
       final major6 = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.major6,
+        quality: ChordQuality.major6,
         extensions: const {ChordExtension.flat9},
       );
       final minor6 = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.minor6,
+        quality: ChordQuality.minor6,
         extensions: const {ChordExtension.flat9},
       );
       final major = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         extensions: const {ChordExtension.flat9},
       );
 
@@ -732,7 +725,7 @@ void main() {
 
     test('drops redundant thirteenth for sixth qualities', () {
       final normalized = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.major6,
+        quality: ChordQuality.major6,
         extensions: const {
           ChordExtension.add9,
           ChordExtension.add13,
@@ -745,7 +738,7 @@ void main() {
 
     test('drops add tones that duplicate suspended core tones', () {
       final sus2 = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.sus2,
+        quality: ChordQuality.sus2,
         extensions: const {
           ChordExtension.add9,
           ChordExtension.add11,
@@ -753,7 +746,7 @@ void main() {
         },
       );
       final sus4 = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.sus4,
+        quality: ChordQuality.sus4,
         extensions: const {
           ChordExtension.add9,
           ChordExtension.add11,
@@ -767,7 +760,7 @@ void main() {
 
     test('preserves supported alterations for non-seventh qualities', () {
       final normalized = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.minor,
+        quality: ChordQuality.minor,
         extensions: const {
           ChordExtension.flat9,
           ChordExtension.sharp9,
@@ -785,7 +778,7 @@ void main() {
 
     test('drops seventh-family extensions that duplicate core chord tones', () {
       final normalized = normalizeExtensionsForQuality(
-        quality: ChordQualityToken.diminished7,
+        quality: ChordQuality.diminished7,
         extensions: const {
           ChordExtension.sharp9,
           ChordExtension.sharp11,
@@ -801,10 +794,10 @@ void main() {
 
   group('selectExtensionChoice', () {
     test('selects triad-like added tones independently', () {
-      final group = buildExtensionControlGroups(ChordQualityToken.major).first;
+      final group = buildExtensionOptionGroups(ChordQuality.major).first;
 
       final withAdd9 = selectExtensionChoice(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         currentExtensions: const {},
         group: group,
         choice: group.choices[0],
@@ -813,7 +806,7 @@ void main() {
       expect(withAdd9, {ChordExtension.add9});
 
       final withAdd11 = selectExtensionChoice(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         currentExtensions: withAdd9,
         group: group,
         choice: group.choices[1],
@@ -823,12 +816,12 @@ void main() {
     });
 
     test('selects flat ninth as an added tone for major qualities', () {
-      final groups = buildExtensionControlGroups(ChordQualityToken.major);
+      final groups = buildExtensionOptionGroups(ChordQuality.major);
       final addToneGroup = groups[0];
       final colorGroup = groups[1];
 
       final withAddFlat9 = selectExtensionChoice(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         currentExtensions: const {ChordExtension.add9},
         group: colorGroup,
         choice: colorGroup.choices.firstWhere(
@@ -841,7 +834,7 @@ void main() {
       expect(withAddFlat9, {ChordExtension.addFlat9});
 
       final backToAdd9 = selectExtensionChoice(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         currentExtensions: withAddFlat9,
         group: addToneGroup,
         choice: addToneGroup.choices.firstWhere(
@@ -853,12 +846,12 @@ void main() {
     });
 
     test('replaces natural and sharp ninth choices for major qualities', () {
-      final groups = buildExtensionControlGroups(ChordQualityToken.major);
+      final groups = buildExtensionOptionGroups(ChordQuality.major);
       final addToneGroup = groups[0];
       final colorGroup = groups[1];
 
       final withSharp9 = selectExtensionChoice(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         currentExtensions: const {ChordExtension.add9},
         group: colorGroup,
         choice: colorGroup.choices.firstWhere(
@@ -869,7 +862,7 @@ void main() {
       expect(withSharp9, {ChordExtension.addSharp9});
 
       final withAdd9 = selectExtensionChoice(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         currentExtensions: withSharp9,
         group: addToneGroup,
         choice: addToneGroup.choices.firstWhere(
@@ -881,12 +874,12 @@ void main() {
     });
 
     test('replaces natural and sharp eleventh choices for major qualities', () {
-      final groups = buildExtensionControlGroups(ChordQualityToken.major);
+      final groups = buildExtensionOptionGroups(ChordQuality.major);
       final addToneGroup = groups[0];
       final colorGroup = groups[1];
 
       final withSharp11 = selectExtensionChoice(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         currentExtensions: const {ChordExtension.add11},
         group: colorGroup,
         choice: colorGroup.choices.firstWhere(
@@ -897,7 +890,7 @@ void main() {
       expect(withSharp11, {ChordExtension.sharp11});
 
       final withAdd11 = selectExtensionChoice(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         currentExtensions: withSharp11,
         group: addToneGroup,
         choice: addToneGroup.choices.firstWhere(
@@ -909,12 +902,12 @@ void main() {
     });
 
     test('replaces natural and flat thirteenth choices for sus qualities', () {
-      final groups = buildExtensionControlGroups(ChordQualityToken.sus4);
+      final groups = buildExtensionOptionGroups(ChordQuality.sus4);
       final addToneGroup = groups[0];
       final colorGroup = groups[1];
 
       final withFlat13 = selectExtensionChoice(
-        quality: ChordQualityToken.sus4,
+        quality: ChordQuality.sus4,
         currentExtensions: const {ChordExtension.add13},
         group: colorGroup,
         choice: colorGroup.choices.firstWhere(
@@ -925,7 +918,7 @@ void main() {
       expect(withFlat13, {ChordExtension.flat13});
 
       final withAdd13 = selectExtensionChoice(
-        quality: ChordQualityToken.sus4,
+        quality: ChordQuality.sus4,
         currentExtensions: withFlat13,
         group: addToneGroup,
         choice: addToneGroup.choices.firstWhere(
@@ -937,12 +930,12 @@ void main() {
     });
 
     test('toggles triad-like extension choices within their groups', () {
-      final groups = buildExtensionControlGroups(ChordQualityToken.major);
+      final groups = buildExtensionOptionGroups(ChordQuality.major);
       final addToneGroup = groups[0];
       final colorGroup = groups[1];
 
       final withoutAdd11 = selectExtensionChoice(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         currentExtensions: const {
           ChordExtension.add9,
           ChordExtension.sharp11,
@@ -957,7 +950,7 @@ void main() {
       expect(withoutAdd11, {ChordExtension.add9, ChordExtension.sharp11});
 
       final withoutSharp11 = selectExtensionChoice(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         currentExtensions: withoutAdd11,
         group: colorGroup,
         choice: colorGroup.choices.firstWhere(
@@ -969,12 +962,12 @@ void main() {
     });
 
     test('replaces natural and flat ninth choices for sixth qualities', () {
-      final groups = buildExtensionControlGroups(ChordQualityToken.minor6);
+      final groups = buildExtensionOptionGroups(ChordQuality.minor6);
       final addToneGroup = groups[0];
       final colorGroup = groups[1];
 
       final withFlat9 = selectExtensionChoice(
-        quality: ChordQualityToken.minor6,
+        quality: ChordQuality.minor6,
         currentExtensions: const {ChordExtension.add9},
         group: colorGroup,
         choice: colorGroup.choices[0],
@@ -983,7 +976,7 @@ void main() {
       expect(withFlat9, {ChordExtension.flat9});
 
       final withAdd9 = selectExtensionChoice(
-        quality: ChordQualityToken.minor6,
+        quality: ChordQuality.minor6,
         currentExtensions: withFlat9,
         group: addToneGroup,
         choice: addToneGroup.choices[0],
@@ -993,12 +986,12 @@ void main() {
     });
 
     test('replaces the seventh-family headline choice', () {
-      final headlineGroup = buildExtensionControlGroups(
-        ChordQualityToken.dominant7,
+      final headlineGroup = buildExtensionOptionGroups(
+        ChordQuality.dominant7,
       ).first;
 
       final normalized = selectExtensionChoice(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         currentExtensions: const {ChordExtension.flat9, ChordExtension.sharp11},
         group: headlineGroup,
         choice: headlineGroup.choices[3],
@@ -1014,12 +1007,12 @@ void main() {
     test(
       'promotes skipped added tones when a later headline completes them',
       () {
-        final headlineGroup = buildExtensionControlGroups(
-          ChordQualityToken.dominant7,
+        final headlineGroup = buildExtensionOptionGroups(
+          ChordQuality.dominant7,
         ).first;
 
         final withEleven = selectExtensionChoice(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           currentExtensions: const {ChordExtension.add11},
           group: headlineGroup,
           choice: headlineGroup.choices[1],
@@ -1032,15 +1025,15 @@ void main() {
     test(
       'promotes a seventh-family added eleventh when it completes a stack',
       () {
-        final headlineGroup = buildExtensionControlGroups(
-          ChordQualityToken.dominant7,
+        final headlineGroup = buildExtensionOptionGroups(
+          ChordQuality.dominant7,
         ).first;
-        final addToneGroup = buildExtensionControlGroups(
-          ChordQualityToken.dominant7,
+        final addToneGroup = buildExtensionOptionGroups(
+          ChordQuality.dominant7,
         )[1];
 
         final withNine = selectExtensionChoice(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           currentExtensions: const {},
           group: headlineGroup,
           choice: headlineGroup.choices[1],
@@ -1049,7 +1042,7 @@ void main() {
         expect(withNine, {ChordExtension.nine});
 
         final withEleven = selectExtensionChoice(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           currentExtensions: withNine,
           group: addToneGroup,
           choice: addToneGroup.choices[0],
@@ -1062,12 +1055,12 @@ void main() {
     test(
       'keeps a seventh-family added eleventh explicit when the ninth is skipped',
       () {
-        final addToneGroup = buildExtensionControlGroups(
-          ChordQualityToken.dominant7,
+        final addToneGroup = buildExtensionOptionGroups(
+          ChordQuality.dominant7,
         )[1];
 
         final withAdd11 = selectExtensionChoice(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           currentExtensions: const {},
           group: addToneGroup,
           choice: addToneGroup.choices[0],
@@ -1078,12 +1071,12 @@ void main() {
     );
 
     test('promotes a seventh-family added eleventh above an altered ninth', () {
-      final addToneGroup = buildExtensionControlGroups(
-        ChordQualityToken.dominant7,
+      final addToneGroup = buildExtensionOptionGroups(
+        ChordQuality.dominant7,
       )[1];
 
       final normalized = selectExtensionChoice(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         currentExtensions: const {ChordExtension.flat9},
         group: addToneGroup,
         choice: addToneGroup.choices[0],
@@ -1093,12 +1086,12 @@ void main() {
     });
 
     test('none clears the seventh-family headline only', () {
-      final headlineGroup = buildExtensionControlGroups(
-        ChordQualityToken.dominant7,
+      final headlineGroup = buildExtensionOptionGroups(
+        ChordQuality.dominant7,
       ).first;
 
       final normalized = selectExtensionChoice(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         currentExtensions: const {
           ChordExtension.thirteen,
           ChordExtension.sharp11,
@@ -1112,12 +1105,10 @@ void main() {
     });
 
     test('stacks altered ninth color choices', () {
-      final colorGroup = buildExtensionControlGroups(
-        ChordQualityToken.dominant7,
-      )[2];
+      final colorGroup = buildExtensionOptionGroups(ChordQuality.dominant7)[2];
 
       final normalized = selectExtensionChoice(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         currentExtensions: const {
           ChordExtension.flat9,
           ChordExtension.thirteen,
@@ -1136,12 +1127,10 @@ void main() {
     test(
       'sharp eleventh preserves the lower stack from a selected eleventh',
       () {
-        final colorGroup = buildExtensionControlGroups(
-          ChordQualityToken.minor7,
-        )[2];
+        final colorGroup = buildExtensionOptionGroups(ChordQuality.minor7)[2];
 
         final normalized = selectExtensionChoice(
-          quality: ChordQualityToken.minor7,
+          quality: ChordQuality.minor7,
           currentExtensions: const {ChordExtension.eleven},
           group: colorGroup,
           choice: colorGroup.choices.firstWhere(
@@ -1156,12 +1145,12 @@ void main() {
     test(
       'flat thirteenth preserves the lower stack from a selected thirteenth',
       () {
-        final colorGroup = buildExtensionControlGroups(
-          ChordQualityToken.dominant7,
+        final colorGroup = buildExtensionOptionGroups(
+          ChordQuality.dominant7,
         )[2];
 
         final normalized = selectExtensionChoice(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           currentExtensions: const {ChordExtension.thirteen},
           group: colorGroup,
           choice: colorGroup.choices[3],
@@ -1196,17 +1185,11 @@ void main() {
     });
 
     test('spells the chord from the chosen enharmonic root', () {
-      final flat = _example(
-        root: Tonic.dFlat,
-        quality: ChordQualityToken.major,
-      );
+      final flat = _example(root: Tonic.dFlat, quality: ChordQuality.major);
       expect(flat.presentation.symbol.toString(), 'Db');
       expect(flat.members, ['Db', 'F', 'Ab']);
 
-      final sharp = _example(
-        root: Tonic.cSharp,
-        quality: ChordQualityToken.major,
-      );
+      final sharp = _example(root: Tonic.cSharp, quality: ChordQuality.major);
       expect(sharp.presentation.symbol.toString(), 'C#');
       expect(sharp.members, ['C#', 'E#', 'G#']);
     });
@@ -1217,7 +1200,7 @@ void main() {
       final cb = _example(
         root: Tonic.cFlat,
         tonality: gbMajor,
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
       );
       expect(cb.presentation.symbol.toString(), 'Cb');
       expect(cb.presentation.scaleDegreeAnalysis?.degree, ScaleDegree.four);
@@ -1227,7 +1210,7 @@ void main() {
       final b = _example(
         root: Tonic.b,
         tonality: gbMajor,
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
       );
       expect(b.presentation.symbol.toString(), 'B');
       expect(b.presentation.scaleDegreeAnalysis, isNull);
@@ -1238,7 +1221,7 @@ void main() {
       final identity = _example(
         root: Tonic.cFlat,
         tonality: gbMajor,
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
       ).presentation.identity;
 
       // No root name: resolves to the diatonic spelling (Cb) and labels IV.
@@ -1256,7 +1239,7 @@ void main() {
 
   group('ChordExampleBuilder', () {
     test('keeps a simple seventh complete', () {
-      final example = _example(quality: ChordQualityToken.dominant7);
+      final example = _example(quality: ChordQuality.dominant7);
 
       expect(example.members, ['C', 'E', 'G', 'Bb']);
       expect(example.memberDegrees, ['1', '3', '5', 'b7']);
@@ -1264,7 +1247,7 @@ void main() {
     });
 
     test('keeps suspended triads in compact chord-tone order', () {
-      final example = _example(quality: ChordQualityToken.sus4);
+      final example = _example(quality: ChordQuality.sus4);
 
       expect(example.members, ['C', 'F', 'G']);
       expect(example.memberDegrees, ['1', '4', '5']);
@@ -1272,22 +1255,22 @@ void main() {
     });
 
     test('uses the lower octave for roots just below middle C', () {
-      final aMajor = _example(rootPc: 9, quality: ChordQualityToken.major);
-      final bMajor = _example(rootPc: 11, quality: ChordQualityToken.major);
+      final aMajor = _example(rootPc: 9, quality: ChordQuality.major);
+      final bMajor = _example(rootPc: 11, quality: ChordQuality.major);
 
       expect(aMajor.normalizedVoicing, [57, 61, 64]);
       expect(bMajor.normalizedVoicing, [59, 63, 66]);
     });
 
     test('uses the lower octave for slash bass notes just below middle C', () {
-      final example = _example(quality: ChordQualityToken.major7, bassPc: 11);
+      final example = _example(quality: ChordQuality.major7, bassPc: 11);
 
       expect(example.normalizedVoicing, [59, 60, 64, 67]);
     });
 
     test('keeps major sharp-eleventh examples literal', () {
       final example = _example(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         extensions: const {ChordExtension.sharp11},
       );
 
@@ -1299,7 +1282,7 @@ void main() {
 
     test('builds split-third add sharp-nine examples', () {
       final example = _example(
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         extensions: const {ChordExtension.addSharp9},
       );
 
@@ -1312,7 +1295,7 @@ void main() {
     test('builds minor sharp-eleventh examples', () {
       final example = _example(
         rootPc: 9,
-        quality: ChordQualityToken.minor,
+        quality: ChordQuality.minor,
         extensions: const {ChordExtension.sharp11},
       );
 
@@ -1324,7 +1307,7 @@ void main() {
 
     test('keeps augmented added-thirteenth examples literal', () {
       final example = _example(
-        quality: ChordQualityToken.augmented,
+        quality: ChordQuality.augmented,
         extensions: const {ChordExtension.add13},
       );
 
@@ -1336,7 +1319,7 @@ void main() {
 
     test('keeps minor-six added-eleventh examples literal', () {
       final example = _example(
-        quality: ChordQualityToken.minor6,
+        quality: ChordQuality.minor6,
         extensions: const {ChordExtension.add11},
       );
 
@@ -1348,11 +1331,11 @@ void main() {
 
     test('builds sixth flat-ninth examples', () {
       final major = _example(
-        quality: ChordQualityToken.major6,
+        quality: ChordQuality.major6,
         extensions: const {ChordExtension.flat9},
       );
       final minor = _example(
-        quality: ChordQualityToken.minor6,
+        quality: ChordQuality.minor6,
         extensions: const {ChordExtension.flat9},
       );
 
@@ -1371,7 +1354,7 @@ void main() {
       'does not imply redundant added ninth for sus2 add-thirteenth examples',
       () {
         final example = _example(
-          quality: ChordQualityToken.sus2,
+          quality: ChordQuality.sus2,
           extensions: const {ChordExtension.add13},
         );
 
@@ -1384,7 +1367,7 @@ void main() {
 
     test('builds a ninth with the extension above the seventh', () {
       final example = _example(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         extensions: const {ChordExtension.nine},
       );
 
@@ -1397,7 +1380,7 @@ void main() {
       'builds a dominant eleventh with implied ninth and retained fifth',
       () {
         final example = _example(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           extensions: const {ChordExtension.eleven},
         );
 
@@ -1412,7 +1395,7 @@ void main() {
       'uses implied ninth but no sharp eleventh for a dominant thirteenth example',
       () {
         final example = _example(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           extensions: const {ChordExtension.thirteen},
         );
 
@@ -1425,7 +1408,7 @@ void main() {
 
     test('uses only the selected added tone for a dominant add-eleventh', () {
       final example = _example(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         extensions: const {ChordExtension.add11},
       );
 
@@ -1439,7 +1422,7 @@ void main() {
       'uses explicit sharp-eleventh color for a dominant thirteenth sharp-eleventh',
       () {
         final example = _example(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           extensions: const {ChordExtension.sharp11, ChordExtension.thirteen},
         );
 
@@ -1452,7 +1435,7 @@ void main() {
 
     test('uses altered ninth instead of implied natural ninth', () {
       final example = _example(
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         extensions: const {ChordExtension.flat9, ChordExtension.thirteen},
       );
 
@@ -1468,7 +1451,7 @@ void main() {
         'C13#11': {ChordExtension.sharp11, ChordExtension.thirteen},
       }.entries) {
         final example = _example(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           extensions: entry.value,
         );
         final analyzed = ChordAnalyzer.analyze(
@@ -1494,7 +1477,7 @@ ChordExample _example({
   int? bassPc,
   Tonic? root,
   Tonality tonality = const Tonality(Tonic.c, TonalityMode.major),
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   Set<ChordExtension> extensions = const {},
 }) {
   var state = ChordConstruction(

--- a/packages/whatchord/test/harte_chord_formatter_test.dart
+++ b/packages/whatchord/test/harte_chord_formatter_test.dart
@@ -9,7 +9,7 @@ void main() {
       HarteChordFormatter.format(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.major,
+          quality: ChordQuality.major,
           intervals: const [0, 4, 7],
         ),
       ),
@@ -20,7 +20,7 @@ void main() {
       HarteChordFormatter.format(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.diminished7,
+          quality: ChordQuality.diminished7,
           intervals: const [0, 3, 6, 9],
         ),
       ),
@@ -31,7 +31,7 @@ void main() {
       HarteChordFormatter.format(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.minor7Sharp5,
+          quality: ChordQuality.minor7Sharp5,
           intervals: const [0, 3, 8, 10],
         ),
       ),
@@ -42,7 +42,7 @@ void main() {
   test('adds extra degrees to official shorthands', () {
     final identity = _identity(
       root: 'C',
-      quality: ChordQualityToken.major7,
+      quality: ChordQuality.major7,
       extensions: const {ChordExtension.sharp11},
       intervals: const [0, 4, 7, 11, 6],
     );
@@ -55,7 +55,7 @@ void main() {
       HarteChordFormatter.format(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.sus2,
+          quality: ChordQuality.sus2,
           intervals: const [0, 2, 7],
         ),
       ),
@@ -66,7 +66,7 @@ void main() {
       HarteChordFormatter.format(
         _identity(
           root: 'C',
-          quality: ChordQualityToken.dominant7Flat5,
+          quality: ChordQuality.dominant7Flat5,
           intervals: const [0, 4, 6, 10],
         ),
       ),
@@ -78,7 +78,7 @@ void main() {
     final identity = _identity(
       root: 'D#',
       bass: 'A#',
-      quality: ChordQualityToken.minor7,
+      quality: ChordQuality.minor7,
       extensions: const {ChordExtension.nine},
       intervals: const [0, 3, 7, 10, 2],
     );
@@ -89,7 +89,7 @@ void main() {
   test('preserves an explicit enharmonic root spelling', () {
     final identity = _identity(
       root: 'C#',
-      quality: ChordQualityToken.minor,
+      quality: ChordQuality.minor,
       intervals: const [0, 3, 7],
     );
 
@@ -100,7 +100,7 @@ void main() {
   test('keeps suspended fourth as official shorthand with extra degrees', () {
     final identity = _identity(
       root: 'Bb',
-      quality: ChordQualityToken.dominant7sus4,
+      quality: ChordQuality.dominant7sus4,
       intervals: const [0, 5, 7, 10],
     );
 
@@ -110,7 +110,7 @@ void main() {
 
 ChordIdentity _identity({
   required String root,
-  required ChordQualityToken quality,
+  required ChordQuality quality,
   required List<int> intervals,
   String? bass,
   Set<ChordExtension> extensions = const {},

--- a/packages/whatchord/test/helpers/chord_analyzer_golden_helpers.dart
+++ b/packages/whatchord/test/helpers/chord_analyzer_golden_helpers.dart
@@ -34,7 +34,7 @@ class GoldenCase {
   final String? expectedBass;
 
   /// Expected winning quality.
-  final ChordQualityToken? expectedQuality;
+  final ChordQuality? expectedQuality;
 
   /// Extensions that must appear on the winning identity.
   final Set<ChordExtension> expectedExtensions;
@@ -77,7 +77,7 @@ GoldenCase golden({
   Tonality? tonality,
   String? expectedRoot,
   String? expectedBass,
-  ChordQualityToken? expectedQuality,
+  ChordQuality? expectedQuality,
   Set<ChordExtension> expectedExtensions = const {},
   bool expectNoExtensions = false,
   Set<ChordExtension> unexpectedExtensions = const {},

--- a/packages/whatchord/test/note_display_formatter_test.dart
+++ b/packages/whatchord/test/note_display_formatter_test.dart
@@ -43,12 +43,12 @@ void main() {
     });
   });
 
-  group('theoryTokenDisplayLabel', () {
-    test('converts canonical ASCII role and quality tokens for UI', () {
-      expect(theoryTokenDisplayLabel('b9'), '♭9');
-      expect(theoryTokenDisplayLabel('#11'), '♯11');
-      expect(theoryTokenDisplayLabel('bb7'), '𝄫7');
-      expect(theoryTokenDisplayLabel('m7(b5)'), 'm7(♭5)');
+  group('toGlyphAccidentals', () {
+    test('converts canonical ASCII role and quality labels for UI', () {
+      expect(toGlyphAccidentals('b9'), '♭9');
+      expect(toGlyphAccidentals('#11'), '♯11');
+      expect(toGlyphAccidentals('bb7'), '𝄫7');
+      expect(toGlyphAccidentals('m7(b5)'), 'm7(♭5)');
     });
   });
 

--- a/packages/whatchord/test/scale_degree_golden_test.dart
+++ b/packages/whatchord/test/scale_degree_golden_test.dart
@@ -17,7 +17,7 @@ class ScaleDegreeCase {
   final String? expectedRomanNumeral;
 
   /// Sanity-checks for the winning analyzer identity.
-  final ChordQualityToken? expectedQuality;
+  final ChordQuality? expectedQuality;
   final Set<ChordExtension> expectedExtensions;
 
   const ScaleDegreeCase({
@@ -43,7 +43,7 @@ ScaleDegreeCase deg({
   required ScaleDegree? expected,
   ScaleDegreeSource? expectedSource,
   String? expectedRomanNumeral,
-  ChordQualityToken? expectedQuality,
+  ChordQuality? expectedQuality,
   Set<ChordExtension> expectedExtensions = const {},
 }) {
   return ScaleDegreeCase(
@@ -88,7 +88,7 @@ void main() {
       description: 'major tonic seventh',
       pcs: ['C', 'E', 'G', 'B'],
       expected: ScaleDegree.one,
-      expectedQuality: ChordQualityToken.major7,
+      expectedQuality: ChordQuality.major7,
     ),
     deg(
       description: 'supertonic minor triad',
@@ -99,20 +99,20 @@ void main() {
       description: 'supertonic minor seventh',
       pcs: ['D', 'F', 'A', 'C'],
       expected: ScaleDegree.two,
-      expectedQuality: ChordQualityToken.minor7,
+      expectedQuality: ChordQuality.minor7,
     ),
     deg(
       description: 'dominant seventh',
       pcs: ['G', 'B', 'D', 'F'],
       expected: ScaleDegree.five,
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
     ),
     deg(
       description: 'leading-tone half-diminished seventh',
       pcs: ['B', 'D', 'F', 'A'],
       expected: ScaleDegree.seven,
       expectedRomanNumeral: 'viiø7',
-      expectedQuality: ChordQualityToken.halfDiminished7,
+      expectedQuality: ChordQuality.halfDiminished7,
     ),
 
     // -------------------------
@@ -124,7 +124,7 @@ void main() {
       description: 'suspended chord has no strict degree',
       pcs: ['C', 'F', 'G'],
       expected: null,
-      expectedQuality: ChordQualityToken.sus4,
+      expectedQuality: ChordQuality.sus4,
     ),
 
     // Altered dominants are non-diatonic under natural major/minor strictness.
@@ -132,7 +132,7 @@ void main() {
       description: 'chromatic altered dominant has no strict major degree',
       pcs: ['C', 'E', 'G', 'Bb', 'Db'],
       expected: null,
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9},
     ),
 
@@ -141,14 +141,14 @@ void main() {
       description: 'diatonic added-sixth tonic',
       pcs: ['C', 'E', 'G', 'A'],
       expected: ScaleDegree.one,
-      expectedQuality: ChordQualityToken.major6,
+      expectedQuality: ChordQuality.major6,
     ),
     deg(
       description: 'non-diatonic minor sixth has no strict major degree',
       pcs: ['A', 'C', 'E', 'F#'],
       expected: null,
       // The analyzer still returns Am6; the classifier rejects the degree.
-      expectedQuality: ChordQualityToken.minor6,
+      expectedQuality: ChordQuality.minor6,
     ),
 
     // Diminished7 is not diatonic in C major natural scale.
@@ -193,7 +193,7 @@ void main() {
       expected: ScaleDegree.five,
       expectedSource: ScaleDegreeSource.harmonicMinor,
       expectedRomanNumeral: 'V7',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
     ),
     deg(
       description: 'harmonic-minor dominant flat ninth',
@@ -202,7 +202,7 @@ void main() {
       expected: ScaleDegree.five,
       expectedSource: ScaleDegreeSource.harmonicMinor,
       expectedRomanNumeral: 'V7',
-      expectedQuality: ChordQualityToken.dominant7,
+      expectedQuality: ChordQuality.dominant7,
       expectedExtensions: {ChordExtension.flat9},
     ),
     deg(
@@ -212,7 +212,7 @@ void main() {
       expected: ScaleDegree.five,
       expectedSource: ScaleDegreeSource.harmonicMinor,
       expectedRomanNumeral: 'V7#5',
-      expectedQuality: ChordQualityToken.dominant7Sharp5,
+      expectedQuality: ChordQuality.dominant7Sharp5,
     ),
     deg(
       description: 'natural-minor flat seventh dominant seventh',
@@ -237,7 +237,7 @@ void main() {
       expected: ScaleDegree.seven,
       expectedSource: ScaleDegreeSource.harmonicMinor,
       expectedRomanNumeral: 'vii°7',
-      expectedQuality: ChordQualityToken.diminished7,
+      expectedQuality: ChordQuality.diminished7,
     ),
     deg(
       description: 'harmonic-minor augmented mediant',
@@ -246,7 +246,7 @@ void main() {
       expected: ScaleDegree.three,
       expectedSource: ScaleDegreeSource.harmonicMinor,
       expectedRomanNumeral: '♭III+',
-      expectedQuality: ChordQualityToken.augmented,
+      expectedQuality: ChordQuality.augmented,
     ),
     deg(
       description: 'harmonic-minor augmented mediant seventh',
@@ -255,7 +255,7 @@ void main() {
       expected: ScaleDegree.three,
       expectedSource: ScaleDegreeSource.harmonicMinor,
       expectedRomanNumeral: '♭III+maj7#5',
-      expectedQuality: ChordQualityToken.major7Sharp5,
+      expectedQuality: ChordQuality.major7Sharp5,
     ),
     deg(
       description: 'harmonic-minor tonic major seventh',
@@ -264,7 +264,7 @@ void main() {
       expected: ScaleDegree.one,
       expectedSource: ScaleDegreeSource.harmonicMinor,
       expectedRomanNumeral: 'i(maj7)',
-      expectedQuality: ChordQualityToken.minorMajor7,
+      expectedQuality: ChordQuality.minorMajor7,
     ),
   ];
 

--- a/packages/whatchord/test/scale_degree_roman_numerals_test.dart
+++ b/packages/whatchord/test/scale_degree_roman_numerals_test.dart
@@ -5,28 +5,22 @@ import 'package:whatchord/whatchord.dart';
 void main() {
   group('romanNumeralForQuality', () {
     test('adds seventh-family suffixes to an existing roman base', () {
-      expect(romanNumeralForQuality('V', ChordQualityToken.dominant7), 'V7');
-      expect(
-        romanNumeralForQuality('V', ChordQualityToken.dominant7Sharp5),
-        'V7#5',
-      );
-      expect(romanNumeralForQuality('I', ChordQualityToken.major7), 'Imaj7');
-      expect(
-        romanNumeralForQuality('i', ChordQualityToken.minorMajor7),
-        'i(maj7)',
-      );
+      expect(romanNumeralForQuality('V', ChordQuality.dominant7), 'V7');
+      expect(romanNumeralForQuality('V', ChordQuality.dominant7Sharp5), 'V7#5');
+      expect(romanNumeralForQuality('I', ChordQuality.major7), 'Imaj7');
+      expect(romanNumeralForQuality('i', ChordQuality.minorMajor7), 'i(maj7)');
     });
 
     test('replaces diminished triad mark with half-diminished symbol', () {
       expect(
-        romanNumeralForQuality('vii°', ChordQualityToken.halfDiminished7),
+        romanNumeralForQuality('vii°', ChordQuality.halfDiminished7),
         'viiø7',
       );
     });
 
     test('keeps unsupported qualities on the base roman numeral', () {
-      expect(romanNumeralForQuality('I', ChordQualityToken.major), 'I');
-      expect(romanNumeralForQuality('i', ChordQualityToken.minorSharp5), 'i#5');
+      expect(romanNumeralForQuality('I', ChordQuality.major), 'I');
+      expect(romanNumeralForQuality('i', ChordQuality.minorSharp5), 'i#5');
     });
   });
 }

--- a/packages/whatchord/test/scale_harmonizer_test.dart
+++ b/packages/whatchord/test/scale_harmonizer_test.dart
@@ -319,10 +319,10 @@ void main() {
   });
 
   group('Diatonic chord qualities', () {
-    List<ChordQualityToken> triads(Scale scale) => [
+    List<ChordQuality> triads(Scale scale) => [
       for (final d in ScaleHarmonizer.harmonize(scale).degrees) d.triadQuality,
     ];
-    List<ChordQualityToken> sevenths(Scale scale) => [
+    List<ChordQuality> sevenths(Scale scale) => [
       for (final d in ScaleHarmonizer.harmonize(scale).degrees)
         d.seventhQuality,
     ];
@@ -330,68 +330,68 @@ void main() {
     test('major scale triads and sevenths', () {
       const cMajor = Scale(Tonic.c, ScaleKind.major);
       expect(triads(cMajor), const [
-        ChordQualityToken.major,
-        ChordQualityToken.minor,
-        ChordQualityToken.minor,
-        ChordQualityToken.major,
-        ChordQualityToken.major,
-        ChordQualityToken.minor,
-        ChordQualityToken.diminished,
+        ChordQuality.major,
+        ChordQuality.minor,
+        ChordQuality.minor,
+        ChordQuality.major,
+        ChordQuality.major,
+        ChordQuality.minor,
+        ChordQuality.diminished,
       ]);
       expect(sevenths(cMajor), const [
-        ChordQualityToken.major7,
-        ChordQualityToken.minor7,
-        ChordQualityToken.minor7,
-        ChordQualityToken.major7,
-        ChordQualityToken.dominant7,
-        ChordQualityToken.minor7,
-        ChordQualityToken.halfDiminished7,
+        ChordQuality.major7,
+        ChordQuality.minor7,
+        ChordQuality.minor7,
+        ChordQuality.major7,
+        ChordQuality.dominant7,
+        ChordQuality.minor7,
+        ChordQuality.halfDiminished7,
       ]);
     });
 
     test('harmonic minor sevenths include maj7#5 and a fully diminished 7', () {
       expect(sevenths(const Scale(Tonic.a, ScaleKind.harmonicMinor)), const [
-        ChordQualityToken.minorMajor7,
-        ChordQualityToken.halfDiminished7,
-        ChordQualityToken.major7Sharp5,
-        ChordQualityToken.minor7,
-        ChordQualityToken.dominant7,
-        ChordQualityToken.major7,
-        ChordQualityToken.diminished7,
+        ChordQuality.minorMajor7,
+        ChordQuality.halfDiminished7,
+        ChordQuality.major7Sharp5,
+        ChordQuality.minor7,
+        ChordQuality.dominant7,
+        ChordQuality.major7,
+        ChordQuality.diminished7,
       ]);
     });
 
     test('melodic minor sevenths', () {
       expect(sevenths(const Scale(Tonic.a, ScaleKind.melodicMinor)), const [
-        ChordQualityToken.minorMajor7,
-        ChordQualityToken.minor7,
-        ChordQualityToken.major7Sharp5,
-        ChordQualityToken.dominant7,
-        ChordQualityToken.dominant7,
-        ChordQualityToken.halfDiminished7,
-        ChordQualityToken.halfDiminished7,
+        ChordQuality.minorMajor7,
+        ChordQuality.minor7,
+        ChordQuality.major7Sharp5,
+        ChordQuality.dominant7,
+        ChordQuality.dominant7,
+        ChordQuality.halfDiminished7,
+        ChordQuality.halfDiminished7,
       ]);
     });
 
     test('harmonic major triads and sevenths map cleanly', () {
       const cHarmonicMajor = Scale(Tonic.c, ScaleKind.harmonicMajor);
       expect(triads(cHarmonicMajor), const [
-        ChordQualityToken.major,
-        ChordQualityToken.diminished,
-        ChordQualityToken.minor,
-        ChordQualityToken.minor,
-        ChordQualityToken.major,
-        ChordQualityToken.augmented,
-        ChordQualityToken.diminished,
+        ChordQuality.major,
+        ChordQuality.diminished,
+        ChordQuality.minor,
+        ChordQuality.minor,
+        ChordQuality.major,
+        ChordQuality.augmented,
+        ChordQuality.diminished,
       ]);
       expect(sevenths(cHarmonicMajor), const [
-        ChordQualityToken.major7,
-        ChordQualityToken.halfDiminished7,
-        ChordQualityToken.minor7,
-        ChordQualityToken.minorMajor7,
-        ChordQualityToken.dominant7,
-        ChordQualityToken.major7Sharp5,
-        ChordQualityToken.diminished7,
+        ChordQuality.major7,
+        ChordQuality.halfDiminished7,
+        ChordQuality.minor7,
+        ChordQuality.minorMajor7,
+        ChordQuality.dominant7,
+        ChordQuality.major7Sharp5,
+        ChordQuality.diminished7,
       ]);
     });
   });

--- a/packages/whatchord/test/seed_derivation_test.dart
+++ b/packages/whatchord/test/seed_derivation_test.dart
@@ -13,7 +13,7 @@ void main() {
 
       expect(seed.rootPc, 0);
       expect(seed.bassPc, 0);
-      expect(seed.quality, ChordQualityToken.major);
+      expect(seed.quality, ChordQuality.major);
     });
 
     test('uses the selected minor-key tonic when idle', () {
@@ -24,7 +24,7 @@ void main() {
 
       expect(seed.rootPc, 9);
       expect(seed.bassPc, 9);
-      expect(seed.quality, ChordQualityToken.minor);
+      expect(seed.quality, ChordQuality.minor);
     });
 
     test('uses a single note as root with the current key-mode quality', () {
@@ -35,15 +35,15 @@ void main() {
 
       expect(seed.rootPc, 4);
       expect(seed.bassPc, 4);
-      expect(seed.quality, ChordQualityToken.major);
+      expect(seed.quality, ChordQuality.major);
     });
 
     test('maps dyad intervals to simple chord qualities', () {
-      expect(_dyadQuality(60, 62), ChordQualityToken.sus2);
-      expect(_dyadQuality(60, 63), ChordQualityToken.minor);
-      expect(_dyadQuality(60, 64), ChordQualityToken.major);
-      expect(_dyadQuality(60, 65), ChordQualityToken.sus4);
-      expect(_dyadQuality(60, 66), ChordQualityToken.diminished);
+      expect(_dyadQuality(60, 62), ChordQuality.sus2);
+      expect(_dyadQuality(60, 63), ChordQuality.minor);
+      expect(_dyadQuality(60, 64), ChordQuality.major);
+      expect(_dyadQuality(60, 65), ChordQuality.sus4);
+      expect(_dyadQuality(60, 66), ChordQuality.diminished);
     });
 
     test('maps perfect fifths to the current key-mode quality', () {
@@ -56,8 +56,8 @@ void main() {
         tonality: const Tonality(Tonic.a, TonalityMode.minor),
       );
 
-      expect(majorSeed.quality, ChordQualityToken.major);
-      expect(minorSeed.quality, ChordQualityToken.minor);
+      expect(majorSeed.quality, ChordQuality.major);
+      expect(minorSeed.quality, ChordQuality.minor);
     });
 
     test('falls back deterministically for ambiguous dyads', () {
@@ -70,18 +70,18 @@ void main() {
         tonality: const Tonality(Tonic.a, TonalityMode.minor),
       );
 
-      expect(majorSeed.quality, ChordQualityToken.major);
-      expect(minorSeed.quality, ChordQualityToken.minor);
+      expect(majorSeed.quality, ChordQuality.major);
+      expect(minorSeed.quality, ChordQuality.minor);
     });
 
     test('preserves the current full-chord identity', () {
       final current = ChordIdentity(
         rootPc: 2,
         bassPc: 6,
-        quality: ChordQualityToken.dominant7,
+        quality: ChordQuality.dominant7,
         extensions: const {ChordExtension.flat9},
         toneRolesByInterval: ChordToneRoles.build(
-          quality: ChordQualityToken.dominant7,
+          quality: ChordQuality.dominant7,
           extensions: const {ChordExtension.flat9},
           relMask: 0x493,
         ),
@@ -99,7 +99,7 @@ void main() {
   });
 }
 
-ChordQualityToken _dyadQuality(int bassMidi, int upperMidi) {
+ChordQuality _dyadQuality(int bassMidi, int upperMidi) {
   final seed = buildSeedIdentity(
     input: _input([bassMidi, upperMidi]),
     tonality: const Tonality(Tonic.c, TonalityMode.major),

--- a/packages/whatchord/test/theory_transposition_property_test.dart
+++ b/packages/whatchord/test/theory_transposition_property_test.dart
@@ -12,8 +12,8 @@ const _supportedExtensionIntervals = <int>[1, 2, 3, 5, 6, 8, 9];
 const _analysisTake = 256;
 
 final List<Tonality> _supportedTonalities = <Tonality>[
-  for (final keySignature in keySignatureRows) keySignature.relativeMajor,
-  for (final keySignature in keySignatureRows) keySignature.relativeMinor,
+  for (final keySignature in keySignatures) keySignature.relativeMajor,
+  for (final keySignature in keySignatures) keySignature.relativeMinor,
 ];
 
 class _GeneratedChordCase {

--- a/packages/whatchord/test/voicing_evidence_test.dart
+++ b/packages/whatchord/test/voicing_evidence_test.dart
@@ -27,7 +27,7 @@ void main() {
       final results = ChordAnalyzer.analyze(input, context: context);
 
       expect(results.first.identity.rootPc, pc('D'));
-      expect(results.first.identity.quality, ChordQualityToken.dominant7sus4);
+      expect(results.first.identity.quality, ChordQuality.dominant7sus4);
     });
 
     test('an isolated bass below a complete upper chord promotes Am7/D', () {
@@ -41,7 +41,7 @@ void main() {
       );
 
       expect(results.first.identity.rootPc, pc('A'));
-      expect(results.first.identity.quality, ChordQualityToken.minor7);
+      expect(results.first.identity.quality, ChordQuality.minor7);
       expect(results.first.identity.hasSlashBass, isTrue);
       expect(results.first.identity.bassPc, pc('D'));
 
@@ -52,7 +52,7 @@ void main() {
           alternatives,
           (c) =>
               c.identity.rootPc == pc('D') &&
-              c.identity.quality == ChordQualityToken.dominant7sus4,
+              c.identity.quality == ChordQuality.dominant7sus4,
         ),
         isNotNull,
       );
@@ -85,7 +85,7 @@ void main() {
       );
 
       expect(results.first.identity.rootPc, pc('D'));
-      expect(results.first.identity.quality, ChordQualityToken.dominant7sus4);
+      expect(results.first.identity.quality, ChordQuality.dominant7sus4);
     });
   });
 
@@ -115,7 +115,7 @@ void main() {
     const identity = ChordIdentity(
       rootPc: 9,
       bassPc: 2,
-      quality: ChordQualityToken.minor7,
+      quality: ChordQuality.minor7,
       presentIntervalsMask: 0,
     );
 

--- a/packages/whatkey/lib/src/detectors/key_space.dart
+++ b/packages/whatkey/lib/src/detectors/key_space.dart
@@ -12,7 +12,7 @@ abstract final class KeySpace {
   static final List<Tonality> canonicalTonalities = _canonicalTonalities();
 
   static List<Tonality> _canonicalTonalities() {
-    final rows = [...keySignatureRows]
+    final rows = [...keySignatures]
       ..sort((a, b) {
         final byCount = a.accidentalCount.abs().compareTo(
           b.accidentalCount.abs(),
@@ -53,31 +53,31 @@ abstract final class KeySpace {
   /// Chord qualities that read as "home" over a major tonic. Includes
   /// dominant7 so a blues I7 counts as tonic rather than only as V-of-IV
   /// (log entry 2026-07-07-10).
-  static const Set<ChordQualityToken> majorTonicQualities = {
-    ChordQualityToken.major,
-    ChordQualityToken.major6,
-    ChordQualityToken.major7,
-    ChordQualityToken.dominant7,
+  static const Set<ChordQuality> majorTonicQualities = {
+    ChordQuality.major,
+    ChordQuality.major6,
+    ChordQuality.major7,
+    ChordQuality.dominant7,
   };
 
   /// Chord qualities that read as "home" over a minor tonic.
-  static const Set<ChordQualityToken> minorTonicQualities = {
-    ChordQualityToken.minor,
-    ChordQualityToken.minor6,
-    ChordQualityToken.minor7,
-    ChordQualityToken.minorMajor7,
+  static const Set<ChordQuality> minorTonicQualities = {
+    ChordQuality.minor,
+    ChordQuality.minor6,
+    ChordQuality.minor7,
+    ChordQuality.minorMajor7,
   };
 
   /// The tonic quality set for [tonality]'s mode.
-  static Set<ChordQualityToken> tonicQualities(Tonality tonality) =>
+  static Set<ChordQuality> tonicQualities(Tonality tonality) =>
       tonality.isMajor ? majorTonicQualities : minorTonicQualities;
 
   /// Chord qualities that read as dominant function on any root.
-  static const Set<ChordQualityToken> dominantQualities = {
-    ChordQualityToken.dominant7,
-    ChordQualityToken.dominant7sus2,
-    ChordQualityToken.dominant7sus4,
-    ChordQualityToken.dominant7Flat5,
-    ChordQualityToken.dominant7Sharp5,
+  static const Set<ChordQuality> dominantQualities = {
+    ChordQuality.dominant7,
+    ChordQuality.dominant7sus2,
+    ChordQuality.dominant7sus4,
+    ChordQuality.dominant7Flat5,
+    ChordQuality.dominant7Sharp5,
   };
 }

--- a/packages/whatkey/lib/src/detectors/progression_key_detector.dart
+++ b/packages/whatkey/lib/src/detectors/progression_key_detector.dart
@@ -193,7 +193,7 @@ class ProgressionKeyDetector implements KeyDetector {
     if (toIsTonic && fromInterval == 7) {
       if (_dominantFamily.contains(from.quality)) {
         points += cadencePoints;
-      } else if (from.quality == ChordQualityToken.major) {
+      } else if (from.quality == ChordQuality.major) {
         points += cadenceTriadPoints;
       }
       if (points > 0 && !from.hasSlashBass && !to.hasSlashBass) {
@@ -218,15 +218,15 @@ class ProgressionKeyDetector implements KeyDetector {
         toInterval == 7 &&
         _predominantFamily.contains(from.quality) &&
         (_dominantFamily.contains(to.quality) ||
-            to.quality == ChordQualityToken.major)) {
+            to.quality == ChordQuality.major)) {
       points += iiToVPoints;
     }
 
     if (toIsTonic &&
         fromInterval == 5 &&
-        (from.quality == ChordQualityToken.major ||
-            from.quality == ChordQualityToken.dominant7 ||
-            from.quality == ChordQualityToken.minor)) {
+        (from.quality == ChordQuality.major ||
+            from.quality == ChordQuality.dominant7 ||
+            from.quality == ChordQuality.minor)) {
       points += plagalPoints;
     }
 
@@ -234,8 +234,8 @@ class ProgressionKeyDetector implements KeyDetector {
         fromInterval == 7 &&
         toInterval == 9 &&
         _dominantFamily.contains(from.quality) &&
-        (to.quality == ChordQualityToken.minor ||
-            to.quality == ChordQualityToken.minor7)) {
+        (to.quality == ChordQuality.minor ||
+            to.quality == ChordQuality.minor7)) {
       points += deceptivePoints;
     }
 
@@ -304,26 +304,26 @@ class ProgressionKeyDetector implements KeyDetector {
     return estimates;
   }
 
-  static const Set<ChordQualityToken> _dominantFamily = {
-    ChordQualityToken.dominant7,
-    ChordQualityToken.dominant7sus2,
-    ChordQualityToken.dominant7sus4,
-    ChordQualityToken.dominant7Flat5,
-    ChordQualityToken.dominant7Sharp5,
+  static const Set<ChordQuality> _dominantFamily = {
+    ChordQuality.dominant7,
+    ChordQuality.dominant7sus2,
+    ChordQuality.dominant7sus4,
+    ChordQuality.dominant7Flat5,
+    ChordQuality.dominant7Sharp5,
   };
 
   /// Pre-dominant qualities on the second degree: ii/ii7 in major, ii°/ii-7b5
   /// in minor.
-  static const Set<ChordQualityToken> _predominantFamily = {
-    ChordQualityToken.minor,
-    ChordQualityToken.minor7,
-    ChordQualityToken.diminished,
-    ChordQualityToken.halfDiminished7,
+  static const Set<ChordQuality> _predominantFamily = {
+    ChordQuality.minor,
+    ChordQuality.minor7,
+    ChordQuality.diminished,
+    ChordQuality.halfDiminished7,
   };
 
-  static const Set<ChordQualityToken> _leadingToneFamily = {
-    ChordQualityToken.diminished,
-    ChordQualityToken.diminished7,
-    ChordQualityToken.halfDiminished7,
+  static const Set<ChordQuality> _leadingToneFamily = {
+    ChordQuality.diminished,
+    ChordQuality.diminished7,
+    ChordQuality.halfDiminished7,
   };
 }

--- a/packages/whatkey/lib/src/detectors/weighted_evidence_key_detector.dart
+++ b/packages/whatkey/lib/src/detectors/weighted_evidence_key_detector.dart
@@ -175,7 +175,7 @@ class WeightedEvidenceKeyDetector implements KeyDetector {
     if (rootInterval == 7 && _dominantFamily.contains(identity.quality)) {
       points += dominantBonusPoints;
     }
-    if (rootInterval == 7 && identity.quality == ChordQualityToken.major) {
+    if (rootInterval == 7 && identity.quality == ChordQuality.major) {
       points += dominantTriadBonusPoints;
     }
     if (rootInterval == 11 && _leadingToneFamily.contains(identity.quality)) {
@@ -241,13 +241,12 @@ class WeightedEvidenceKeyDetector implements KeyDetector {
     return estimates;
   }
 
-  static const Set<ChordQualityToken> _dominantFamily =
-      KeySpace.dominantQualities;
+  static const Set<ChordQuality> _dominantFamily = KeySpace.dominantQualities;
 
-  static const Set<ChordQualityToken> _leadingToneFamily = {
-    ChordQualityToken.diminished,
-    ChordQualityToken.halfDiminished7,
-    ChordQualityToken.diminished7,
+  static const Set<ChordQuality> _leadingToneFamily = {
+    ChordQuality.diminished,
+    ChordQuality.halfDiminished7,
+    ChordQuality.diminished7,
   };
 
   static int _bitCount(int mask) {

--- a/packages/whatkey/test/bocpd_key_detector_test.dart
+++ b/packages/whatkey/test/bocpd_key_detector_test.dart
@@ -5,7 +5,7 @@ import 'package:whatkey/whatkey.dart';
 
 const _cMajorTonality = Tonality(Tonic.c, TonalityMode.major);
 
-ChordEvent _event(int index, List<int> pcs, ChordQualityToken quality) {
+ChordEvent _event(int index, List<int> pcs, ChordQuality quality) {
   var mask = 0;
   for (final pc in pcs) {
     mask |= 1 << (pc % 12);
@@ -41,10 +41,10 @@ List<KeyEstimateFrame> _run(KeyDetector detector, List<ChordEvent> events) {
 
 void main() {
   final cCadence = [
-    _event(0, [0, 4, 7], ChordQualityToken.major),
-    _event(1, [5, 9, 0], ChordQualityToken.major),
-    _event(2, [7, 11, 2, 5], ChordQualityToken.dominant7),
-    _event(3, [0, 4, 7], ChordQualityToken.major),
+    _event(0, [0, 4, 7], ChordQuality.major),
+    _event(1, [5, 9, 0], ChordQuality.major),
+    _event(2, [7, 11, 2, 5], ChordQuality.dominant7),
+    _event(3, [0, 4, 7], ChordQuality.major),
   ];
 
   test('claims C major for a C major cadence', () {
@@ -76,8 +76,8 @@ void main() {
     final frames = _run(BocpdKeyDetector(), [
       ...cCadence,
       for (var i = 0; i < 6; i++) ...[
-        _event(4 + 2 * i, [2, 6, 9, 0], ChordQualityToken.dominant7),
-        _event(5 + 2 * i, [7, 11, 2], ChordQualityToken.major),
+        _event(4 + 2 * i, [2, 6, 9, 0], ChordQuality.dominant7),
+        _event(5 + 2 * i, [7, 11, 2], ChordQuality.major),
       ],
     ]);
     final claim = frames.last.claim;
@@ -89,9 +89,9 @@ void main() {
   test('an established key persists through a single tonicization', () {
     final frames = _run(BocpdKeyDetector(), [
       ...cCadence,
-      _event(4, [2, 6, 9, 0], ChordQualityToken.dominant7), // V7/V
-      _event(5, [7, 11, 2, 5], ChordQualityToken.dominant7),
-      _event(6, [0, 4, 7], ChordQualityToken.major),
+      _event(4, [2, 6, 9, 0], ChordQuality.dominant7), // V7/V
+      _event(5, [7, 11, 2, 5], ChordQuality.dominant7),
+      _event(6, [0, 4, 7], ChordQuality.major),
     ]);
     for (final frame in frames.skip(3)) {
       final claim = frame.claim;
@@ -104,8 +104,7 @@ void main() {
   test('run-length truncation keeps the posterior normalized', () {
     final detector = BocpdKeyDetector(maxRunLength: 8);
     final frames = _run(detector, [
-      for (var i = 0; i < 40; i++)
-        _event(i, [0, 4, 7], ChordQualityToken.major),
+      for (var i = 0; i < 40; i++) _event(i, [0, 4, 7], ChordQuality.major),
     ]);
     final total = frames.last.ranked.fold(0.0, (s, e) => s + e.confidence);
     expect(total, closeTo(1.0, 1e-9));

--- a/packages/whatkey/test/claim_hysteresis_detector_test.dart
+++ b/packages/whatkey/test/claim_hysteresis_detector_test.dart
@@ -49,7 +49,7 @@ ChordEvent _event(int index) => ChordEvent(
       identity: const ChordIdentity(
         rootPc: 0,
         bassPc: 0,
-        quality: ChordQualityToken.major,
+        quality: ChordQuality.major,
         presentIntervalsMask: 0x91,
       ),
       cost: 0,

--- a/packages/whatkey/test/hmm_key_detector_test.dart
+++ b/packages/whatkey/test/hmm_key_detector_test.dart
@@ -5,7 +5,7 @@ import 'package:whatkey/whatkey.dart';
 
 const _cMajorTonality = Tonality(Tonic.c, TonalityMode.major);
 
-ChordEvent _event(int index, List<int> pcs, ChordQualityToken quality) {
+ChordEvent _event(int index, List<int> pcs, ChordQuality quality) {
   var mask = 0;
   for (final pc in pcs) {
     mask |= 1 << (pc % 12);
@@ -47,16 +47,16 @@ List<ChordEvent> _bluesChorus(int startIndex) {
   final bars = [i7, i7, i7, i7, iv7, iv7, i7, i7, v7, iv7, i7, v7];
   return [
     for (var bar = 0; bar < bars.length; bar++)
-      _event(startIndex + bar, bars[bar], ChordQualityToken.dominant7),
+      _event(startIndex + bar, bars[bar], ChordQuality.dominant7),
   ];
 }
 
 void main() {
   final cCadence = [
-    _event(0, [0, 4, 7], ChordQualityToken.major),
-    _event(1, [5, 9, 0], ChordQualityToken.major),
-    _event(2, [7, 11, 2, 5], ChordQualityToken.dominant7),
-    _event(3, [0, 4, 7], ChordQualityToken.major),
+    _event(0, [0, 4, 7], ChordQuality.major),
+    _event(1, [5, 9, 0], ChordQuality.major),
+    _event(2, [7, 11, 2, 5], ChordQuality.dominant7),
+    _event(3, [0, 4, 7], ChordQuality.major),
   ];
 
   test('claims C major for a C major cadence', () {
@@ -86,10 +86,10 @@ void main() {
 
   test('claims A minor for a harmonic-minor cadence with E7', () {
     final frames = _run(HmmKeyDetector(), [
-      _event(0, [9, 0, 4], ChordQualityToken.minor),
-      _event(1, [2, 5, 9], ChordQualityToken.minor),
-      _event(2, [4, 8, 11, 2], ChordQualityToken.dominant7),
-      _event(3, [9, 0, 4], ChordQualityToken.minor),
+      _event(0, [9, 0, 4], ChordQuality.minor),
+      _event(1, [2, 5, 9], ChordQuality.minor),
+      _event(2, [4, 8, 11, 2], ChordQuality.dominant7),
+      _event(3, [9, 0, 4], ChordQuality.minor),
     ]);
     final claim = frames.last.claim;
     expect(claim, isNotNull);
@@ -100,9 +100,9 @@ void main() {
   test('an established key persists through a single tonicization', () {
     final frames = _run(HmmKeyDetector(), [
       ...cCadence,
-      _event(4, [2, 6, 9, 0], ChordQualityToken.dominant7), // V7/V
-      _event(5, [7, 11, 2, 5], ChordQualityToken.dominant7),
-      _event(6, [0, 4, 7], ChordQualityToken.major),
+      _event(4, [2, 6, 9, 0], ChordQuality.dominant7), // V7/V
+      _event(5, [7, 11, 2, 5], ChordQuality.dominant7),
+      _event(6, [0, 4, 7], ChordQuality.major),
     ]);
     for (final frame in frames.skip(3)) {
       final claim = frame.claim;
@@ -116,8 +116,8 @@ void main() {
     final frames = _run(HmmKeyDetector(), [
       ...cCadence,
       for (var i = 0; i < 6; i++) ...[
-        _event(4 + 2 * i, [2, 6, 9, 0], ChordQualityToken.dominant7),
-        _event(5 + 2 * i, [7, 11, 2], ChordQualityToken.major),
+        _event(4 + 2 * i, [2, 6, 9, 0], ChordQuality.dominant7),
+        _event(5 + 2 * i, [7, 11, 2], ChordQuality.major),
       ],
     ]);
     final claim = frames.last.claim;
@@ -135,7 +135,7 @@ void main() {
     final frames = _run(HmmKeyDetector(), [
       ..._bluesChorus(0),
       ..._bluesChorus(12),
-      _event(24, [0, 4, 7, 10], ChordQualityToken.dominant7),
+      _event(24, [0, 4, 7, 10], ChordQuality.dominant7),
     ]);
     final lastClaim = frames.last.claim;
     expect(lastClaim, isNotNull);
@@ -146,8 +146,8 @@ void main() {
     final events = [
       ...cCadence,
       for (var i = 0; i < 6; i++) ...[
-        _event(4 + 2 * i, [2, 6, 9, 0], ChordQualityToken.dominant7),
-        _event(5 + 2 * i, [7, 11, 2], ChordQualityToken.major),
+        _event(4 + 2 * i, [2, 6, 9, 0], ChordQuality.dominant7),
+        _event(5 + 2 * i, [7, 11, 2], ChordQuality.major),
       ],
     ];
     final plain = _run(HmmKeyDetector(modeTilt: 0), events);
@@ -167,10 +167,10 @@ void main() {
     // tonic chord's quality, which is exactly what the tilt reads.
     final vamp = [
       for (var i = 0; i < 4; i++) ...[
-        _event(4 * i, [0, 3, 7], ChordQualityToken.minor),
-        _event(4 * i + 1, [5, 9, 0], ChordQualityToken.major),
-        _event(4 * i + 2, [7, 11, 2], ChordQualityToken.major),
-        _event(4 * i + 3, [0, 3, 7], ChordQualityToken.minor),
+        _event(4 * i, [0, 3, 7], ChordQuality.minor),
+        _event(4 * i + 1, [5, 9, 0], ChordQuality.major),
+        _event(4 * i + 2, [7, 11, 2], ChordQuality.major),
+        _event(4 * i + 3, [0, 3, 7], ChordQuality.minor),
       ],
     ];
     double cMinorConfidence(List<KeyEstimateFrame> frames) => frames.last.ranked
@@ -206,8 +206,8 @@ void main() {
     final events = [
       ...cCadence,
       for (var i = 0; i < 6; i++) ...[
-        _event(4 + 2 * i, [2, 6, 9, 0], ChordQualityToken.dominant7),
-        _event(5 + 2 * i, [7, 11, 2], ChordQualityToken.major),
+        _event(4 + 2 * i, [2, 6, 9, 0], ChordQuality.dominant7),
+        _event(5 + 2 * i, [7, 11, 2], ChordQuality.major),
       ],
     ];
     final plain = _run(HmmKeyDetector(), events);
@@ -224,9 +224,9 @@ void main() {
     // relative major.
     final vamp = [
       for (var i = 0; i < 4; i++) ...[
-        _event(3 * i, [9, 0, 4], ChordQualityToken.minor),
-        _event(3 * i + 1, [2, 5, 9], ChordQualityToken.minor),
-        _event(3 * i + 2, [9, 0, 4], ChordQualityToken.minor),
+        _event(3 * i, [9, 0, 4], ChordQuality.minor),
+        _event(3 * i + 1, [2, 5, 9], ChordQuality.minor),
+        _event(3 * i + 2, [9, 0, 4], ChordQuality.minor),
       ],
     ];
     double aMinorConfidence(List<KeyEstimateFrame> frames) => frames.last.ranked
@@ -244,8 +244,8 @@ void main() {
     // major relative to the untilted run.
     final phrase = [
       for (var i = 0; i < 4; i++) ...[
-        _event(2 * i, [4, 8, 11, 2], ChordQualityToken.dominant7),
-        _event(2 * i + 1, [9, 0, 4], ChordQualityToken.minor),
+        _event(2 * i, [4, 8, 11, 2], ChordQuality.dominant7),
+        _event(2 * i + 1, [9, 0, 4], ChordQuality.minor),
       ],
     ];
     double aMinorConfidence(List<KeyEstimateFrame> frames) => frames.last.ranked
@@ -263,7 +263,7 @@ void main() {
     // Exercised indirectly: run one event and confirm the posterior stays
     // normalized after prediction with an uninformative start.
     final frames = _run(detector, [
-      _event(0, [0, 4, 7], ChordQualityToken.major),
+      _event(0, [0, 4, 7], ChordQuality.major),
     ]);
     final total = frames.single.ranked.fold(0.0, (s, e) => s + e.confidence);
     expect(total, closeTo(1.0, 1e-9));

--- a/packages/whatkey/test/hybrid_key_detector_test.dart
+++ b/packages/whatkey/test/hybrid_key_detector_test.dart
@@ -5,7 +5,7 @@ import 'package:whatkey/whatkey.dart';
 
 const _cMajorTonality = Tonality(Tonic.c, TonalityMode.major);
 
-ChordEvent _event(int index, List<int> pcs, ChordQualityToken quality) {
+ChordEvent _event(int index, List<int> pcs, ChordQuality quality) {
   var mask = 0;
   for (final pc in pcs) {
     mask |= 1 << (pc % 12);
@@ -41,10 +41,10 @@ List<KeyEstimateFrame> _run(KeyDetector detector, List<ChordEvent> events) {
 
 void main() {
   final cCadence = [
-    _event(0, [0, 4, 7], ChordQualityToken.major),
-    _event(1, [5, 9, 0], ChordQualityToken.major),
-    _event(2, [7, 11, 2, 5], ChordQualityToken.dominant7),
-    _event(3, [0, 4, 7], ChordQualityToken.major),
+    _event(0, [0, 4, 7], ChordQuality.major),
+    _event(1, [5, 9, 0], ChordQuality.major),
+    _event(2, [7, 11, 2, 5], ChordQuality.dominant7),
+    _event(3, [0, 4, 7], ChordQuality.major),
   ];
 
   test('claims C major for a C major cadence', () {
@@ -74,10 +74,10 @@ void main() {
 
   test('claims A minor for a harmonic-minor cadence with E7', () {
     final frames = _run(HybridKeyDetector(), [
-      _event(0, [9, 0, 4], ChordQualityToken.minor),
-      _event(1, [2, 5, 9], ChordQualityToken.minor),
-      _event(2, [4, 8, 11, 2], ChordQualityToken.dominant7),
-      _event(3, [9, 0, 4], ChordQualityToken.minor),
+      _event(0, [9, 0, 4], ChordQuality.minor),
+      _event(1, [2, 5, 9], ChordQuality.minor),
+      _event(2, [4, 8, 11, 2], ChordQuality.dominant7),
+      _event(3, [9, 0, 4], ChordQuality.minor),
     ]);
     final claim = frames.last.claim;
     expect(claim, isNotNull);
@@ -88,10 +88,10 @@ void main() {
   test('claims C major on the diatonic pop loop where evidence alone ties', () {
     final frames = _run(HybridKeyDetector(), [
       for (var repeat = 0; repeat < 2; repeat++) ...[
-        _event(repeat * 4, [0, 4, 7], ChordQualityToken.major),
-        _event(repeat * 4 + 1, [7, 11, 2], ChordQualityToken.major),
-        _event(repeat * 4 + 2, [9, 0, 4], ChordQualityToken.minor),
-        _event(repeat * 4 + 3, [5, 9, 0], ChordQualityToken.major),
+        _event(repeat * 4, [0, 4, 7], ChordQuality.major),
+        _event(repeat * 4 + 1, [7, 11, 2], ChordQuality.major),
+        _event(repeat * 4 + 2, [9, 0, 4], ChordQuality.minor),
+        _event(repeat * 4 + 3, [5, 9, 0], ChordQuality.major),
       ],
     ]);
     final claim = frames.last.claim;

--- a/packages/whatkey/test/profile_correlation_key_detector_test.dart
+++ b/packages/whatkey/test/profile_correlation_key_detector_test.dart
@@ -23,7 +23,7 @@ ChordEvent _event(int index, List<int> pcs) {
         identity: ChordIdentity(
           rootPc: pcs.first % 12,
           bassPc: pcs.first % 12,
-          quality: ChordQualityToken.major,
+          quality: ChordQuality.major,
           presentIntervalsMask: 1,
         ),
         cost: 0,

--- a/packages/whatkey/test/progression_key_detector_test.dart
+++ b/packages/whatkey/test/progression_key_detector_test.dart
@@ -8,7 +8,7 @@ const _cMajorTonality = Tonality(Tonic.c, TonalityMode.major);
 ChordEvent _event(
   int index,
   List<int> pcs,
-  ChordQualityToken quality, {
+  ChordQuality quality, {
   int? bassPc,
 }) {
   var mask = 0;
@@ -51,8 +51,8 @@ KeyEstimate _estimateFor(KeyEstimateFrame frame, int tonicPc, bool isMinor) =>
 void main() {
   test('a G7 to C cadence tops the ranking with C major', () {
     final frames = _run(ProgressionKeyDetector(minEvents: 2), [
-      _event(0, [7, 11, 2, 5], ChordQualityToken.dominant7),
-      _event(1, [0, 4, 7], ChordQualityToken.major),
+      _event(0, [7, 11, 2, 5], ChordQuality.dominant7),
+      _event(1, [0, 4, 7], ChordQuality.major),
     ]);
     final top = frames.last.ranked.first;
     expect(top.tonality.tonicPitchClass, 0);
@@ -61,13 +61,13 @@ void main() {
 
   test('ii-V-I completion scores above a bare V-I', () {
     final bare = _run(ProgressionKeyDetector(minEvents: 2), [
-      _event(0, [7, 11, 2, 5], ChordQualityToken.dominant7),
-      _event(1, [0, 4, 7], ChordQualityToken.major),
+      _event(0, [7, 11, 2, 5], ChordQuality.dominant7),
+      _event(1, [0, 4, 7], ChordQuality.major),
     ]);
     final complete = _run(ProgressionKeyDetector(minEvents: 2), [
-      _event(0, [2, 5, 9, 0], ChordQualityToken.minor7),
-      _event(1, [7, 11, 2, 5], ChordQualityToken.dominant7),
-      _event(2, [0, 4, 7], ChordQualityToken.major),
+      _event(0, [2, 5, 9, 0], ChordQuality.minor7),
+      _event(1, [7, 11, 2, 5], ChordQuality.dominant7),
+      _event(2, [0, 4, 7], ChordQuality.major),
     ]);
     final bareC = _estimateFor(bare.last, 0, false).confidence;
     final completeC = _estimateFor(complete.last, 0, false).confidence;
@@ -78,8 +78,8 @@ void main() {
     // G7 -> C7: with dominant7 in the tonic quality set, this is V7 -> I7 in
     // C, not motion toward F.
     final frames = _run(ProgressionKeyDetector(minEvents: 2), [
-      _event(0, [7, 11, 2, 5], ChordQualityToken.dominant7),
-      _event(1, [0, 4, 7, 10], ChordQualityToken.dominant7),
+      _event(0, [7, 11, 2, 5], ChordQuality.dominant7),
+      _event(1, [0, 4, 7, 10], ChordQuality.dominant7),
     ]);
     final top = frames.last.ranked.first;
     expect(top.tonality.tonicPitchClass, 0);
@@ -88,8 +88,8 @@ void main() {
 
   test('E7 to Am cadence supports A minor', () {
     final frames = _run(ProgressionKeyDetector(minEvents: 2), [
-      _event(0, [4, 8, 11, 2], ChordQualityToken.dominant7),
-      _event(1, [9, 0, 4], ChordQualityToken.minor),
+      _event(0, [4, 8, 11, 2], ChordQuality.dominant7),
+      _event(1, [9, 0, 4], ChordQuality.minor),
     ]);
     final top = frames.last.ranked.first;
     expect(top.tonality.tonicPitchClass, 9);
@@ -99,7 +99,7 @@ void main() {
   test('repeated identical chords accumulate no transition evidence', () {
     final frames = _run(ProgressionKeyDetector(minEvents: 1), [
       for (var i = 0; i < 4; i++)
-        _event(i, [0, 4, 7, 10], ChordQualityToken.dominant7),
+        _event(i, [0, 4, 7, 10], ChordQuality.dominant7),
     ]);
     expect(frames.every((frame) => frame.isAbstention), isTrue);
   });
@@ -107,15 +107,15 @@ void main() {
   test('hybrid with progression blend claims C on the blues loop', () {
     // I7 I7 IV7 I7 V7 IV7 I7 V7, roughly the 12-bar skeleton.
     final blues = [
-      _event(0, [0, 4, 7, 10], ChordQualityToken.dominant7),
-      _event(1, [0, 4, 7, 10], ChordQualityToken.dominant7),
-      _event(2, [5, 9, 0, 3], ChordQualityToken.dominant7),
-      _event(3, [0, 4, 7, 10], ChordQualityToken.dominant7),
-      _event(4, [7, 11, 2, 5], ChordQualityToken.dominant7),
-      _event(5, [5, 9, 0, 3], ChordQualityToken.dominant7),
-      _event(6, [0, 4, 7, 10], ChordQualityToken.dominant7),
-      _event(7, [7, 11, 2, 5], ChordQualityToken.dominant7),
-      _event(8, [0, 4, 7, 10], ChordQualityToken.dominant7),
+      _event(0, [0, 4, 7, 10], ChordQuality.dominant7),
+      _event(1, [0, 4, 7, 10], ChordQuality.dominant7),
+      _event(2, [5, 9, 0, 3], ChordQuality.dominant7),
+      _event(3, [0, 4, 7, 10], ChordQuality.dominant7),
+      _event(4, [7, 11, 2, 5], ChordQuality.dominant7),
+      _event(5, [5, 9, 0, 3], ChordQuality.dominant7),
+      _event(6, [0, 4, 7, 10], ChordQuality.dominant7),
+      _event(7, [7, 11, 2, 5], ChordQuality.dominant7),
+      _event(8, [0, 4, 7, 10], ChordQuality.dominant7),
     ];
     final without = _run(HybridKeyDetector(progressionBlend: 0), blues);
     final with_ = _run(HybridKeyDetector(progressionBlend: 0.1), blues);
@@ -135,10 +135,10 @@ void main() {
 
   test('explicit progression blend of zero is deterministic across runs', () {
     final cadence = [
-      _event(0, [0, 4, 7], ChordQualityToken.major),
-      _event(1, [5, 9, 0], ChordQualityToken.major),
-      _event(2, [7, 11, 2, 5], ChordQualityToken.dominant7),
-      _event(3, [0, 4, 7], ChordQualityToken.major),
+      _event(0, [0, 4, 7], ChordQuality.major),
+      _event(1, [5, 9, 0], ChordQuality.major),
+      _event(2, [7, 11, 2, 5], ChordQuality.dominant7),
+      _event(3, [0, 4, 7], ChordQuality.major),
     ];
     final base = _run(
       HybridKeyDetector(functionalBlend: 0.1, progressionBlend: 0),

--- a/packages/whatkey/test/weighted_evidence_key_detector_test.dart
+++ b/packages/whatkey/test/weighted_evidence_key_detector_test.dart
@@ -8,7 +8,7 @@ const _cMajorTonality = Tonality(Tonic.c, TonalityMode.major);
 ChordEvent _event(
   int index,
   List<int> pcs,
-  ChordQualityToken quality, {
+  ChordQuality quality, {
   double alternativeCostGap = double.infinity,
 }) {
   var mask = 0;
@@ -36,7 +36,7 @@ ChordEvent _event(
           identity: ChordIdentity(
             rootPc: (pcs.first + 3) % 12,
             bassPc: pcs.first % 12,
-            quality: ChordQualityToken.major,
+            quality: ChordQuality.major,
             presentIntervalsMask: 1,
           ),
           cost: alternativeCostGap,
@@ -57,10 +57,10 @@ List<KeyEstimateFrame> _run(
 
 void main() {
   final cCadence = [
-    _event(0, [0, 4, 7], ChordQualityToken.major),
-    _event(1, [5, 9, 0], ChordQualityToken.major),
-    _event(2, [7, 11, 2, 5], ChordQualityToken.dominant7),
-    _event(3, [0, 4, 7], ChordQualityToken.major),
+    _event(0, [0, 4, 7], ChordQuality.major),
+    _event(1, [5, 9, 0], ChordQuality.major),
+    _event(2, [7, 11, 2, 5], ChordQuality.dominant7),
+    _event(3, [0, 4, 7], ChordQuality.major),
   ];
 
   test('claims C major for a C major cadence', () {
@@ -80,10 +80,10 @@ void main() {
 
   test('claims A minor for a harmonic-minor cadence with E7', () {
     final frames = _run(WeightedEvidenceKeyDetector(), [
-      _event(0, [9, 0, 4], ChordQualityToken.minor),
-      _event(1, [2, 5, 9], ChordQualityToken.minor),
-      _event(2, [4, 8, 11, 2], ChordQualityToken.dominant7),
-      _event(3, [9, 0, 4], ChordQualityToken.minor),
+      _event(0, [9, 0, 4], ChordQuality.minor),
+      _event(1, [2, 5, 9], ChordQuality.minor),
+      _event(2, [4, 8, 11, 2], ChordQuality.dominant7),
+      _event(3, [9, 0, 4], ChordQuality.minor),
     ]);
     final claim = frames.last.claim;
     expect(claim, isNotNull);
@@ -97,7 +97,7 @@ void main() {
     // carries the dominant bonus, so a lone E7 must rank A minor at the top
     // alongside A major (where it is also V7), never below it.
     final frames = _run(WeightedEvidenceKeyDetector(minEvents: 1), [
-      _event(0, [4, 8, 11, 2], ChordQualityToken.dominant7),
+      _event(0, [4, 8, 11, 2], ChordQuality.dominant7),
     ]);
     final ranked = frames.single.ranked;
     final aMinorRank = ranked.indexWhere(
@@ -118,15 +118,10 @@ void main() {
     () {
       // The C cadence, but every identity reported as a dead tie.
       final ambiguous = [
-        _event(0, [0, 4, 7], ChordQualityToken.major, alternativeCostGap: 0),
-        _event(1, [5, 9, 0], ChordQualityToken.major, alternativeCostGap: 0),
-        _event(
-          2,
-          [7, 11, 2, 5],
-          ChordQualityToken.dominant7,
-          alternativeCostGap: 0,
-        ),
-        _event(3, [0, 4, 7], ChordQualityToken.major, alternativeCostGap: 0),
+        _event(0, [0, 4, 7], ChordQuality.major, alternativeCostGap: 0),
+        _event(1, [5, 9, 0], ChordQuality.major, alternativeCostGap: 0),
+        _event(2, [7, 11, 2, 5], ChordQuality.dominant7, alternativeCostGap: 0),
+        _event(3, [0, 4, 7], ChordQuality.major, alternativeCostGap: 0),
       ];
       final weighted = _run(WeightedEvidenceKeyDetector(), ambiguous);
       expect(weighted.every((frame) => frame.isAbstention), isTrue);
@@ -143,8 +138,8 @@ void main() {
     final frames = _run(WeightedEvidenceKeyDetector(), [
       ...cCadence,
       for (var i = 0; i < 6; i++) ...[
-        _event(4 + 2 * i, [2, 6, 9, 0], ChordQualityToken.dominant7),
-        _event(5 + 2 * i, [7, 11, 2], ChordQualityToken.major),
+        _event(4 + 2 * i, [2, 6, 9, 0], ChordQuality.dominant7),
+        _event(5 + 2 * i, [7, 11, 2], ChordQuality.major),
       ],
     ]);
     final claim = frames.last.claim;
@@ -157,7 +152,7 @@ void main() {
     // A lone C7: without the tonic bonus, F major scores +9 (diatonic root,
     // all tones diatonic, dominant-on-V) while C major scores +1 (root
     // diatonic, Bb chromatic). The bonus must narrow that structural gap.
-    final event = _event(0, [0, 4, 7, 10], ChordQualityToken.dominant7);
+    final event = _event(0, [0, 4, 7, 10], ChordQuality.dominant7);
     double gap(WeightedEvidenceKeyDetector detector) {
       detector.reset();
       final ranked = detector.onEvent(event).ranked;

--- a/test/history/chord_history_notifier_test.dart
+++ b/test/history/chord_history_notifier_test.dart
@@ -98,7 +98,7 @@ void main() {
     final events = container.read(chordHistoryProvider);
     expect(events, hasLength(2));
     expect(events.first.identity.rootPc, 0);
-    expect(events.first.identity.quality, ChordQualityToken.major);
+    expect(events.first.identity.quality, ChordQuality.major);
     expect(events.first.timestamp, startedAt);
     // C ended when the F challenger began, not when it stabilized.
     expect(events.first.duration, const Duration(seconds: 2));
@@ -119,7 +119,7 @@ void main() {
 
     final events = container.read(chordHistoryProvider);
     expect(events, hasLength(1));
-    expect(events.single.identity.quality, ChordQualityToken.major);
+    expect(events.single.identity.quality, ChordQuality.major);
     // The blip folds into the held chord instead of splitting it.
     expect(
       events.single.duration,
@@ -199,7 +199,7 @@ void main() {
 
     var events = container.read(chordHistoryProvider);
     expect(events, hasLength(1));
-    expect(events.single.identity.quality, ChordQualityToken.major7);
+    expect(events.single.identity.quality, ChordQuality.major7);
     expect(events.single.duration, const Duration(seconds: 1));
 
     advance(const Duration(seconds: 1));

--- a/test/key/inferred_key_notifier_test.dart
+++ b/test/key/inferred_key_notifier_test.dart
@@ -9,7 +9,7 @@ import 'package:whatchord_app/features/midi/midi_input_source.dart';
 
 const _cMajorTonality = Tonality(Tonic.c, TonalityMode.major);
 
-ChordEvent _event(int index, List<int> pcs, ChordQualityToken quality) {
+ChordEvent _event(int index, List<int> pcs, ChordQuality quality) {
   var mask = 0;
   for (final pc in pcs) {
     mask |= 1 << (pc % 12);
@@ -39,10 +39,10 @@ ChordEvent _event(int index, List<int> pcs, ChordQualityToken quality) {
 }
 
 List<ChordEvent> _cCadence() => [
-  _event(0, [0, 4, 7], ChordQualityToken.major),
-  _event(1, [5, 9, 0], ChordQualityToken.major),
-  _event(2, [7, 11, 2, 5], ChordQualityToken.dominant7),
-  _event(3, [0, 4, 7], ChordQualityToken.major),
+  _event(0, [0, 4, 7], ChordQuality.major),
+  _event(1, [5, 9, 0], ChordQuality.major),
+  _event(2, [7, 11, 2, 5], ChordQuality.dominant7),
+  _event(3, [0, 4, 7], ChordQuality.major),
 ];
 
 void main() {
@@ -132,7 +132,7 @@ void main() {
     record(container, _cCadence());
     await Future<void>.delayed(const Duration(milliseconds: 50));
     record(container, [
-      _event(4, [0, 4, 7], ChordQualityToken.major),
+      _event(4, [0, 4, 7], ChordQuality.major),
     ]);
     await Future<void>.delayed(const Duration(milliseconds: 50));
 
@@ -157,7 +157,7 @@ void main() {
     // One event after a reset must not produce a claim: warmup applies again,
     // proving the detector state was truly discarded.
     record(container, [
-      _event(9, [0, 4, 7], ChordQualityToken.major),
+      _event(9, [0, 4, 7], ChordQuality.major),
     ]);
     final state = container.read(inferredKeyProvider);
     expect(state.freshness, InferredKeyFreshness.fresh);
@@ -185,20 +185,7 @@ void main() {
     // the detector abstains, the display keeps the last claim (dimmed).
     record(container, [
       for (var i = 4; i < 10; i++)
-        _event(i, [
-          0,
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-        ], ChordQualityToken.major),
+        _event(i, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], ChordQuality.major),
     ]);
     final state = container.read(inferredKeyProvider);
     expect(state.lastClaim, isNotNull);
@@ -225,7 +212,7 @@ void main() {
 
     // Warmup applies again: the fresh detector heard none of the history.
     record(container, [
-      _event(9, [0, 4, 7], ChordQualityToken.major),
+      _event(9, [0, 4, 7], ChordQuality.major),
     ]);
     state = container.read(inferredKeyProvider);
     expect(state.freshness, InferredKeyFreshness.fresh);

--- a/test/key/key_mode_notifier_test.dart
+++ b/test/key/key_mode_notifier_test.dart
@@ -11,7 +11,7 @@ import 'package:whatchord_app/features/theory/theory.dart';
 const _cMajorTonality = Tonality(Tonic.c, TonalityMode.major);
 const _aMinorTonality = Tonality(Tonic.a, TonalityMode.minor);
 
-ChordEvent _event(int index, List<int> pcs, ChordQualityToken quality) {
+ChordEvent _event(int index, List<int> pcs, ChordQuality quality) {
   var mask = 0;
   for (final pc in pcs) {
     mask |= 1 << (pc % 12);
@@ -51,7 +51,7 @@ List<ChordEvent> _gMajorPhrase([int start = 0]) => [
         [2, 6, 9, 0],
         [7, 11, 2],
       ][i % 4],
-      i % 4 == 2 ? ChordQualityToken.dominant7 : ChordQualityToken.major,
+      i % 4 == 2 ? ChordQuality.dominant7 : ChordQuality.major,
     ),
 ];
 

--- a/test/theory/chord_member_spelling_test.dart
+++ b/test/theory/chord_member_spelling_test.dart
@@ -7,12 +7,12 @@ import 'package:whatchord/testing.dart';
 
 void main() {
   // Regression: a non-diatonic chord root must be spelled with chord context,
-  // not the plain chromatic pcToName. Bbmaj9/D in C major identifies with root
-  // pitch class 10; pcToName(10) is "A#", which would spell every member
+  // not the plain chromatic noteNameForPitchClass. Bbmaj9/D in C major identifies with root
+  // pitch class 10; noteNameForPitchClass(10) is "A#", which would spell every member
   // relative to A# (Cx, E#, Gx, B#). The chips must match the identity card's
   // Bb spelling instead.
   test(
-    'member chips use the chord-aware root spelling, not plain pcToName',
+    'member chips use the chord-aware root spelling, not plain noteNameForPitchClass',
     () {
       const cMajor = Tonality(Tonic.c, TonalityMode.major);
 
@@ -27,7 +27,7 @@ void main() {
 
       // Guard the underlying contract both call sites depend on.
       expect(identity.rootPc, 10);
-      expect(pcToName(identity.rootPc, tonality: cMajor), 'A#');
+      expect(noteNameForPitchClass(identity.rootPc, tonality: cMajor), 'A#');
       expect(spellChordRoot(identity, tonality: cMajor), 'Bb');
 
       final presentation = ChordPresentationBuilder.fromIdentity(

--- a/tool/chord_debug.dart
+++ b/tool/chord_debug.dart
@@ -436,7 +436,7 @@ String _formatTones(
   ], identity: id);
   for (final interval in intervals) {
     final pc = {(id.rootPc + interval) % 12};
-    final degree = theoryTokenDisplayLabel(
+    final degree = toGlyphAccidentals(
       ChordMemberDegreeFormatter.formatDegrees(
         identity: id,
         pitchClasses: pc,
@@ -921,7 +921,7 @@ String _formatIdentityCompact(ChordIdentity id) {
   var s = id.toString();
 
   // Strip enum type prefixes for readability.
-  s = s.replaceAll('ChordQualityToken.', '');
+  s = s.replaceAll('ChordQuality.', '');
   s = s.replaceAll('ChordExtension.', '');
   s = s.replaceAll('ChordToneRole.', '');
 

--- a/tool/src/chord_id_engine.dart
+++ b/tool/src/chord_id_engine.dart
@@ -213,7 +213,7 @@ ChordIdResult identifyChord(
   final bassLabel = noteDisplayLabel(
     bassPreserved != null
         ? normalizeNoteNameToAscii(bassPreserved)
-        : pcToName(bassPc, tonality: tonality),
+        : noteNameForPitchClass(bassPc, tonality: tonality),
   );
 
   // Register evidence applies only when actual MIDI numbers were given; bare
@@ -342,7 +342,7 @@ Tonality parseTonality(String raw) {
 /// Normalizes theoretical enharmonic key spellings to the supported 15
 /// conventional key signatures while preserving mode and tonic pitch class.
 Tonality normalizeTonalityForKeySignature(Tonality tonality) {
-  for (final keySignature in keySignatureRows) {
+  for (final keySignature in keySignatures) {
     final rowTonality = tonality.isMajor
         ? keySignature.relativeMajor
         : keySignature.relativeMinor;
@@ -351,7 +351,7 @@ Tonality normalizeTonalityForKeySignature(Tonality tonality) {
 
   final candidates =
       [
-        for (final keySignature in keySignatureRows)
+        for (final keySignature in keySignatures)
           (
             accidentalDistance: keySignature.accidentalCount.abs(),
             tonality: tonality.isMajor
@@ -447,7 +447,7 @@ List<String> inputNoteLabels(NoteParse parsed, {required Tonality tonality}) {
         noteDisplayLabel(
           n.name != null
               ? normalizeNoteNameToAscii(n.name!)
-              : pcToName(n.pc, tonality: tonality),
+              : noteNameForPitchClass(n.pc, tonality: tonality),
         ),
   ];
 }
@@ -492,7 +492,7 @@ String _spellAlsoPlayedTones(
         noteDisplayLabel(
           note.name != null
               ? normalizeNoteNameToAscii(note.name!)
-              : pcToName(note.pc, tonality: tonality),
+              : noteNameForPitchClass(note.pc, tonality: tonality),
         ),
   ].join(' ');
 }

--- a/tool/src/whatkey/whatkey_fixtures.dart
+++ b/tool/src/whatkey/whatkey_fixtures.dart
@@ -106,9 +106,7 @@ class LabeledFixture {
       identity: ChordIdentity(
         rootPc: candidate['rootPc'] as int,
         bassPc: candidate['bassPc'] as int,
-        quality: ChordQualityToken.values.byName(
-          candidate['quality'] as String,
-        ),
+        quality: ChordQuality.values.byName(candidate['quality'] as String),
         extensions: {
           for (final name in (candidate['extensions'] as List).cast<String>())
             ChordExtension.values.byName(name),


### PR DESCRIPTION
Rename ChordQualityToken to ChordQuality, the name consumers would expect for the flagship enum, along with its extensions and label file. Scrub the remaining app residue from the surface: keySignatures drops its table-row framing, the tonality picker label and extension control types lose their widget vocabulary, and the engine counters flag loses its Flutter-style k prefix. Remove theoryTokenDisplayLabel, a literal alias of toGlyphAccidentals, and privatize the formatting-internal fifth-alteration enum so exactly one FifthAlteration remains public. The whatkey surface passed review unchanged.