### PR TITLE
Expand package READMEs for eventual pub.dev publication

### DIFF
--- a/packages/whatchord/README.md
+++ b/packages/whatchord/README.md
@@ -1,17 +1,117 @@
 # whatchord
 
 The pure Dart chord identification and harmony analysis engine behind
-[WhatChord](https://whatchord.earthmanmuons.com/). No Flutter dependencies.
+[WhatChord](https://whatchord.earthmanmuons.com/). No Flutter dependencies; the
+only runtime dependency is `package:meta`.
 
-`ChordAnalyzer.analyze()` takes a `ChordInput` (set of pitch classes) plus an
-`AnalysisContext` and returns ranked `ChordCandidate` results, using ranking
-heuristics that encode musician-expected naming conventions. Supporting services
-cover note spelling, chord quality intervals, scale harmonization, and scale
-degree classification. Formatters render identities as chord symbols, spoken
-names, long-form academic names, and Harte notation. The construction services
-answer the inverse question: given a selected `ChordSpec` (root, quality,
-extensions), derive a canonical example voicing and the compatible options.
+The engine optimizes for musician-expected naming: given an observed voicing, it
+prefers the stable, conventional reading over simple note-matching, surfaces the
+plausible alternatives instead of hiding ambiguity, and can explain why the
+winner ranked first.
 
-This package is consumed by the WhatChord app via a path dependency and is not
-yet published; its public API is still being curated as part of the extraction
-from the app codebase.
+## Features
+
+- **Chord identification.** `ChordAnalyzer.analyze()` takes a `ChordInput` (a
+  set of pitch classes plus the bass) and an `AnalysisContext` (key and spelling
+  policy) and returns ranked `ChordCandidate` results, memoized in a 512-entry
+  LRU cache.
+- **Alternatives and explanations.** `ChordCandidateRanking.alternatives()`
+  picks out the readings priced close to the winner, and
+  `ChordAnalyzer.explain()` returns each candidate's cost breakdown along with
+  the rule that ordered it against its neighbor.
+- **Chord construction.** The inverse question: given a selected root, quality,
+  extensions, and bass, `ChordExampleBuilder` derives a canonical example
+  voicing, and the option services report which extensions and bass notes are
+  compatible with the current selection.
+- **Formatting.** Renders chord identities as symbols (textual or traditional
+  symbolic notation), spoken names, long-form academic names, and Harte
+  notation.
+- **Notes, scales, and degrees.** Context-aware enharmonic note spelling, chord
+  quality intervals, scale harmonization, Roman numeral degree classification,
+  and scale voicings.
+- **Temporal context.** `ChordEvent` (a committed chord from live play) and
+  `ChordEventSegmenter` turn a stream of analyses into discrete events; these
+  feed the [whatkey][WHATKEY] key detectors.
+
+[WHATKEY]: https://github.com/EarthmanMuons/whatchord/tree/main/packages/whatkey
+
+## Getting started
+
+The package requires Dart SDK 3.8 or later and runs anywhere Dart runs (VM,
+Flutter, web). It is developed in the [WhatChord monorepo][REPO] and consumed by
+the app through the repository's pub workspace; it is not yet published to
+pub.dev.
+
+[REPO]: https://github.com/EarthmanMuons/whatchord
+
+## Usage
+
+```dart
+import 'package:whatchord/whatchord.dart';
+
+void main() {
+  const tonality = Tonality(Tonic.c, TonalityMode.major);
+  final keySignature = KeySignature.fromTonality(tonality);
+  final context = AnalysisContext(
+    tonality: tonality,
+    keySignature: keySignature,
+    spellingPolicy: NoteSpellingPolicy(preferFlats: keySignature.prefersFlats),
+  );
+
+  // C E G A reads as C6 or as Am7 over C; the engine weighs both.
+  final pcs = [for (final n in ['C', 'E', 'G', 'A']) pitchClassFromNoteName(n)];
+  final input = ChordInput(
+    pcMask: pcs.fold(0, (mask, pc) => mask | 1 << pc),
+    bassPc: pcs.first,
+    noteCount: pcs.length,
+  );
+
+  final candidates = ChordAnalyzer.analyze(input, context: context);
+  final symbol = ChordSymbolBuilder.formatIdentity(
+    identity: candidates.first.identity,
+    tonality: tonality,
+    notation: ChordNotationStyle.textual,
+  );
+  print(symbol); // C6
+}
+```
+
+The [example](example/example.dart) is a fuller tour: presentation formatting,
+alternatives, ranking explanations, chord construction from a spec, and scale
+harmonization.
+
+Two secondary libraries ship alongside the main one:
+
+- `package:whatchord/testing.dart` provides factories for analysis contexts and
+  chord inputs, for use in downstream tests.
+- `package:whatchord/diagnostics.dart` exposes engine instrumentation counters
+  for benchmarks and performance analysis.
+
+## Design notes
+
+Analysis and construction answer different questions and are tuned differently:
+analysis names an observed voicing the way a musician would expect, while
+construction produces canonical, clean examples of a selected chord symbol. The
+ranking is cost-based; hard preference rules are kept to a minimum and each
+surviving rule is documented in the explanation traces.
+
+## Additional information
+
+The package follows [Semantic Versioning](https://semver.org/); while the
+version is below 1.0.0, minor releases may include breaking API changes (see the
+[changelog](CHANGELOG.md)).
+
+If you believe a chord has been identified incorrectly, please [open an
+issue][ISSUE]. When possible, include the notes played, the key signature, and
+the chord reported versus the expected result.
+
+[ISSUE]: https://github.com/EarthmanMuons/whatchord/issues/new/choose
+
+## License
+
+This package is released under the [Zero Clause BSD License](LICENSE) (SPDX:
+0BSD).
+
+Copyright &copy; 2025&ndash;2026 [Aaron Bull Schaefer][EMAIL] and contributors
+
+[EMAIL]: mailto:aaron@elasticdog.com

--- a/packages/whatkey/README.md
+++ b/packages/whatkey/README.md
@@ -2,21 +2,108 @@
 
 Streaming key (tonal center) detection for
 [WhatChord](https://whatchord.earthmanmuons.com/). Pure Dart; consumes chord
-evidence from the [whatchord](../whatchord/) engine.
+evidence from the [whatchord][WHATCHORD] engine.
 
-The detector is a compact hidden Markov model run strictly forward in time: it
-keeps a posterior over the 24 major and minor keys, updates it from committed
-`ChordEvent`s, and abstains when the leading candidates are too close. The
-`KeyBehavior` presets trade section-key stability against local-key
-responsiveness, and display calibration keeps user-facing confidence honest
-without changing the detector's decisions.
+The shipped detector is a compact hidden Markov model run strictly forward in
+time: it keeps a posterior over the 24 major and minor keys, updates it from
+committed `ChordEvent`s, and abstains when the leading candidates are too close.
+When the evidence is ambiguous, it waits instead of guessing.
 
-The design, evaluation protocol, and experiment record live in the [WhatKey
-research directory][research], including the preprint describing the headline
-results.
+[WHATCHORD]:
+  https://github.com/EarthmanMuons/whatchord/tree/main/packages/whatchord
 
-[research]:
+## Features
+
+- **HMM key detector.** `HmmKeyDetector` is the production detector: chord
+  evidence in, a `KeyEstimateFrame` out after every event, with a full ranking
+  over all 24 keys.
+- **Abstention over guessing.** Claim hysteresis separates "leading candidate"
+  from "claimed key", so the detector reports no key at all until the evidence
+  clears a margin, and holds a claim through brief contradictions.
+- **Behavior presets.** `KeyBehavior` packages the research-tuned timescales,
+  trading section-key stability against local-key responsiveness.
+- **Honest confidence display.** `DisplayCalibration` maps posterior mass to
+  user-facing confidence without changing the detector's decisions.
+- **Baselines and alternatives.** The `KeyDetector` interface is also
+  implemented by the research detectors (profile correlation, weighted evidence,
+  progression, BOCPD, hybrid), kept for comparison and evaluation.
+
+## Getting started
+
+The package requires Dart SDK 3.8 or later and depends on the whatchord engine
+for its chord evidence types. It is developed in the [WhatChord monorepo][REPO]
+and consumed by the app through the repository's pub workspace; it is not yet
+published to pub.dev.
+
+[REPO]: https://github.com/EarthmanMuons/whatchord
+
+## Usage
+
+A detector is driven by committed `ChordEvent`s, which the whatchord engine
+produces from live play (via `ChordAnalyzer` and `ChordEventSegmenter`):
+
+```dart
+import 'package:whatchord/whatchord.dart';
+import 'package:whatkey/whatkey.dart';
+
+void main() {
+  final behavior = KeyBehavior.balanced;
+  final detector = HmmKeyDetector(decayHalfLife: behavior.emissionHalfLife);
+
+  detector.reset();
+  // liveChordEvents: an Iterable<ChordEvent> from your capture pipeline.
+  for (final event in liveChordEvents) {
+    final frame = detector.onEvent(event);
+    final claim = frame.claim;
+    print(claim == null ? 'abstains' : 'claims ${claim.tonality.displayName}');
+  }
+}
+```
+
+The [example](example/example.dart) builds the full pipeline: it runs a chord
+progression through the whatchord recognizer, feeds the events to the detector,
+and prints the claim after each chord. For I vi IV V7 I in C major followed by a
+ii-V-I modulation to Eb major, it produces:
+
+```
+C     -> abstains (not enough evidence)
+Am    -> abstains (not enough evidence)
+F     -> claims C major (55% shown)
+G7    -> claims C major (61% shown)
+C     -> claims C major (79% shown)
+Fm7   -> claims C major (87% shown)
+Bb7   -> claims C major (65% shown)
+Eb    -> claims C major (38% shown)
+Ab    -> abstains (not enough evidence)
+Eb    -> claims Eb major (51% shown)
+```
+
+## Research
+
+The detector design, frozen evaluation protocol, versioned fixtures, external
+baselines, and dated experiment logs live in the [WhatKey research
+directory][RESEARCH], including the preprint describing the headline results.
+
+[RESEARCH]:
   https://github.com/EarthmanMuons/whatchord/tree/main/research/whatkey
 
-This package is consumed by the WhatChord app via the repository's pub workspace
-and is not yet published; its public API is still being curated.
+## Additional information
+
+The package follows [Semantic Versioning](https://semver.org/); while the
+version is below 1.0.0, minor releases may include breaking API changes (see the
+[changelog](CHANGELOG.md)).
+
+Bug reports and questions are welcome on the [issue tracker][ISSUE]. For
+suspected wrong key calls, the chord sequence that produced them is the most
+useful thing to include.
+
+[ISSUE]: https://github.com/EarthmanMuons/whatchord/issues/new/choose
+
+## License
+
+This package is released under the [Zero Clause BSD License](LICENSE) (SPDX:
+0BSD).
+
+Copyright &copy; 2025&ndash;2026 [Aaron Bull Schaefer][EMAIL] and contributors
+
+[EMAIL]: mailto:aaron@elasticdog.com


### PR DESCRIPTION
Restructure the whatchord and whatkey package READMEs around the sections pub.dev listings expect: features, getting started, a verified usage snippet, example pointers, versioning and issue guidance, and the standard license section from the app README. Drop the public API curation sidenotes now that the surfaces have settled.