### PR TITLE
Replace the nav checkbox hack with a disclosure button

### DIFF
--- a/docs/site/articles/benchmarking-on-hardware-you-dont-control.html
+++ b/docs/site/articles/benchmarking-on-hardware-you-dont-control.html
@@ -63,13 +63,16 @@
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
         <div class="nav-spacer"></div>
-        <input
-          type="checkbox"
-          id="nav-toggle"
-          class="nav-toggle"
+        <button
+          class="nav-burger"
+          type="button"
           aria-label="Menu"
-        />
-        <div class="nav-menu">
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <span></span>
+        </button>
+        <div class="nav-menu" id="nav-menu">
           <a class="btn btn-ghost" href="./"
             ><svg
               class="nav-icon"
@@ -105,7 +108,6 @@
           href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
           >Get the app</a
         >
-        <label class="nav-burger" for="nav-toggle"><span></span></label>
       </div>
     </nav>
 

--- a/docs/site/articles/chord-naming.html
+++ b/docs/site/articles/chord-naming.html
@@ -57,13 +57,16 @@
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
         <div class="nav-spacer"></div>
-        <input
-          type="checkbox"
-          id="nav-toggle"
-          class="nav-toggle"
+        <button
+          class="nav-burger"
+          type="button"
           aria-label="Menu"
-        />
-        <div class="nav-menu">
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <span></span>
+        </button>
+        <div class="nav-menu" id="nav-menu">
           <a class="btn btn-ghost" href="./"
             ><svg
               class="nav-icon"
@@ -99,7 +102,6 @@
           href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
           >Get the app</a
         >
-        <label class="nav-burger" for="nav-toggle"><span></span></label>
       </div>
     </nav>
 
@@ -135,10 +137,7 @@
           </p>
 
           <div class="member-stack-scroll">
-            <table
-              class="member-stack"
-              aria-label="C-rooted tertian note names with degree numbers"
-            >
+            <table class="member-stack">
               <caption>
                 Tertian Slots Above C
               </caption>
@@ -434,10 +433,7 @@
           <p>Start by stacking thirds above C through the ninth:</p>
 
           <div class="member-stack-scroll">
-            <table
-              class="member-stack"
-              aria-label="C-rooted tertian note names through the ninth with degree numbers"
-            >
+            <table class="member-stack">
               <caption>
                 Tertian Slots Above C
               </caption>
@@ -474,10 +470,7 @@
           </p>
 
           <div class="member-stack-scroll">
-            <table
-              class="member-stack"
-              aria-label="Sounding note names mapped to degree numbers"
-            >
+            <table class="member-stack">
               <caption>
                 Sounding Notes Interpreted Above C
               </caption>
@@ -522,10 +515,7 @@
           </p>
 
           <div class="member-stack-scroll">
-            <table
-              class="member-stack"
-              aria-label="Sounding note names mapped to degree numbers above E"
-            >
+            <table class="member-stack">
               <caption>
                 Sounding Notes Interpreted Above E
               </caption>

--- a/docs/site/articles/chord-ranking-performance.html
+++ b/docs/site/articles/chord-ranking-performance.html
@@ -65,13 +65,16 @@
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
         <div class="nav-spacer"></div>
-        <input
-          type="checkbox"
-          id="nav-toggle"
-          class="nav-toggle"
+        <button
+          class="nav-burger"
+          type="button"
           aria-label="Menu"
-        />
-        <div class="nav-menu">
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <span></span>
+        </button>
+        <div class="nav-menu" id="nav-menu">
           <a class="btn btn-ghost" href="./"
             ><svg
               class="nav-icon"
@@ -107,7 +110,6 @@
           href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
           >Get the app</a
         >
-        <label class="nav-burger" for="nav-toggle"><span></span></label>
       </div>
     </nav>
 

--- a/docs/site/articles/chord-recognition-algorithm.html
+++ b/docs/site/articles/chord-recognition-algorithm.html
@@ -39,13 +39,16 @@
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
         <div class="nav-spacer"></div>
-        <input
-          type="checkbox"
-          id="nav-toggle"
-          class="nav-toggle"
+        <button
+          class="nav-burger"
+          type="button"
           aria-label="Menu"
-        />
-        <div class="nav-menu">
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <span></span>
+        </button>
+        <div class="nav-menu" id="nav-menu">
           <a class="btn btn-ghost" href="./"
             ><svg
               class="nav-icon"
@@ -81,7 +84,6 @@
           href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
           >Get the app</a
         >
-        <label class="nav-burger" for="nav-toggle"><span></span></label>
       </div>
     </nav>
 

--- a/docs/site/articles/chord-symbols.html
+++ b/docs/site/articles/chord-symbols.html
@@ -57,13 +57,16 @@
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
         <div class="nav-spacer"></div>
-        <input
-          type="checkbox"
-          id="nav-toggle"
-          class="nav-toggle"
+        <button
+          class="nav-burger"
+          type="button"
           aria-label="Menu"
-        />
-        <div class="nav-menu">
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <span></span>
+        </button>
+        <div class="nav-menu" id="nav-menu">
           <a class="btn btn-ghost" href="./"
             ><svg
               class="nav-icon"
@@ -99,7 +102,6 @@
           href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
           >Get the app</a
         >
-        <label class="nav-burger" for="nav-toggle"><span></span></label>
       </div>
     </nav>
 

--- a/docs/site/articles/index.html
+++ b/docs/site/articles/index.html
@@ -61,13 +61,16 @@
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
         <div class="nav-spacer"></div>
-        <input
-          type="checkbox"
-          id="nav-toggle"
-          class="nav-toggle"
+        <button
+          class="nav-burger"
+          type="button"
           aria-label="Menu"
-        />
-        <div class="nav-menu">
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <span></span>
+        </button>
+        <div class="nav-menu" id="nav-menu">
           <a class="btn btn-ghost" href="./" aria-current="page"
             ><svg
               class="nav-icon"
@@ -103,7 +106,6 @@
           href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
           >Get the app</a
         >
-        <label class="nav-burger" for="nav-toggle"><span></span></label>
       </div>
     </nav>
 

--- a/docs/site/articles/million-chord-annotations.html
+++ b/docs/site/articles/million-chord-annotations.html
@@ -42,13 +42,16 @@
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
         <div class="nav-spacer"></div>
-        <input
-          type="checkbox"
-          id="nav-toggle"
-          class="nav-toggle"
+        <button
+          class="nav-burger"
+          type="button"
           aria-label="Menu"
-        />
-        <div class="nav-menu">
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <span></span>
+        </button>
+        <div class="nav-menu" id="nav-menu">
           <a class="btn btn-ghost" href="./"
             ><svg
               class="nav-icon"
@@ -84,7 +87,6 @@
           href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
           >Get the app</a
         >
-        <label class="nav-burger" for="nav-toggle"><span></span></label>
       </div>
     </nav>
 

--- a/docs/site/articles/why-chord-naming-is-hard.html
+++ b/docs/site/articles/why-chord-naming-is-hard.html
@@ -63,13 +63,16 @@
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
         <div class="nav-spacer"></div>
-        <input
-          type="checkbox"
-          id="nav-toggle"
-          class="nav-toggle"
+        <button
+          class="nav-burger"
+          type="button"
           aria-label="Menu"
-        />
-        <div class="nav-menu">
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <span></span>
+        </button>
+        <div class="nav-menu" id="nav-menu">
           <a class="btn btn-ghost" href="./"
             ><svg
               class="nav-icon"
@@ -105,7 +108,6 @@
           href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
           >Get the app</a
         >
-        <label class="nav-burger" for="nav-toggle"><span></span></label>
       </div>
     </nav>
 

--- a/docs/site/css/style.css
+++ b/docs/site/css/style.css
@@ -259,11 +259,9 @@ img {
   color: #bfbfd0;
 }
 
-/* The checkbox drives the CSS-only menu, but it is only meaningful on narrow
-   screens. Off by default (no phantom tab stop on desktop, where the menu is
-   always open); the hamburger breakpoint restores it as a focusable,
-   visually-hidden control. */
-.nav-toggle,
+/* The hamburger button only matters on narrow screens. Off by default (no
+   phantom tab stop on desktop, where the menu is always open); the hamburger
+   breakpoint restores it. */
 .nav-burger {
   display: none;
 }
@@ -1668,7 +1666,6 @@ a.heading-anchor svg {
   }
 
   .article-page .nav-spacer,
-  .article-page .nav-toggle,
   .article-page .nav-menu,
   .article-page .btn-get-app,
   .article-page .nav-burger {
@@ -2034,7 +2031,6 @@ a.heading-anchor svg {
   }
 
   .articles-index-page .nav-spacer,
-  .articles-index-page .nav-toggle,
   .articles-index-page .nav-menu,
   .articles-index-page .btn-get-app,
   .articles-index-page .nav-burger,
@@ -2192,23 +2188,16 @@ a.heading-anchor svg {
 /* Collapse Articles + Source into a hamburger menu on phones, keeping the
    logo and the primary "Get the app" CTA visible inline. */
 @media (width <= 640px) {
-  /* Visually hidden but focusable, so keyboard and AT users can operate it. */
-  .nav-toggle {
-    position: absolute;
-    display: block;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    white-space: nowrap;
-    clip-path: inset(50%);
-  }
-
+  /* The button sits before the menu in the DOM (so tab order flows from the
+     trigger into the disclosed links); order places it visually last. */
   .nav-burger {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    order: 1;
     width: 40px;
     height: 40px;
+    padding: 0;
     color: var(--text-2);
     cursor: pointer;
     background: transparent;
@@ -2258,11 +2247,11 @@ a.heading-anchor svg {
     box-shadow: var(--shadow);
   }
 
-  .nav-toggle:checked ~ .nav-menu {
+  .nav-menu.is-open {
     display: flex;
   }
 
-  .nav-toggle:focus-visible ~ .nav-burger {
+  .nav-burger:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
   }

--- a/docs/site/css/try.css
+++ b/docs/site/css/try.css
@@ -600,7 +600,6 @@ select.try-select:focus {
   }
 
   .try-page .nav-spacer,
-  .try-page .nav-toggle,
   .try-page .nav-menu,
   .try-page .btn-get-app,
   .try-page .nav-burger {

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -44,13 +44,16 @@
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
         <div class="nav-spacer"></div>
-        <input
-          type="checkbox"
-          id="nav-toggle"
-          class="nav-toggle"
+        <button
+          class="nav-burger"
+          type="button"
           aria-label="Menu"
-        />
-        <div class="nav-menu">
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <span></span>
+        </button>
+        <div class="nav-menu" id="nav-menu">
           <a class="btn btn-ghost" href="articles/"
             ><svg
               class="nav-icon"
@@ -86,7 +89,6 @@
           href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
           >Get the app</a
         >
-        <label class="nav-burger" for="nav-toggle"><span></span></label>
       </div>
     </nav>
 

--- a/docs/site/js/site.js
+++ b/docs/site/js/site.js
@@ -81,9 +81,7 @@
 
     function resolvedPageUrl() {
       var pageUrl =
-        (canonicalLink && canonicalLink.href) ||
-        (ogUrl && ogUrl.content) ||
-        "";
+        (canonicalLink && canonicalLink.href) || (ogUrl && ogUrl.content) || "";
 
       if (/^https?:$/.test(window.location.protocol)) {
         return window.location.href;
@@ -135,31 +133,27 @@
     window.addEventListener("beforeprint", syncPrintUrls);
   }
 
-  // The mobile nav menu opens and closes via a CSS-only checkbox toggle. Add
-  // the conveniences CSS can't: close on an outside click, on Escape, or after
-  // choosing an item, and keep aria-expanded in sync.
-  var navToggle = document.getElementById("nav-toggle");
-  var navMenu = document.querySelector(".nav-menu");
+  // The mobile nav menu is a disclosure: the hamburger button toggles the
+  // menu and reports its state via aria-expanded. Also close on an outside
+  // click, on Escape, or after choosing an item.
   var navBurger = document.querySelector(".nav-burger");
-  if (navToggle && navMenu) {
-    function setNavOpen(open) {
-      navToggle.checked = open;
-      navToggle.setAttribute("aria-expanded", String(open));
+  var navMenu = document.querySelector(".nav-menu");
+  if (navBurger && navMenu) {
+    function navOpen() {
+      return navBurger.getAttribute("aria-expanded") === "true";
     }
 
-    setNavOpen(navToggle.checked);
+    function setNavOpen(open) {
+      navBurger.setAttribute("aria-expanded", String(open));
+      navMenu.classList.toggle("is-open", open);
+    }
+
+    navBurger.addEventListener("click", function () {
+      setNavOpen(!navOpen());
+    });
 
     document.addEventListener("click", function (event) {
-      // Let the checkbox and its label toggle themselves. (Clicking the label
-      // also fires a synthetic click on the hidden checkbox; ignoring it here
-      // is what keeps the menu from snapping shut the instant it opens.)
-      if (
-        event.target === navToggle ||
-        (navBurger && navBurger.contains(event.target))
-      ) {
-        return;
-      }
-      if (!navToggle.checked) return;
+      if (!navOpen() || navBurger.contains(event.target)) return;
       // A chosen menu link closes the menu (then navigates); any other outside
       // click just closes it.
       if (navMenu.contains(event.target)) {
@@ -170,9 +164,9 @@
     });
 
     document.addEventListener("keydown", function (event) {
-      if (event.key === "Escape" && navToggle.checked) {
+      if (event.key === "Escape" && navOpen()) {
         setNavOpen(false);
-        navToggle.focus();
+        navBurger.focus();
       }
     });
   }

--- a/docs/site/try.html
+++ b/docs/site/try.html
@@ -60,13 +60,16 @@
           <span>What<span class="logo-bold">Chord</span></span>
         </a>
         <div class="nav-spacer"></div>
-        <input
-          type="checkbox"
-          id="nav-toggle"
-          class="nav-toggle"
+        <button
+          class="nav-burger"
+          type="button"
           aria-label="Menu"
-        />
-        <div class="nav-menu">
+          aria-expanded="false"
+          aria-controls="nav-menu"
+        >
+          <span></span>
+        </button>
+        <div class="nav-menu" id="nav-menu">
           <a class="btn btn-ghost" href="articles/"
             ><svg
               class="nav-icon"
@@ -102,7 +105,6 @@
           href="https://apps.apple.com/us/app/whatchord-midi/id6758409779"
           >Get the app</a
         >
-        <label class="nav-burger" for="nav-toggle"><span></span></label>
       </div>
     </nav>
 


### PR DESCRIPTION
Convert the mobile hamburger from a checkbox+label CSS toggle to a real button with aria-expanded and aria-controls, moving open/close handling into site.js. Screen readers now announce it as an expandable button instead of a checkbox, and keyboard behavior is unchanged.

Also let the visible captions name the member-stack tables in the chord naming article; their aria-labels overrode the captions, so assistive tech heard a different name than sighted readers saw.