### PR TITLE
Audit and normalize comments across the app

### DIFF
--- a/lib/core/audio/soundfont_assets.dart
+++ b/lib/core/audio/soundfont_assets.dart
@@ -1,8 +1,8 @@
 /// Canonical SoundFont assets bundled with the application.
 ///
 /// If this changes, ensure:
-/// - pubspec.yaml is updated
-/// - NOTICE.md remains accurate
+/// - pubspec.yaml is updated.
+/// - NOTICE.md remains accurate.
 abstract final class SoundFontAssets {
   static const defaultPiano =
       'assets/soundfonts/generaluser-gs-v2.0.2-grand-piano.sf2';

--- a/lib/core/widgets/copy_choice_dialog.dart
+++ b/lib/core/widgets/copy_choice_dialog.dart
@@ -61,8 +61,8 @@ Future<void> showCopyChoiceDialog(
   );
   if (choice == null || !context.mounted) return;
 
-  // iOS gives no system confirmation for clipboard writes, so surface our own;
-  // Android already shows one, so avoid a duplicate there.
+  // iOS gives no system confirmation for clipboard writes, so surface one;
+  // Android already shows its own, so avoid a duplicate there.
   final messenger = Theme.of(context).platform == TargetPlatform.iOS
       ? ScaffoldMessenger.maybeOf(context)
       : null;

--- a/lib/features/audio/providers/app_audio_monitor_lifecycle_provider.dart
+++ b/lib/features/audio/providers/app_audio_monitor_lifecycle_provider.dart
@@ -67,7 +67,7 @@ class _AudioMonitorLifecycleController with WidgetsBindingObserver {
         break;
       case AppLifecycleState.inactive:
         // iOS system interruptions (alarms/calls) can leave the output unit in
-        // a bad state unless we rebuild on resume.
+        // a bad state unless it is rebuilt on resume.
         if (defaultTargetPlatform == TargetPlatform.iOS) {
           monitor.setBackgrounded(true);
         }

--- a/lib/features/audio/providers/audio_monitor_notifier.dart
+++ b/lib/features/audio/providers/audio_monitor_notifier.dart
@@ -92,7 +92,7 @@ class AudioMonitorNotifier extends Notifier<AudioMonitorState> {
       next,
     ) {
       // A disconnected device cannot receive note-offs; drop the tracked notes
-      // so we never treat its notes as still sounding.
+      // so they are never treated as still sounding.
       if (previous?.isConnected == true && !next.isConnected) {
         _enqueueAudioOperation(() async {
           _midiNotesOn.clear();

--- a/lib/features/audio/providers/audio_monitor_settings_notifier.dart
+++ b/lib/features/audio/providers/audio_monitor_settings_notifier.dart
@@ -44,8 +44,8 @@ class AudioMonitorSettingsNotifier extends Notifier<AudioMonitorSettings> {
     );
   }
 
-  /// Resolves the output mode and muted state, migrating the legacy on/off flag.
-  /// Since mute is now the off switch, a prior disabled monitor maps to muted.
+  /// Resolves the output mode and muted state, migrating the legacy on/off
+  /// flag. Mute is the off switch, so a prior disabled monitor maps to muted.
   (AudioMonitorMode, bool) _readModeAndMuted(
     SharedPreferences prefs,
     AudioMonitorSettings defaults,

--- a/lib/features/home/models/home_layout_config.dart
+++ b/lib/features/home/models/home_layout_config.dart
@@ -105,7 +105,7 @@ class HomeLayoutConfig {
   });
 }
 
-/// Largest height the resizable keyboard may occupy on a page right now.
+/// Largest height the resizable keyboard may occupy in the current layout.
 ///
 /// [availableHeight] is the body region shared by the page content and the
 /// keyboard. [reservedChrome] is the height of everything the keyboard region

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -133,8 +133,8 @@ class _HomePageState extends ConsumerState<HomePage> {
             ? math.max(mq.viewPadding.left, mq.viewPadding.right)
             : 0.0;
 
-        // Symmetric rail inset for top bar and tonality bar.
-        // In landscape we draw full-bleed horizontally, so we add the largest system cutout inset.
+        // Symmetric rail inset for top bar and tonality bar. Landscape draws
+        // full-bleed horizontally, so add the largest system cutout inset.
         final horizontalInset = barBaseInset + maxHorizontalCutout;
 
         return EdgeToEdgeController(
@@ -421,7 +421,7 @@ class _HomePortrait extends ConsumerWidget {
                   maxKeyboardHeight: maxKeyboardHeightForLayout(
                     availableHeight: bodyConstraints.maxHeight,
                     isLandscape: false,
-                    // tonality bar + separator band + 1px felt line, plus the
+                    // Tonality bar + separator band + 1px felt line, plus the
                     // input display / demo prompt above.
                     reservedChrome:
                         _tonalityBarHeight +

--- a/lib/features/input/providers/input_idle_notifier.dart
+++ b/lib/features/input/providers/input_idle_notifier.dart
@@ -21,20 +21,20 @@ class InputIdleState {
 
   final Duration cooldown;
 
-  /// True once we have ever observed engagement (notes) at least once.
+  /// True once engagement (notes) has been observed at least once.
   final bool hasSeenEngagement;
 
   /// True while user currently has any keys down (or pedal down if included).
   final bool isEngagedNow;
 
   /// Timestamp of the most recent "fully released" moment (notes empty + pedal up).
-  /// Null until we have ever observed a full release after activity.
+  /// Null until a full release after activity has been observed.
   final DateTime? lastReleaseAt;
 
-  /// Convenience: "eligible to show idle UI"
-  /// - True on first load (before any activity)
-  /// - False while engaged
-  /// - True only after cooldown since lastReleaseAt
+  /// Convenience: whether idle UI is eligible to show.
+  /// - True on first load (before any activity).
+  /// - False while engaged.
+  /// - True only after the cooldown since [lastReleaseAt].
   final bool isEligible;
 
   InputIdleState copyWith({
@@ -54,6 +54,7 @@ class InputIdleState {
   }
 }
 
+/// Quiet time after the last full release before idle UI may show.
 final inputIdleCooldownProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 8);
 });
@@ -62,7 +63,7 @@ final inputIdleProvider = NotifierProvider<InputIdleNotifier, InputIdleState>(
   InputIdleNotifier.new,
 );
 
-/// If you prefer a boolean-only API for consumers:
+/// The [InputIdleState.isEligible] flag alone, for boolean-only consumers.
 final inputIdleEligibleProvider = Provider<bool>((ref) {
   return ref.watch(inputIdleProvider).isEligible;
 });
@@ -94,8 +95,8 @@ class InputIdleNotifier extends Notifier<InputIdleState> {
 
     state = initial;
 
-    // When demo mode toggles, force idle immediately so we do not wait for
-    // any existing MIDI cooldown to expire before showing the glyph.
+    // When demo mode toggles, force idle immediately rather than waiting for
+    // an existing MIDI cooldown to expire before showing the glyph.
     ref.listen<bool>(demoModeProvider, (prev, next) {
       if ((prev == false && next == true) || (prev == true && next == false)) {
         markIdleNow();
@@ -160,7 +161,7 @@ class InputIdleNotifier extends Notifier<InputIdleState> {
     // If state didn't actually change, do nothing.
     if (wasEngaged == engagedNow) return;
 
-    // Transition: idle/released -> engaged
+    // Transition: idle/released -> engaged.
     if (engagedNow) {
       _timer?.cancel();
       _timer = null;
@@ -174,7 +175,7 @@ class InputIdleNotifier extends Notifier<InputIdleState> {
       return;
     }
 
-    // Transition: engaged -> fully released
+    // Transition: engaged -> fully released.
     final releaseAt = DateTime.now();
 
     state = state.copyWith(
@@ -192,7 +193,7 @@ class InputIdleNotifier extends Notifier<InputIdleState> {
     _timer?.cancel();
     _timer = null;
 
-    // If we haven't seen any activity ever, stay eligible.
+    // With no activity observed yet, stay eligible.
     if (!state.hasSeenEngagement) {
       state = state.copyWith(isEligible: true);
       return;
@@ -206,7 +207,7 @@ class InputIdleNotifier extends Notifier<InputIdleState> {
 
     final releaseAt = state.lastReleaseAt;
     if (releaseAt == null) {
-      // We have seen activity but no recorded release yet; be conservative.
+      // Activity observed but no release recorded yet; be conservative.
       state = state.copyWith(isEligible: false);
       return;
     }
@@ -220,8 +221,8 @@ class InputIdleNotifier extends Notifier<InputIdleState> {
     }
 
     _timer = Timer(remaining, () {
-      // Only flip eligible if we are still not engaged and the release timestamp
-      // hasn't changed under us (i.e., no re-engagement since scheduling).
+      // Only flip eligible if still not engaged and the release timestamp is
+      // unchanged (no re-engagement since scheduling).
       final currentReleaseAt = state.lastReleaseAt;
       if (state.isEngagedNow) return;
       if (currentReleaseAt == null) return;

--- a/lib/features/input/providers/sounding_note_numbers_providers.dart
+++ b/lib/features/input/providers/sounding_note_numbers_providers.dart
@@ -37,7 +37,7 @@ final soundingNoteNumbersProvider = Provider<Set<int>>((ref) {
   return ref.watch(liveSoundingNoteNumbersProvider);
 });
 
-/// Sorted sounding note numbers (e.g. bassMidi = first),
+/// Sorted sounding note numbers; the first entry is the lowest (bass).
 final soundingNoteNumbersSortedProvider = Provider<UnmodifiableListView<int>>((
   ref,
 ) {

--- a/lib/features/input/widgets/input_display/input_display.dart
+++ b/lib/features/input/widgets/input_display/input_display.dart
@@ -45,8 +45,8 @@ class _InputDisplayState extends ConsumerState<InputDisplay>
   static const double _followMargin = _fadeWidth;
   // Trailing gap between chips; the chip box carries it on its right side only.
   static const double _chipTrailingGap = 8.0;
-  // Wait for the insert animation to settle so the chip is full-size before we
-  // measure it; also coalesces rapid note-ons to a single follow.
+  // Wait for the insert animation to settle so the chip is full-size before
+  // it is measured; also coalesces rapid note-ons to a single follow.
   static const Duration _followSettleDelay = Duration(milliseconds: 160);
 
   late List<SoundingNote> _notes;

--- a/lib/features/lookup/lookup_voicing.dart
+++ b/lib/features/lookup/lookup_voicing.dart
@@ -1,7 +1,7 @@
 /// Pure helpers for turning entered pitch classes into a MIDI voicing.
 ///
-/// The selection is an ordered list (first entry is the bass). We build an
-/// ascending stack: each note after the bass is placed at the lowest octave
+/// The selection is an ordered list (first entry is the bass). The voicing is
+/// an ascending stack: each note after the bass is placed at the lowest octave
 /// strictly above the previous note. This preserves the order notes were
 /// tapped (MIDI order tracks press order) and lets repeats climb to the next
 /// octave instead of collapsing. Chord identity is unaffected since analysis
@@ -12,7 +12,8 @@ class LookupVoicing {
   /// Bass octave (C3..B3). The first note lands here.
   static const int bassOctaveBase = 48;
 
-  /// Highest note we will climb to (C8), to keep voicings on the keyboard.
+  /// Highest note the stack may climb to (C8), keeping voicings on the
+  /// keyboard.
   static const int _maxMidi = 108;
 
   /// Builds the ascending MIDI voicing for [orderedPitchClasses].

--- a/lib/features/midi/midi.dart
+++ b/lib/features/midi/midi.dart
@@ -1,32 +1,31 @@
-// ignore: dangling_library_doc_comments
-///
 /// MIDI device connection infrastructure (Bluetooth + wired/native).
 ///
 /// ## Architecture Layers
 ///
 /// 1. **Transport** ([MidiDeviceManager]):
-///    - Bluetooth central management, scanning, and device discovery
-///    - Low-level connect/disconnect operations
+///    - Bluetooth central management, scanning, and device discovery.
+///    - Low-level connect/disconnect operations.
 ///
 /// 2. **Connection Workflow** ([MidiConnectionNotifier]):
-///    - Retry logic, auto-reconnect, backoff
-///    - User-facing connection state machine
+///    - Retry logic, auto-reconnect, backoff.
+///    - User-facing connection state machine.
 ///
 /// 3. **Presentation** ([MidiConnectionStatus]):
-///    - UI-friendly status labels and details
-///    - Computed from connection state
+///    - UI-friendly status labels and details.
+///    - Computed from connection state.
 ///
 /// 4. **Message Parsing** ([MidiParser], [MidiNoteStateNotifier]):
-///    - Raw MIDI byte stream → domain events
-///    - Note on/off tracking, sustain pedal handling
+///    - Raw MIDI byte stream to domain events.
+///    - Note on/off tracking, sustain pedal handling.
 ///
 /// ## Usage
 ///
 /// Most app code should interact with:
-/// - [midiConnectionStateProvider] for connection state
-/// - [midiSoundingNoteNumbersProvider] for sounding note numbers
-/// - [MidiSettingsPage] for user-facing controls
-///
+/// - [midiConnectionStateProvider] for connection state.
+/// - [midiSoundingNoteNumbersProvider] for sounding note numbers.
+/// - [MidiSettingsPage] for user-facing controls.
+library;
+
 export 'models/midi_connection.dart';
 export 'models/midi_connection_status.dart';
 

--- a/lib/features/midi/models/midi_constants.dart
+++ b/lib/features/midi/models/midi_constants.dart
@@ -4,7 +4,7 @@ abstract class MidiConstants {
   static const int maxNote = 127;
   static const int middleC = 60;
 
-  /// Control Change (CC) numbers
+  /// Control Change (CC) numbers.
   static const int ccSustainPedal = 64;
   static const int ccAllSoundOff = 120;
   static const int ccAllNotesOff = 123;

--- a/lib/features/midi/providers/app_midi_lifecycle_provider.dart
+++ b/lib/features/midi/providers/app_midi_lifecycle_provider.dart
@@ -75,9 +75,10 @@ class _MidiLifecycleController with WidgetsBindingObserver {
         midi.setBackgrounded(false);
         connectionState.setBackgrounded(false);
 
-        // IMPORTANT: On iOS especially, the OS may drop Bluetooth connections while the
-        // app is backgrounded without our watchdog running. Reconcile first so
-        // we don't keep showing a stale "Connected" state and short-circuit reconnect.
+        // On iOS especially, the OS may drop Bluetooth connections while the
+        // app is backgrounded with no watchdog running. Reconcile first so a
+        // stale "Connected" state does not persist and short-circuit
+        // reconnect.
         unawaited(
           Future<void>.microtask(() async {
             await midi.reconcileConnectedDevice(
@@ -98,7 +99,8 @@ class _MidiLifecycleController with WidgetsBindingObserver {
       case AppLifecycleState.detached:
         midi.setBackgrounded(true);
         connectionState.setBackgrounded(true);
-        // Fire-and-forget: we only need best-effort scan stop while backgrounding.
+        // Fire-and-forget: best-effort scan stop is enough while
+        // backgrounding.
         unawaited(connectionState.stopScanning());
         break;
     }

--- a/lib/features/midi/providers/midi_ble_service_provider.dart
+++ b/lib/features/midi/providers/midi_ble_service_provider.dart
@@ -17,7 +17,7 @@ final midiCommandProvider = Provider<fmc.MidiCommand>((ref) {
   final cmd = fmc.MidiCommand(bleTransport: UniversalBleMidiTransport());
   if (!kReleaseMode) {
     // Surfaces the plugin's device merge, route, and BLE-to-CoreMIDI handoff
-    // diagnostics while we chase connection issues (debug and profile builds).
+    // diagnostics for connection debugging (debug and profile builds).
     cmd.logHandler = debugPrint;
     // Timestamped setup events (deviceConnected, deviceDisconnected, ...) to
     // pin down when a mid-session drop happens relative to launch.

--- a/lib/features/midi/providers/midi_connection_notifier.dart
+++ b/lib/features/midi/providers/midi_connection_notifier.dart
@@ -54,9 +54,9 @@ class MidiConnectionNotifier extends Notifier<MidiConnectionState> {
   MidiDeviceManager get _midi => ref.read(midiDeviceManagerProvider.notifier);
 
   /// Explicit user/controller cancel:
-  /// - cancels reconnect/backoff loops
-  /// - stops scanning
-  /// - normalizes UI state
+  /// - cancels reconnect/backoff loops.
+  /// - stops scanning.
+  /// - normalizes UI state.
   Future<void> cancel({String reason = 'user_cancel'}) async {
     if (_debugLog) debugPrint('[CONN] cancel reason=$reason');
     _cancelRequested = true;
@@ -67,10 +67,11 @@ class MidiConnectionNotifier extends Notifier<MidiConnectionState> {
 
     final connected = ref.read(midiDeviceManagerProvider).connectedDevice;
 
-    // Backgrounding must not drop a live connection; just pause scanning. A
+    // Backgrounding must not drop a live connection; only pause scanning. A
     // network session's local endpoint always reads connected even when its
     // peer is gone, so only trust the snapshot for the background case.
     if (reason == 'background' && connected?.isConnected == true) {
+      // Best-effort; the plugin may throw when the central is down.
       try {
         await _midi.stopScanning();
       } catch (_) {}
@@ -79,7 +80,8 @@ class MidiConnectionNotifier extends Notifier<MidiConnectionState> {
 
     // User cancel: abort any in-flight connect and stop scanning.
     // `disconnect()` bumps the manager's connect generation, so a connect that
-    // is parked mid-flight self-aborts instead of landing after we cancel.
+    // is parked mid-flight self-aborts instead of landing after the cancel.
+    // Best-effort teardown; the plugin may throw when the central is down.
     try {
       await _midi.disconnect();
     } catch (_) {}
@@ -136,7 +138,7 @@ class MidiConnectionNotifier extends Notifier<MidiConnectionState> {
         // Allow persisting the same device id again after disconnect/forget.
         _lastPersistedDeviceId = null;
 
-        // If we were connected and became disconnected, fall back to idle.
+        // On a connected-to-disconnected transition, fall back to idle.
         if (state.phase == MidiConnectionPhase.connected) {
           state = const MidiConnectionState.idle();
         }
@@ -144,86 +146,89 @@ class MidiConnectionNotifier extends Notifier<MidiConnectionState> {
     );
 
     // React to bluetooth availability changes.
-    ref.listen<
-      BluetoothState
-    >(midiDeviceManagerProvider.select((s) => s.bluetoothState), (prev, next) {
-      final bt = next;
-      if (_debugLog) {
-        debugPrint(
-          '[CONN] bt update prev=$prev next=$next phase=${state.phase}',
-        );
-      }
+    ref.listen<BluetoothState>(
+      midiDeviceManagerProvider.select((s) => s.bluetoothState),
+      (prev, next) {
+        final bt = next;
+        if (_debugLog) {
+          debugPrint(
+            '[CONN] bt update prev=$prev next=$next phase=${state.phase}',
+          );
+        }
 
-      final prevBt = _lastBluetoothState; // capture before overwrite
-      _lastBluetoothState = bt;
+        final prevBt = _lastBluetoothState; // capture before overwrite
+        _lastBluetoothState = bt;
 
-      final readyNow = _bluetoothReady(bt);
-      final wasReady = prevBt != null ? _bluetoothReady(prevBt) : false;
+        final readyNow = _bluetoothReady(bt);
+        final wasReady = prevBt != null ? _bluetoothReady(prevBt) : false;
 
-      if (!readyNow) {
-        final isInReconnectUi =
-            state.phase == MidiConnectionPhase.connecting ||
-            state.phase == MidiConnectionPhase.retrying ||
-            state.phase == MidiConnectionPhase.bluetoothUnavailable;
+        if (!readyNow) {
+          final isInReconnectUi =
+              state.phase == MidiConnectionPhase.connecting ||
+              state.phase == MidiConnectionPhase.retrying ||
+              state.phase == MidiConnectionPhase.bluetoothUnavailable;
 
-        final shouldPublishUnavailable =
-            bt != BluetoothState.unknown && (wasReady || isInReconnectUi);
+          final shouldPublishUnavailable =
+              bt != BluetoothState.unknown && (wasReady || isInReconnectUi);
 
-        if (!shouldPublishUnavailable) {
-          // Keep state as-is (usually idle) and just cache the bt value.
+          if (!shouldPublishUnavailable) {
+            // Keep state as-is (usually idle) and only cache the Bluetooth
+            // value.
+            return;
+          }
+
+          _cancelRetry();
+          _cancelRequested = true;
+
+          final nextReason = switch (bt) {
+            BluetoothState.poweredOff => BluetoothUnavailability.adapterOff,
+            BluetoothState.unauthorized =>
+              BluetoothUnavailability.permissionDenied,
+            BluetoothState.unknown => BluetoothUnavailability.notReady,
+            BluetoothState.poweredOn =>
+              BluetoothUnavailability.notReady, // unreachable here
+          };
+
+          // Preserve a stronger reason already set by permission gating.
+          final currentReason = state.unavailability;
+          final preserve =
+              currentReason ==
+              BluetoothUnavailability.permissionPermanentlyDenied;
+          final message = preserve ? state.message : bt.displayName;
+
+          state = state.copyWith(
+            phase: MidiConnectionPhase.bluetoothUnavailable,
+            message: message,
+            nextDelay: null,
+            attempt: 0,
+            unavailability: preserve ? currentReason : nextReason,
+          );
           return;
         }
 
-        _cancelRetry();
-        _cancelRequested = true;
+        // Only act on a transition to ready; repeated "on" events would spam
+        // reconnect attempts.
+        if (!wasReady && readyNow) {
+          // Bluetooth is ready again; allow reconnect attempts.
+          _cancelRequested = false;
 
-        final nextReason = switch (bt) {
-          BluetoothState.poweredOff => BluetoothUnavailability.adapterOff,
-          BluetoothState.unauthorized =>
-            BluetoothUnavailability.permissionDenied,
-          BluetoothState.unknown => BluetoothUnavailability.notReady,
-          BluetoothState.poweredOn =>
-            BluetoothUnavailability.notReady, // unreachable here
-        };
-
-        // Preserve a stronger reason already set by permission gating.
-        final currentReason = state.unavailability;
-        final preserve =
-            currentReason ==
-            BluetoothUnavailability.permissionPermanentlyDenied;
-        final message = preserve ? state.message : bt.displayName;
-
-        state = state.copyWith(
-          phase: MidiConnectionPhase.bluetoothUnavailable,
-          message: message,
-          nextDelay: null,
-          attempt: 0,
-          unavailability: preserve ? currentReason : nextReason,
-        );
-        return;
-      }
-
-      // Only act on a transition to ready (avoid spamming if we get repeated "on").
-      if (!wasReady && readyNow) {
-        // IMPORTANT: bluetooth is ready again; allow reconnect attempts.
-        _cancelRequested = false;
-
-        if (!_backgrounded) {
-          unawaited(
-            Future<void>.microtask(() {
-              if (_backgrounded) return;
-              if (_attemptInFlight) return;
-              unawaited(tryAutoReconnect(reason: 'bt-ready'));
-            }),
-          );
-        } else {
-          // clear stale UI if we're backgrounded.
-          if (state.phase == MidiConnectionPhase.bluetoothUnavailable) {
-            state = const MidiConnectionState.idle();
+          if (!_backgrounded) {
+            unawaited(
+              Future<void>.microtask(() {
+                if (_backgrounded) return;
+                if (_attemptInFlight) return;
+                unawaited(tryAutoReconnect(reason: 'bt-ready'));
+              }),
+            );
+          } else {
+            // Clear stale UI while backgrounded.
+            if (state.phase == MidiConnectionPhase.bluetoothUnavailable) {
+              state = const MidiConnectionState.idle();
+            }
           }
         }
-      }
-    });
+      },
+    );
 
     ref.onDispose(_cancelRetry);
     return const MidiConnectionState.idle();
@@ -377,7 +382,7 @@ class MidiConnectionNotifier extends Notifier<MidiConnectionState> {
         unawaited(_midi.reconcileConnectedDevice(reason: 'tryAutoReconnect'));
       }
 
-      // Preflight: we are about to attempt a connection; publish attempt=1.
+      // Preflight: publish attempt=1 before the connection attempt starts.
       state = state.copyWith(
         phase: MidiConnectionPhase.connecting,
         message: isManual
@@ -435,7 +440,7 @@ class MidiConnectionNotifier extends Notifier<MidiConnectionState> {
             );
           } catch (_) {
             if (_debugLog) debugPrint('[CONN] bluetooth prime failed');
-            // If we cannot prime, treat as not-ready and stop.
+            // If priming fails, treat Bluetooth as not ready and stop.
             _cancelRetry();
             state = state.copyWith(
               phase: MidiConnectionPhase.bluetoothUnavailable,
@@ -633,10 +638,10 @@ class MidiConnectionNotifier extends Notifier<MidiConnectionState> {
   }
 
   /// Manual refresh from UI.
-  /// - restartScan=true: "hard refresh" (stop/start scan)
-  /// - restartScan=false: force device list refresh while scanning
+  /// - restartScan=true: "hard refresh" (stop/start scan).
+  /// - restartScan=false: force a device list refresh while scanning.
   Future<void> refreshDevices({bool restartScan = true}) async {
-    // If you're in backoff/retry UI, a manual refresh should cancel the timer.
+    // A manual refresh cancels any pending backoff timer.
     _cancelRetry();
     if (_debugLog) debugPrint('[CONN] refreshDevices restartScan=$restartScan');
 
@@ -790,7 +795,7 @@ class MidiConnectionNotifier extends Notifier<MidiConnectionState> {
     try {
       return await completer.future.timeout(timeout);
     } on TimeoutException {
-      // Fall back to whatever we have at timeout (may still be unknown).
+      // Fall back to the last known state at timeout (may still be unknown).
       return ref.read(midiDeviceManagerProvider).bluetoothState;
     } finally {
       sub.close();

--- a/lib/features/midi/providers/midi_device_manager.dart
+++ b/lib/features/midi/providers/midi_device_manager.dart
@@ -123,7 +123,8 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
   bool _centralStarted = false;
   Future<void>? _centralStartInFlight;
 
-  // Internal coordination: signals whenever we publish a new device snapshot.
+  // Internal coordination: signals whenever a new device snapshot is
+  // published.
   final StreamController<void> _devicesChanged =
       StreamController<void>.broadcast();
 
@@ -133,8 +134,8 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
   MidiDeviceManagerState build() {
     state = MidiDeviceManagerState.initial;
 
-    // IMPORTANT: We install listeners early, but we do NOT prime Bluetooth here.
-    // Bluetooth will be primed lazily when scanning/connecting/reconnecting.
+    // Listeners install early, but Bluetooth is not primed here; priming
+    // happens lazily on scanning, connecting, or reconnecting.
     _setupListeners();
 
     ref.onDispose(() {
@@ -189,7 +190,7 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
   // Forcefully restart scanning (stop then start) as a recovery action.
   // Intended for "Refresh" / "Try again" UI when scanning stalls on some platforms.
   Future<void> restartScanning() async {
-    // If scan isn't running, just start.
+    // If no scan is running, start one.
     if (!state.isScanning) {
       await startScanning();
       return;
@@ -233,6 +234,7 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
       // the new device (the message stream is not filtered by device).
       final previous = state.connectedDevice;
       if (previous != null && previous.id != device.id) {
+        // Best-effort; the stale link may already be gone.
         try {
           await _disconnectBestEffort(
             previous.id,
@@ -243,17 +245,19 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
       }
 
       // Do not stop scanning until after connection is verified.
-      // With the Bluetooth service boundary, we connect by id and verify by querying state.
+      // With the Bluetooth service boundary, connecting is by id and verified
+      // by querying state.
       await _cleanupStaleConnection(device.id);
       await _performConnection(device.id);
       await _verifyConnection(device.id);
 
-      // A disconnect (or newer connect) landed while we were connecting: tear
-      // down the link we just made and do not publish it.
+      // A disconnect (or newer connect) landed mid-connect: tear down the
+      // link this attempt made and do not publish it.
       if (generation != _connectGeneration) {
         if (_debugLog) {
           debugPrint('[MGR] connect superseded id=${device.id}; aborting');
         }
+        // Best-effort teardown of the superseded link.
         try {
           await _disconnectBestEffort(device.id, transport: device.transport);
         } catch (_) {}
@@ -270,8 +274,8 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
   }
 
   Future<void> disconnect() async {
-    // Invalidate any in-flight connect (synchronously, before any await) so it
-    // self-aborts instead of re-publishing a connection after we drop it.
+    // Invalidate any in-flight connect (synchronously, before any await) so
+    // it self-aborts instead of re-publishing a connection after the drop.
     _connectGeneration++;
 
     final current = state.connectedDevice;
@@ -279,8 +283,8 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
 
     try {
       if (_debugLog) debugPrint('[MGR] disconnect id=${current.id}');
-      // Best-effort; do not force a prime just to disconnect.
-      // If central was never started, this should simply no-op.
+      // Best-effort; do not force a prime only to disconnect. If the central
+      // was never started, this is a no-op.
       await _disconnectBestEffort(current.id, transport: current.transport);
     } catch (e) {
       debugPrint('Warning: Error disconnecting MIDI device: $e');
@@ -372,8 +376,8 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
   Future<BluetoothAccessResult> ensureBluetoothAccess() =>
       _bluetoothPerms.ensureBluetoothAccess();
 
-  /// Foreground reconciliation: confirms whether our last-known connected device
-  /// is still actually connected at the plugin level.
+  /// Foreground reconciliation: confirms whether the last-known connected
+  /// device is still actually connected at the plugin level.
   ///
   /// This is particularly important on iOS where the OS may drop Bluetooth connections
   /// while the app is backgrounded without producing a timely setup-change event.
@@ -411,12 +415,12 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
     }
 
     try {
-      // If we believe we are connected, it is reasonable to prime the central
-      // on foreground so we can validate the connection.
+      // When a connection is believed live, prime the central on foreground
+      // to validate it.
       await _ensureBluetoothCentralReady();
     } catch (e) {
-      // If Bluetooth is off/unauthorized, our BT state listener should clear the
-      // connection anyway. If we cannot prime, don't blindly clear here.
+      // If Bluetooth is off/unauthorized, the Bluetooth state listener clears
+      // the connection anyway. If priming fails, do not blindly clear here.
       debugPrint('reconcileConnectedDevice($reason): prime failed: $e');
       return;
     }
@@ -439,7 +443,7 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
         );
         _setConnectedDevice(null);
       } else {
-        // Keep the flag fresh in case our stored snapshot drifted.
+        // Keep the flag fresh in case the stored snapshot drifted.
         _setConnectedDevice(current.copyWith(isConnected: true));
       }
     } catch (e) {
@@ -695,7 +699,8 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
       unawaited(_safeRefreshDevices(bypassThrottle: true));
     });
 
-    // Absolute timeout: do not reset just because device snapshots keep arriving.
+    // Absolute timeout: do not reset merely because device snapshots keep
+    // arriving.
     deadline = Timer(timeout, () {
       if (completer.isCompleted) return;
       if (_debugLog) {
@@ -738,6 +743,7 @@ class MidiDeviceManager extends Notifier<MidiDeviceManagerState> {
       }
       if (!connected) return;
 
+      // Best-effort; the reconnect proceeds regardless.
       await _ble.disconnect(deviceId);
       await Future<void>.delayed(_disconnectBeforeReconnectDelay);
     } catch (_) {}

--- a/lib/features/midi/providers/midi_preferences_notifier.dart
+++ b/lib/features/midi/providers/midi_preferences_notifier.dart
@@ -29,7 +29,7 @@ final lastConnectedMidiDeviceIdProvider = Provider<String?>((ref) {
   );
 });
 
-/// Whether we have a non-empty last-connected device id.
+/// Whether a non-empty last-connected device id is stored.
 final hasLastConnectedMidiDeviceProvider = Provider<bool>((ref) {
   final id = ref.watch(lastConnectedMidiDeviceIdProvider);
   return id != null && id.trim().isNotEmpty;

--- a/lib/features/midi/services/midi_ble_service.dart
+++ b/lib/features/midi/services/midi_ble_service.dart
@@ -31,9 +31,9 @@ class MidiBleService {
   /// Stream of parsed MIDI messages relevant to the app.
   ///
   /// The plugin parses raw bytes into typed messages with per-source state
-  /// (running status, multi-message packets); we translate those into our own
-  /// [MidiMessage] model and drop the ones we don't use. If the plugin exposes
-  /// no MIDI stream on this platform/version, this stream is empty.
+  /// (running status, multi-message packets); this service translates them
+  /// into the app's [MidiMessage] model and drops unused kinds. If the plugin
+  /// exposes no MIDI stream on this platform/version, this stream is empty.
   Stream<MidiMessage> get onMidiMessages =>
       _midi.onMidiDataReceived
           ?.map((event) => mapMessage(event.message))
@@ -41,7 +41,7 @@ class MidiBleService {
           .cast<MidiMessage>() ??
       const Stream<MidiMessage>.empty();
 
-  /// Translates a plugin message into our [MidiMessage] model.
+  /// Translates a plugin message into the app's [MidiMessage] model.
   ///
   /// Returns null for message kinds the app does not consume. Velocity-0 note
   /// on is already delivered by the plugin as a note off.

--- a/lib/features/midi/widgets/midi_device_picker.dart
+++ b/lib/features/midi/widgets/midi_device_picker.dart
@@ -373,7 +373,7 @@ class _MidiDevicePickerState extends ConsumerState<MidiDevicePicker> {
             ),
           ),
 
-          // Footer with refresh button
+          // Footer with the refresh button.
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Row(

--- a/lib/features/midi/widgets/midi_status_card.dart
+++ b/lib/features/midi/widgets/midi_status_card.dart
@@ -27,7 +27,6 @@ class MidiStatusCard extends StatelessWidget {
       if (status.phase == MidiConnectionPhase.retrying &&
           status.nextDelay != null)
         'Next retry in ${status.nextDelay!.inSeconds}s',
-      // If you later want error details etc, add more lines here.
     ];
 
     // Text() requires a non-null String.

--- a/lib/features/piano/services/piano_geometry.dart
+++ b/lib/features/piano/services/piano_geometry.dart
@@ -94,7 +94,7 @@ class PianoGeometry {
     final out = <int>[];
     int midi = firstWhiteMidi;
 
-    // Determine which white PC we start on.
+    // Determine the starting white pitch class.
     final normalizedStartPos = _computeStartPos(firstWhiteMidi);
 
     out.add(midi);

--- a/lib/features/piano/services/piano_view_metrics.dart
+++ b/lib/features/piano/services/piano_view_metrics.dart
@@ -5,7 +5,7 @@ import 'piano_geometry.dart';
 
 /// Resolved keyboard dimensions for a viewport, after applying the user's
 /// [PianoViewSettings]. Shared by every page that renders the keyboard so the
-/// sizing math (previously copy-pasted) lives in one place.
+/// sizing math lives in one place.
 @immutable
 class PianoViewMetrics {
   const PianoViewMetrics({

--- a/lib/features/piano/widgets/piano_keyboard/scrollable_piano_keyboard.dart
+++ b/lib/features/piano/widgets/piano_keyboard/scrollable_piano_keyboard.dart
@@ -52,8 +52,9 @@ class _ScrollIndicatorState {
 ///
 /// A single finger is left entirely to the scroll view (its movement is
 /// ignored), so one-finger drags scroll as usual. As soon as a second finger
-/// lands we claim the gesture arena outright: otherwise the scroll view's
-/// (greedy) horizontal drag recognizer wins the moment a finger crosses touch
+/// lands, the recognizer claims the gesture arena outright: otherwise the
+/// scroll view's (greedy) horizontal drag recognizer wins the moment a finger
+/// crosses touch
 /// slop, stealing the pinch before its scale delta grows enough to assert
 /// itself. Two fingers always means zoom; one finger always means scroll.
 class _PinchScaleGestureRecognizer extends ScaleGestureRecognizer {
@@ -648,7 +649,7 @@ class _ScrollablePianoKeyboardState
     final added = next.difference(prev);
     final removed = prev.difference(next);
 
-    // Update the set now that we've captured diffs.
+    // Update the set now that diffs are captured.
     _previousHighlightedNotes = Set<int>.from(next);
 
     // Decide whether anything is actually offscreen.

--- a/lib/features/scales/pages/scale_explorer_page.dart
+++ b/lib/features/scales/pages/scale_explorer_page.dart
@@ -434,8 +434,9 @@ class _ScaleExplorerPageState extends ConsumerState<ScaleExplorerPage> {
 
   /// The scale to seed onto for [tonality]. Major keys seed the major scale and
   /// minor keys seed natural minor, except when the seeding chord matched the
-  /// key's harmonic minor harmony: there we seed harmonic minor so the explorer
-  /// opens on the same scale the home page's scale-degree strip adjusted to.
+  /// key's harmonic minor harmony: then harmonic minor is seeded so the
+  /// explorer opens on the same scale the home page's scale-degree strip
+  /// adjusted to.
   static ScaleKind _seedKindFor(
     Tonality tonality,
     ScaleDegreeAnalysis? analysis,

--- a/lib/features/theory/presentation/models/identity_display.dart
+++ b/lib/features/theory/presentation/models/identity_display.dart
@@ -3,9 +3,9 @@ import 'package:whatchord/whatchord.dart';
 
 /// UI-facing identity produced by analysis, depending on input cardinality.
 ///
-/// - 1 note -> NoteDisplay
-/// - 2 notes -> IntervalDisplay
-/// - 3+ notes -> ChordDisplay
+/// - 1 note -> [NoteDisplay].
+/// - 2 notes -> [IntervalDisplay].
+/// - 3+ notes -> [ChordDisplay].
 @immutable
 sealed class IdentityDisplay {
   const IdentityDisplay({

--- a/lib/features/theory/presentation/widgets/tonality_picker_sheet.dart
+++ b/lib/features/theory/presentation/widgets/tonality_picker_sheet.dart
@@ -114,7 +114,7 @@ class TonalityPickerBody extends ConsumerStatefulWidget {
     this.recenterSignal = false,
   });
 
-  /// Header height with neither panel title nor staff preview: just the
+  /// Header height with neither panel title nor staff preview: only the
   /// column labels and their divider.
   static const double slimHeaderHeight = 36.0;
 

--- a/lib/features/theory/state/providers/chord_member_spellings_providers.dart
+++ b/lib/features/theory/state/providers/chord_member_spellings_providers.dart
@@ -19,7 +19,7 @@ final chordMemberDegreesProvider = Provider<List<String>>((ref) {
 
 /// Role-aware spelled chord members keyed by pitch class (0..11).
 ///
-/// This is preferred over a list of strings when we need a stable label per key/note.
+/// Preferred over a list of strings when a stable label per key is needed.
 final chordMemberSpellingsByPcProvider = Provider<Map<int, String>>((ref) {
   final presentation = ref.watch(chordPresentationProvider);
   if (presentation == null) return const <int, String>{};

--- a/packages/whatchord/lib/whatchord.dart
+++ b/packages/whatchord/lib/whatchord.dart
@@ -1,3 +1,9 @@
+/// Chord identification and harmony analysis: [ChordAnalyzer] names and
+/// explains voicings, construction derives canonical examples from a
+/// [ChordSpec], and formatters render identities as symbols, spoken names,
+/// long-form names, and Harte notation.
+library;
+
 // Analysis engine
 export 'src/analysis/chord_analyzer.dart';
 export 'src/analysis/chord_candidate_ranking.dart';

--- a/packages/whatkey/lib/whatkey.dart
+++ b/packages/whatkey/lib/whatkey.dart
@@ -1,3 +1,8 @@
+/// Streaming key detection from live chord evidence: [KeyDetector]
+/// implementations consume committed chord events and maintain a claim over
+/// the 24 major and minor keys, abstaining when evidence is thin.
+library;
+
 // Detectors
 export 'src/detectors/bocpd_key_detector.dart';
 export 'src/detectors/claim_hysteresis_detector.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,7 @@
 name: whatchord_app
-description: Real-time chord identification via Bluetooth MIDI.
+description:
+  Chord identification, key detection, and harmony exploration from live MIDI
+  or manual note entry.
 
 workspace:
   - packages/whatchord


### PR DESCRIPTION
Rewrite conversational comments in an impersonal register, largely in the MIDI connection stack, and align formatting with Effective Dart: sentence capitalization and punctuation, periods on doc-list items, and a proper library directive for the midi barrel doc. Remove a future advice comment and a historical aside. Spatial wording, runtime conditions, and screenshot script labels are deliberately untouched.