### PR TITLE
Add a historical reproduction contract for the WhatKey paper

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -100,6 +100,7 @@ run = """
 python tool/whatkey/fixture_extract.py \
   --set pop-jazz-v2 \
   --out research/whatkey/data/fixtures \
+  --analysis-profile whatKeyPaper2026 \
   charts --charts-dir research/whatkey/data/sources/pop-jazz
 """
 
@@ -116,6 +117,7 @@ fi
 python tool/whatkey/fixture_extract.py \
   --set when-in-rome-v1 \
   --out build/whatkey-fixtures \
+  --analysis-profile whatKeyPaper2026 \
   when-in-rome --bench-root "$bench_root" \
   --groups bach-wtc brahms-lieder schubert-lieder tavern
 """
@@ -129,7 +131,9 @@ if [ ! -f "$asap_root/asap_annotations.json" ]; then
   echo "Set ASAP_ROOT or: git clone --depth 1 https://github.com/fosfrancesco/asap-dataset.git $asap_root" >&2
   exit 1
 fi
-python tool/whatkey/asap_extract.py --asap-root "$asap_root" --set asap-nc-v2 --max-performances 60
+python tool/whatkey/asap_extract.py \
+  --asap-root "$asap_root" --set asap-nc-v2 --max-performances 60 \
+  --analysis-profile whatKeyPaper2026
 """
 
 [tasks."research:whatkey-harness-pop-jazz"]
@@ -273,6 +277,11 @@ run = "python tool/whatkey/headline_table.py --check"
 description = "Prepare gated headline fixtures locally and rerun the detector/baseline code"
 depends = ["research:python-install"]
 run = "python tool/whatkey/prepare_data.py --run-headline \"$@\""
+
+[tasks."research:whatkey-reproduction-verify"]
+description = "Verify frozen WhatKey fixture and result hashes for v2026.7.14"
+depends = ["research:python-install"]
+run = "python tool/whatkey/reproducibility.py verify \"$@\""
 
 [tasks."research:whatkey-prepare-data"]
 description = "Download pinned WhatKey research corpora into build/ and regenerate fixtures"

--- a/packages/whatchord/lib/src/analysis/chord_analysis_profile.dart
+++ b/packages/whatchord/lib/src/analysis/chord_analysis_profile.dart
@@ -1,0 +1,13 @@
+/// Selects a stable chord-analysis policy without forking the analysis engine.
+///
+/// Production callers use [current]. Research fixture generators may select a
+/// frozen profile so later naming improvements do not silently change the
+/// observations consumed by a published experiment.
+enum ChordAnalysisProfile {
+  /// The current production chord-ranking policy.
+  current,
+
+  /// The ranking policy used to generate the WhatKey paper fixtures released
+  /// with WhatChord v2026.7.14.
+  whatKeyPaper2026,
+}

--- a/packages/whatchord/lib/src/analysis/chord_analyzer.dart
+++ b/packages/whatchord/lib/src/analysis/chord_analyzer.dart
@@ -13,6 +13,7 @@ import '../services/bit_masks.dart';
 import '../services/chord_tone_roles.dart';
 import '../services/interval_constants.dart';
 import '../services/pitch_class.dart';
+import 'chord_analysis_profile.dart';
 import 'chord_candidate_ranking.dart';
 import 'chord_templates.dart';
 import 'engine_counters.dart';
@@ -134,7 +135,11 @@ class ExplainedCandidate {
 final class ChordAnalyzer {
   /// Each instance owns its cache and tuning; the app shares one instance so
   /// every feature that names chords shares the LRU cache.
-  ChordAnalyzer({this.cacheCapacity = 512, this.rankingPruneMargin = 2.0});
+  ChordAnalyzer({
+    this.cacheCapacity = 512,
+    this.rankingPruneMargin = 2.0,
+    this.analysisProfile = ChordAnalysisProfile.current,
+  });
 
   /// Maximum cached analysis results (LRU eviction). Configurable so the
   /// cache test can shrink capacity and exercise eviction without hundreds
@@ -148,6 +153,12 @@ final class ChordAnalyzer {
   /// Configurable so that guard test can disable pruning (raise to infinity)
   /// and measure the unpruned surfaced gap.
   final double rankingPruneMargin;
+
+  /// Ranking policy used by this analyzer instance.
+  ///
+  /// The app leaves this at [ChordAnalysisProfile.current]. Research tooling
+  /// may request a frozen policy when rebuilding published fixtures.
+  final ChordAnalysisProfile analysisProfile;
 
   final LinkedHashMap<int, List<ChordCandidate>> _cache =
       LinkedHashMap<int, List<ChordCandidate>>();
@@ -194,6 +205,7 @@ final class ChordAnalyzer {
   static const _splitFourthSurcharge = 0.6; // natural 4 and #11 at once
   static const _splitSecondSurcharge = 0.4; // natural 2 and b9/#9 at once
   static const _splitSixthSurcharge = 0.8; // natural 6/13 and b13 at once
+  static const _paper2026SplitSixthSurcharge = 0.4;
   static const _splitSharpFiveThirteenSurcharge = 0.8; // #5 and 13 at once
   static const _alteredMajorSeventhFlatNineSurcharge = 0.25; // b9 on maj7#5/b5
   static const _sharpElevenEmptyFifthSurcharge = 0.75; // #11 with no 5th tone
@@ -322,6 +334,7 @@ final class ChordAnalyzer {
                   current.candidate,
                   tonality: context.tonality,
                   voicing: voicing,
+                  profile: analysisProfile,
                 ),
         ),
       );
@@ -399,6 +412,7 @@ final class ChordAnalyzer {
       (e) => e.candidate,
       tonality: context.tonality,
       voicing: voicing,
+      profile: analysisProfile,
     );
   }
 
@@ -443,7 +457,7 @@ final class ChordAnalyzer {
   // - Penalty for ambiguity and complexity (missing tones, extras)
   // - Bass role appropriateness
 
-  static _PricedTemplate? _priceTemplate({
+  _PricedTemplate? _priceTemplate({
     required int relMask,
     required int bassInterval,
     required ChordTemplate template,
@@ -706,7 +720,7 @@ final class ChordAnalyzer {
     };
   }
 
-  static double _tonePrice({
+  double _tonePrice({
     required ChordToneRole role,
     required ChordQuality quality,
     required int relMask,
@@ -772,7 +786,7 @@ final class ChordAnalyzer {
     }
   }
 
-  static double _alteredTonePrice({
+  double _alteredTonePrice({
     required ChordToneRole role,
     required ChordQuality quality,
     required int relMask,
@@ -836,12 +850,15 @@ final class ChordAnalyzer {
       price += _splitSecondSurcharge;
     }
     if (role == ChordToneRole.flat13 && _hasNaturalSixthRole(roles)) {
-      price += _splitSixthSurcharge;
+      price += analysisProfile == ChordAnalysisProfile.whatKeyPaper2026
+          ? _paper2026SplitSixthSurcharge
+          : _splitSixthSurcharge;
     }
     // Flat-nine color on altered major-seventh hosts is much rarer than the
     // same alteration on a dominant. The off-dominant multiplier below doubles
     // this surcharge along with the base alteration price.
     if (role == ChordToneRole.flat9 &&
+        analysisProfile == ChordAnalysisProfile.current &&
         (quality == ChordQuality.major7Flat5 ||
             quality == ChordQuality.major7Sharp5)) {
       price += _alteredMajorSeventhFlatNineSurcharge;

--- a/packages/whatchord/lib/src/analysis/chord_candidate_ranking.dart
+++ b/packages/whatchord/lib/src/analysis/chord_candidate_ranking.dart
@@ -2,6 +2,7 @@ import '../models/chord_candidate.dart';
 import '../models/observed_voicing.dart';
 import '../models/tonality.dart';
 import 'candidate_features.dart';
+import 'chord_analysis_profile.dart';
 import 'ranking_policy.dart' as ranking_policy;
 import 'ranking_rules.dart';
 
@@ -66,6 +67,7 @@ abstract final class ChordCandidateRanking {
     ChordCandidate b, {
     required Tonality tonality,
     ObservedVoicing? voicing,
+    ChordAnalysisProfile profile = ChordAnalysisProfile.current,
   }) {
     return _decide(
       a,
@@ -73,6 +75,7 @@ abstract final class ChordCandidateRanking {
       CandidateFeatures.from(a, voicing: voicing),
       CandidateFeatures.from(b, voicing: voicing),
       tonality: tonality,
+      tieRules: _tieRules(profile),
     ).result;
   }
 
@@ -83,6 +86,7 @@ abstract final class ChordCandidateRanking {
     ChordCandidate b, {
     required Tonality tonality,
     ObservedVoicing? voicing,
+    ChordAnalysisProfile profile = ChordAnalysisProfile.current,
   }) {
     return _decide(
       a,
@@ -90,6 +94,7 @@ abstract final class ChordCandidateRanking {
       CandidateFeatures.from(a, voicing: voicing),
       CandidateFeatures.from(b, voicing: voicing),
       tonality: tonality,
+      tieRules: _tieRules(profile),
     );
   }
 
@@ -151,11 +156,13 @@ abstract final class ChordCandidateRanking {
     ChordCandidate Function(T) candidateOf, {
     required Tonality tonality,
     ObservedVoicing? voicing,
+    ChordAnalysisProfile profile = ChordAnalysisProfile.current,
   }) {
     final n = items.length;
     if (n <= 1) return List<T>.of(items);
 
     final cands = [for (final it in items) candidateOf(it)];
+    final tieRules = _tieRules(profile);
 
     // Features (including any voicing evidence) are computed once per candidate
     // here, rather than rebuilt for each of the O(n^2) pairwise decisions below.
@@ -214,6 +221,7 @@ abstract final class ChordCandidateRanking {
           feats[j],
           tonality: tonality,
           hardRuleMask: mask,
+          tieRules: tieRules,
         );
         if (d.result < 0) {
           beats[i][j] = true;
@@ -294,6 +302,7 @@ abstract final class ChordCandidateRanking {
     CandidateFeatures fa,
     CandidateFeatures fb, {
     required Tonality tonality,
+    required List<NamedRule> tieRules,
     int? hardRuleMask,
   }) {
     // Negative when a is cheaper (better) than b, so the result mapping below
@@ -346,7 +355,7 @@ abstract final class ChordCandidateRanking {
       );
     }
 
-    for (final rule in tieBreakerRules) {
+    for (final rule in tieRules) {
       final r = rule.apply(a, b, fa, fb, tonality);
       if (r != null && r != 0) {
         return RankingDecision(
@@ -364,4 +373,11 @@ abstract final class ChordCandidateRanking {
       costDelta: costDelta,
     );
   }
+
+  static List<NamedRule> _tieRules(ChordAnalysisProfile profile) =>
+      switch (profile) {
+        ChordAnalysisProfile.current => tieBreakerRules,
+        ChordAnalysisProfile.whatKeyPaper2026 =>
+          whatKeyPaper2026TieBreakerRules,
+      };
 }

--- a/packages/whatchord/lib/src/analysis/ranking_rules.dart
+++ b/packages/whatchord/lib/src/analysis/ranking_rules.dart
@@ -133,17 +133,17 @@ final List<NamedRule> hardRules = <NamedRule>[
 /// - Structural clarity (root position, shell tones)
 /// - Functional harmony (diatonic, dominant alterations)
 /// - Simplicity (fewer extensions/alterations, avoid suspensions)
-final List<NamedRule> tieBreakerRules = <NamedRule>[
+/// WhatKey's v2026.7.14 tie-breaker policy.
+///
+/// Production-only rules belong in [tieBreakerRules], not in this historical
+/// list. Fixture hashes guard behavior-preserving changes to shared rules.
+final List<NamedRule> whatKeyPaper2026TieBreakerRules = <NamedRule>[
   // Voicing evidence is consulted first: when the register clearly presents one
   // reading as an upper-structure slash and the other not, that observation
   // outranks the naming conventions below.
   NamedRule(
     'prefer voicing-supported upper-structure slash',
     preferVoicingUpperStructureSlash,
-  ),
-  NamedRule(
-    'prefer key-functional seventh over sixth-chord twin',
-    preferKeyFunctionalSeventhOverSixthTwin,
   ),
   NamedRule('prefer root-position 6th over inverted 7th', prefer6thInRoot),
   NamedRule(
@@ -231,3 +231,29 @@ final List<NamedRule> tieBreakerRules = <NamedRule>[
   NamedRule('avoid suspended chords', avoidSuspended),
   NamedRule('prefer cleaner spelling', preferCleanerSpelling),
 ];
+
+/// Current production policy: the historical ordering plus later improvements.
+///
+/// The key-functional-seventh rule slots in directly after the voicing rule.
+/// Anchoring by name keeps that intent stable if the historical list is later
+/// reordered, where a positional splice would silently shift the insertion.
+final List<NamedRule> tieBreakerRules = _insertAfter(
+  whatKeyPaper2026TieBreakerRules,
+  anchor: 'prefer voicing-supported upper-structure slash',
+  rule: NamedRule(
+    'prefer key-functional seventh over sixth-chord twin',
+    preferKeyFunctionalSeventhOverSixthTwin,
+  ),
+);
+
+List<NamedRule> _insertAfter(
+  List<NamedRule> rules, {
+  required String anchor,
+  required NamedRule rule,
+}) {
+  final index = rules.indexWhere((rule) => rule.name == anchor);
+  if (index < 0) {
+    throw StateError('Tie-breaker anchor rule not found: "$anchor"');
+  }
+  return [...rules.take(index + 1), rule, ...rules.skip(index + 1)];
+}

--- a/packages/whatchord/lib/whatchord.dart
+++ b/packages/whatchord/lib/whatchord.dart
@@ -6,6 +6,7 @@ library;
 
 // Analysis engine
 export 'src/analysis/chord_analyzer.dart';
+export 'src/analysis/chord_analysis_profile.dart';
 export 'src/analysis/chord_candidate_ranking.dart';
 
 // Domain models

--- a/packages/whatchord/test/chord_analysis_profile_test.dart
+++ b/packages/whatchord/test/chord_analysis_profile_test.dart
@@ -1,0 +1,41 @@
+import 'package:test/test.dart';
+import 'package:whatchord/whatchord.dart';
+
+void main() {
+  test('paper profile preserves pre-release altered-color pricing', () {
+    const midiNotes = [38, 49, 53, 57, 60];
+    const tonality = Tonality(Tonic.c, TonalityMode.major);
+    final keySignature = KeySignature.fromTonality(tonality);
+    final context = AnalysisContext(
+      tonality: tonality,
+      keySignature: keySignature,
+      spellingPolicy: NoteSpellingPolicy(
+        preferFlats: keySignature.prefersFlats,
+      ),
+    );
+    var pcMask = 0;
+    for (final note in midiNotes) {
+      pcMask |= 1 << (note % 12);
+    }
+    final input = ChordInput(
+      pcMask: pcMask,
+      bassPc: midiNotes.first % 12,
+      noteCount: midiNotes.length,
+    );
+    final voicing = ObservedVoicing.fromMidi(midiNotes);
+
+    final current = ChordAnalyzer().analyze(
+      input,
+      context: context,
+      voicing: voicing,
+    );
+    final historical = ChordAnalyzer(
+      analysisProfile: ChordAnalysisProfile.whatKeyPaper2026,
+    ).analyze(input, context: context, voicing: voicing);
+
+    expect(current.first.identity.quality, ChordQuality.minor7);
+    expect(current.first.identity.rootPc, 2);
+    expect(historical.first.identity.quality, ChordQuality.major7Sharp5);
+    expect(historical.first.identity.rootPc, 1);
+  });
+}

--- a/packages/whatchord/test/key_functional_seventh_rule_test.dart
+++ b/packages/whatchord/test/key_functional_seventh_rule_test.dart
@@ -109,4 +109,26 @@ void main() {
     expect(identity.quality, ChordQuality.major6);
     expect(identity.rootPc, 5);
   });
+
+  test('WhatKey paper profile preserves the v2026.7.14 sixth-chord choice', () {
+    final historicalAnalyzer = ChordAnalyzer(
+      analysisProfile: ChordAnalysisProfile.whatKeyPaper2026,
+    );
+    var pcMask = 0;
+    for (final note in ii65Voicing) {
+      pcMask |= 1 << (note % 12);
+    }
+    final ranked = historicalAnalyzer.analyze(
+      ChordInput(
+        pcMask: pcMask,
+        bassPc: ii65Voicing.first % 12,
+        noteCount: ii65Voicing.length,
+      ),
+      context: context('c', TonalityMode.major),
+      voicing: ObservedVoicing.fromMidi(ii65Voicing),
+    );
+
+    expect(ranked.first.identity.quality, ChordQuality.major6);
+    expect(ranked.first.identity.rootPc, 5);
+  });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -210,7 +210,7 @@ packages:
     source: hosted
     version: "0.3.5+4"
   crypto:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
     path: packages/whatkey
 
 dev_dependencies:
+  crypto: ^3.0.7
   flutter_test:
     sdk: flutter
 

--- a/research/whatkey/REPRODUCING.md
+++ b/research/whatkey/REPRODUCING.md
@@ -31,6 +31,36 @@ mise install && mise research:whatkey-headline-verify
 That task reads `research/whatkey/results/test-split-2026-07-07/` and
 `MANIFEST.json`; it does not rerun detectors or baselines.
 
+## Historical Reproduction Contract
+
+The current codebase keeps the paper-era behavior behind two explicit names:
+
+- fixture extraction uses the `whatKeyPaper2026` chord-analysis profile;
+- detector reruns use the `whatKeyPaper2026` and `whatKeyPaper2026Reflex`
+  recipes, which pin every detector parameter instead of inheriting mutable
+  defaults.
+
+The app continues to use the current chord-analysis behavior. The historical
+profile is selected only by research tooling, so product improvements do not
+silently rewrite the paper's observation stream.
+
+The canonical SHA-256 values for every paper fixture set and committed result
+directory are recorded in `results/reproduction-v2026.7.14.json`. Canonical JSON
+hashing ignores object key order and whitespace. Fixture hashes cover every
+observation file. Result hashes cover `claims.json` plus the stable scored
+fields of `report.json`; additive diagnostics and run metadata are intentionally
+outside that second hash.
+
+To regenerate all license-gated fixtures and verify the complete lock:
+
+```sh
+mise research:whatkey-prepare-data -- --all --verify-splits --yes
+mise research:whatkey-reproduction-verify
+```
+
+The headline rerun performs the corresponding Isophonics fixture and result hash
+checks automatically after checking the displayed table.
+
 ## Required Tools
 
 Use the repository's normal toolchain:

--- a/research/whatkey/log/2026-07-20-01-historical-reproduction-contract.md
+++ b/research/whatkey/log/2026-07-20-01-historical-reproduction-contract.md
@@ -1,0 +1,139 @@
+# 2026-07-20: Historical reproduction contract
+
+**Goal.** Determine whether the evolving codebase still reproduces the WhatKey
+paper record associated with release `v2026.7.14`, and add a narrow historical
+compatibility boundary where current chord-analysis improvements had changed
+freshly generated observations. The release belongs to Zenodo concept DOI
+`10.5281/zenodo.21322675`; its version DOI is `10.5281/zenodo.21364341`.
+
+**Motivation.** The committed fixtures and result artifacts still made the
+reported detector claims reproducible, but that alone did not prove that a
+future reader could regenerate those fixtures with the current engine. An audit
+after the engine refactor found that the refactor itself preserved behavior,
+while two later intentional chord-naming changes did not:
+
+- Isophonics regeneration under current app behavior reordered candidates in 55
+  events across 14 tracks. That moved the fresh headline from the recorded
+  `0.88 / 0.732 / 0.782` coverage/exact/MIREX values to `0.89 / 0.731 / 0.782`.
+- ASAP regeneration produced 19,545 events rather than the frozen 19,546.
+- ASAP/When-in-Rome regeneration reordered candidates in 2 events.
+
+The relevant post-release changes were the altered-major and split-sixth pricing
+in `a966f09d` and the key-functional seventh-over-sixth tie-breaker in
+`81ec8b77`. Both are useful app improvements and should remain the default.
+Reverting them globally would make the product serve the paper rather than
+letting the paper remain reproducible inside an improving product.
+
+**Setup.** Base engine commit `bbf61788e28fb4c5b547ddaa947e5792ff95112f`, with
+the compatibility changes in this working session. The historical comparison
+checkout was the peeled `v2026.7.14` commit
+`e8ec90c9c409dec765873284a220a088d22a7cde`. Corpus pins remained unchanged:
+contrapunctus-bench `b9e011c8`, When-in-Rome `aa7539f1`, ASAP `afc815c7`, and
+ChoCo `5fe168fd`.
+
+The final end-to-end commands were:
+
+```sh
+mise research:whatkey-prepare-data -- --all --verify-splits --yes
+mise research:whatkey-prepare-data -- --all --verify-only
+mise research:whatkey-headline-rerun -- --yes
+mise research:whatkey-reproduction-verify
+```
+
+The five result directories outside the headline rerun were regenerated with:
+
+```sh
+dart run tool/whatkey/harness.dart --fixtures build/whatkey-fixtures/asap-nc-v2 --split-file research/whatkey/data/splits/asap-nc-v2.json --split test --recipe whatKeyPaper2026 --out build/whatkey-reproduction-current/test-asap-hmm-shipped
+dart run tool/whatkey/harness.dart --fixtures build/whatkey-fixtures/isophonics-nc-v1 --split-file research/whatkey/data/splits/isophonics-nc-v1.json --split test --recipe whatKeyPaper2026Reflex --out build/whatkey-reproduction-current/test-iso-hmm-reflex
+dart run tool/whatkey/harness.dart --fixtures build/whatkey-fixtures/isophonics-nc-v1 --split-file research/whatkey/data/splits/isophonics-nc-v1.json --split test --claims-file build/whatkey-headline-test/baseline-claims/isophonics-nc-v1-test/krumhanslschmuckler.claims.json --restrict-to build/whatkey-headline-test/test-iso-hmm-shipped/claims.json --out build/whatkey-reproduction-current/test-iso-m21-ks-matched
+dart run tool/whatkey/harness.dart --fixtures research/whatkey/data/fixtures/when-in-rome-v1 --split-file research/whatkey/data/splits/when-in-rome-v1.json --split test --recipe whatKeyPaper2026Reflex --out build/whatkey-reproduction-current/test-wir-hmm-reflex
+dart run tool/whatkey/harness.dart --fixtures research/whatkey/data/fixtures/when-in-rome-v1 --split-file research/whatkey/data/splits/when-in-rome-v1.json --split test --recipe whatKeyPaper2026 --out build/whatkey-reproduction-current/test-wir-hmm-shipped
+python tool/whatkey/reproducibility.py verify --fixture when-in-rome-v1 --result test-asap-hmm-shipped --result test-iso-hmm-reflex --result test-iso-m21-ks-matched --result test-wir-hmm-reflex --result test-wir-hmm-shipped --result-root build/whatkey-reproduction-current
+```
+
+For the independent release comparison, the three license-gated fixture sets
+were also regenerated from a detached `v2026.7.14` worktree using the same
+pinned local corpus checkouts. Their canonical fixture JSON was compared with
+the current compatibility-profile output.
+
+**What happened.** A `whatKeyPaper2026` chord-analysis profile now freezes only
+the two post-release ranking/pricing changes. Current app analysis remains the
+default. All WhatKey fixture extractors explicitly request the paper profile,
+and their manifests record it. The batch drivers (`fixture_batch.dart` and
+`replay_batch.dart`) require that field and reject any request that omits it, so
+a caller cannot silently inherit a profile; the chord-context extractor, which
+studies current app naming, pins itself to `current` for the same reason.
+
+The `whatKeyPaper2026` and `whatKeyPaper2026Reflex` detector recipes separately
+pin the complete shipped and faster-decay HMM configurations, so a future change
+to a detector default cannot silently alter a paper rerun. The headline workflow
+invokes the shipped recipe.
+
+Canonical JSON SHA-256 hashes now cover every fixture file and the stable scored
+contents of each result directory. The lock is
+`results/reproduction-v2026.7.14.json`. It covers both committed behavioral
+fixture versions, all four corpus fixture sets, and all nine committed
+test-result directories. Result hashes cover `claims.json` and the scored
+`report.json` fields; timestamps, commands, engine commit metadata, and additive
+diagnostics are deliberately excluded.
+
+The regenerated corpus fixture hashes were:
+
+| Fixture set        | Pieces | Events | Canonical SHA-256                                                  |
+| ------------------ | -----: | -----: | ------------------------------------------------------------------ |
+| `when-in-rome-v1`  |     77 |  5,207 | `0bc6551265f15bc397fa5cece06a909349ac35e27d3ff2891a3dc0e721bba224` |
+| `asap-nc-v2`       |     60 | 19,546 | `c56ac7bf2eb24a9af94980d40b49b1c3189171b7c256f0df98333208fbff21d1` |
+| `isophonics-nc-v1` |    224 | 19,062 | `68e2394dd196aa999473772c73a9ade8fcea33b1aa2511bff6e61d49940d3337` |
+| `asap-wir-nc-v1`   |     36 | 10,395 | `068683ab490dc8457de788172288590c0577f2c4724978d363a801cf02ba402d` |
+
+Each gated fixture hash exactly matched the output independently regenerated
+from `v2026.7.14`. All nine result directories regenerated with the current code
+matched their locked claims and stable scored data. The complete
+reproduction-lock verifier also passed all six fixture sets and all nine
+committed result directories.
+
+The headline rerun again produced:
+
+| System                         | Coverage | Exact | MIREX |
+| ------------------------------ | -------: | ----: | ----: |
+| WhatKey (causal, abstaining)   |     0.88 | 0.732 | 0.782 |
+| music21 Temperley-Kostka-Payne |     1.00 | 0.637 | 0.740 |
+| music21 Krumhansl-Schmuckler   |     1.00 | 0.624 | 0.726 |
+| music21 Aarden-Essen           |     1.00 | 0.558 | 0.690 |
+
+Its HMM `claims.json` canonical hash was
+`e01408a6d92ee96408ba495a9d14fbe65dcebb803ac22e2eb99437be098b1633`, identical to
+the committed paper result.
+
+**Plain-English reading.** Someone using the current repository can regenerate
+the observations that the paper actually evaluated, then produce the same claims
+and numbers. Meanwhile, ordinary app users continue to receive newer
+chord-naming improvements. The hashes turn this from a rounded-number spot check
+into a precise pass/fail test: any future drift in a candidate list, claim, or
+scored field is visible immediately.
+
+**Decisions.** Keep one narrowly named paper profile and fully pinned recipes
+for the two reported detector configurations rather than freezing the whole
+application or branching the engine. Treat the version DOI as the immutable
+historical record and the concept DOI as the evolving project identity. Do not
+change the frozen research numbers or documents merely because the production
+analyzer improves.
+
+Hash semantic JSON rather than file bytes so formatting and object-key order do
+not create false failures. The same canonical hash is computed in both Dart (the
+harness that writes the hashes) and Python (the verifier), so both encoders
+reject non-integer numbers outside `[1e-4, 1e16)`, the range where the two
+languages format floats identically. A value that would hash differently across
+the two implementations fails loudly at generation time rather than silently
+producing a set that later cannot reproduce; every current fixture and result
+falls well inside that range. Exclude additive report diagnostics from the
+stable result-data hash because the release code may legitimately calculate new
+diagnostics without changing any claim or scored paper datum; lock those fields
+separately if a future publication relies on them.
+
+**Next.** Keep `ChordAnalysisProfile.current` as the app default. Any future
+engine change that affects fixture generation should be checked against
+`mise research:whatkey-reproduction-verify`; extend the historical profile only
+when needed to preserve `v2026.7.14`, never to freeze unrelated implementation
+details. A future paper revision may receive its own named recipe and lock, but
+does not overwrite this one.

--- a/research/whatkey/results/reproduction-v2026.7.14.json
+++ b/research/whatkey/results/reproduction-v2026.7.14.json
@@ -1,0 +1,97 @@
+{
+  "schema": "whatkey-reproduction-lock/1",
+  "release": "v2026.7.14",
+  "doi": {
+    "concept": "10.5281/zenodo.21322675",
+    "version": "10.5281/zenodo.21364341"
+  },
+  "canonicalization": "whatkey-canonical-json-v1",
+  "algorithm": "sha256",
+  "resultDataFields": [
+    "schema",
+    "fixtures",
+    "split",
+    "detector",
+    "restrictedTo",
+    "summary",
+    "perPiece"
+  ],
+  "analysisProfile": "whatKeyPaper2026",
+  "detectorRecipes": [
+    "whatKeyPaper2026",
+    "whatKeyPaper2026Reflex"
+  ],
+  "fixtures": {
+    "asap-nc-v2": {
+      "path": "build/whatkey-fixtures/asap-nc-v2",
+      "sha256": "c56ac7bf2eb24a9af94980d40b49b1c3189171b7c256f0df98333208fbff21d1"
+    },
+    "asap-wir-nc-v1": {
+      "path": "build/whatkey-fixtures/asap-wir-nc-v1",
+      "sha256": "068683ab490dc8457de788172288590c0577f2c4724978d363a801cf02ba402d"
+    },
+    "isophonics-nc-v1": {
+      "path": "build/whatkey-fixtures/isophonics-nc-v1",
+      "sha256": "68e2394dd196aa999473772c73a9ade8fcea33b1aa2511bff6e61d49940d3337"
+    },
+    "pop-jazz-v1": {
+      "path": "research/whatkey/data/fixtures/pop-jazz-v1",
+      "sha256": "2046a15fb231fe609fe30ea0215ce363ed2f6d1ba813df285d6c8ad515f90ea2"
+    },
+    "pop-jazz-v2": {
+      "path": "research/whatkey/data/fixtures/pop-jazz-v2",
+      "sha256": "0219dae086be6edf777ed186cb3842c7ff9d5aa2635efc643598b65830c9f78c"
+    },
+    "when-in-rome-v1": {
+      "path": "research/whatkey/data/fixtures/when-in-rome-v1",
+      "sha256": "0bc6551265f15bc397fa5cece06a909349ac35e27d3ff2891a3dc0e721bba224"
+    }
+  },
+  "results": {
+    "test-asap-hmm-shipped": {
+      "path": "research/whatkey/results/test-split-2026-07-07/test-asap-hmm-shipped",
+      "claimsSha256": "bd70b51687a159da9723223e69453e1f3c254fd7582fa39e356609faf57cccdf",
+      "resultDataSha256": "0d636d9a97d29fb5ee72446fae560dffc0debeecbefa2a67904f62e46f28f322"
+    },
+    "test-iso-hmm-reflex": {
+      "path": "research/whatkey/results/test-split-2026-07-07/test-iso-hmm-reflex",
+      "claimsSha256": "5d02436a4dc0ebbe044f7a1f91bdfbfbd4cf54cef3adbe2a1c0052dcfc091dbf",
+      "resultDataSha256": "5c4926cb388867fb883f93a1fa76939464f2c24415da71606cc8ca0f7c310010"
+    },
+    "test-iso-hmm-shipped": {
+      "path": "research/whatkey/results/test-split-2026-07-07/test-iso-hmm-shipped",
+      "claimsSha256": "e01408a6d92ee96408ba495a9d14fbe65dcebb803ac22e2eb99437be098b1633",
+      "resultDataSha256": "50c1b8ac83fb7aadc95169af472a0bdf4800af97492f12e276d6abae51ff3c2c"
+    },
+    "test-iso-m21-aardenessen": {
+      "path": "research/whatkey/results/test-split-2026-07-07/test-iso-m21-aardenessen",
+      "claimsSha256": "ddafb5c261bf450e8e6ef79973876e21dacdf7c5f05b91db6a628705c0642b82",
+      "resultDataSha256": "d6175d9999e6d559285dadff3f49393e5bfcd7cf95c7d826705f4841541c420d"
+    },
+    "test-iso-m21-krumhanslschmuckler": {
+      "path": "research/whatkey/results/test-split-2026-07-07/test-iso-m21-krumhanslschmuckler",
+      "claimsSha256": "3bd4e5812f109a329c847f4157b1e7693dcf2452f234567ef62fd89276d2849f",
+      "resultDataSha256": "23555823658eb77264522c9a254842c5f0dee2cc0dc6a5a430442cd31aff81af"
+    },
+    "test-iso-m21-ks-matched": {
+      "path": "research/whatkey/results/test-split-2026-07-07/test-iso-m21-ks-matched",
+      "claimsSha256": "3bd4e5812f109a329c847f4157b1e7693dcf2452f234567ef62fd89276d2849f",
+      "resultDataSha256": "76bbe267227be84906bf5a9eab63ca135ba038c8dc849fec2dc3f82b52dfbb8a"
+    },
+    "test-iso-m21-temperleykostkapayne": {
+      "path": "research/whatkey/results/test-split-2026-07-07/test-iso-m21-temperleykostkapayne",
+      "claimsSha256": "a0a934f13436a96d9effe36d1197a077e6e13eb80ba859401161fafdcd9cf88b",
+      "resultDataSha256": "53411c5238b684db50c52b0e8d34f0068c2675eb70cc90aee800095a2d2faa15"
+    },
+    "test-wir-hmm-reflex": {
+      "path": "research/whatkey/results/test-split-2026-07-07/test-wir-hmm-reflex",
+      "claimsSha256": "cb6471b92ecac3dde0510c38f2eab7b220e44ba677c91aa0b280dec4f44d4188",
+      "resultDataSha256": "797c6e4712de318ddb0e8d1eceaef2d416e071d925c5280dbbdbd386e8247e5d"
+    },
+    "test-wir-hmm-shipped": {
+      "path": "research/whatkey/results/test-split-2026-07-07/test-wir-hmm-shipped",
+      "claimsSha256": "7afbea27ba5c431249d815306f8d9a99479e83e1ea534335ac1138c985f0ee7d",
+      "resultDataSha256": "c2a004075a25b701e3b734c13388cc432808f0a0b026db44fc728665b635f330"
+    }
+  }
+}

--- a/test/tool/whatkey_scoring_test.dart
+++ b/test/tool/whatkey_scoring_test.dart
@@ -7,6 +7,7 @@ import 'package:whatchord_app/features/key/key.dart';
 
 import '../../tool/src/chord_id_engine.dart';
 import '../../tool/whatkey/src/fixtures.dart';
+import '../../tool/whatkey/src/reproducibility.dart';
 import '../../tool/whatkey/src/scoring.dart';
 
 Map<String, Object?> _eventJson(
@@ -88,6 +89,52 @@ const _abstain = KeyEstimateFrame.abstain([]);
 void main() {
   const cMajor = KeyLabel(0, isMinor: false);
   const aMinor = KeyLabel(9, isMinor: true);
+
+  test('canonical JSON hash ignores map order', () {
+    final hash = canonicalJsonSha256({
+      'b': 2,
+      'a': [1, true],
+    });
+    expect(
+      hash,
+      canonicalJsonSha256({
+        'a': [1, true],
+        'b': 2,
+      }),
+    );
+    expect(
+      hash,
+      '16a5b9826a81dd3e37eb091f70b193b43807f6f51851ee61fc7ef0ee809b5255',
+    );
+  });
+
+  test('hashed result fields match the reproduction lock', () {
+    // The lock, Python REPORT_DATA_KEYS, and this list must stay identical or
+    // `reproducibility.py verify` reports a spurious MISMATCH. Python is checked
+    // against the lock at verify time; this pins the Dart side to the same lock.
+    final lock =
+        jsonDecode(
+              File(
+                'research/whatkey/results/reproduction-v2026.7.14.json',
+              ).readAsStringSync(),
+            )
+            as Map<String, dynamic>;
+    expect(lock['resultDataFields'], resultDataFields);
+  });
+
+  test(
+    'canonical hash rejects floats that Dart and Python format differently',
+    () {
+      expect(() => canonicalJsonSha256({'cost': 1e-5}), throwsStateError);
+      expect(() => canonicalJsonSha256({'cost': 1e16}), throwsStateError);
+      expect(() => canonicalJsonSha256({'cost': double.nan}), throwsStateError);
+      // In-band values (including zero) hash without complaint.
+      expect(
+        () => canonicalJsonSha256({'cost': 0.0, 'weight': 2.5}),
+        returnsNormally,
+      );
+    },
+  );
 
   group('mirexWeight', () {
     test('exact match scores 1.0', () {

--- a/tool/chord-context/dcml_extract.py
+++ b/tool/chord-context/dcml_extract.py
@@ -47,6 +47,10 @@ FIXTURE_SCHEMA = "whatkey-fixture/1"
 MANIFEST_SCHEMA = "whatkey-manifest/1"
 LABELS_SCHEMA = "chord-context-labels/1"
 QB_MS = 500
+# Chord-context studies the app's live naming, so candidates use the current
+# production ranking. fixture_batch requires this to be explicit; if this
+# initiative ever needs a frozen set, pin a paper profile here instead.
+ANALYSIS_PROFILE = "current"
 
 CHORD_TYPE_QUALITY = {
     "M": "major",
@@ -494,6 +498,7 @@ def attach_candidates(fixtures: list[dict], context: str) -> None:
                     "id": f"{fixture['id']}#{event['index']}",
                     "midiNotes": event["midiNotes"],
                     "context": context,
+                    "analysisProfile": ANALYSIS_PROFILE,
                 }
             )
     payload = "".join(json.dumps(request) + "\n" for request in requests)

--- a/tool/whatkey/asap_extract.py
+++ b/tool/whatkey/asap_extract.py
@@ -30,6 +30,13 @@ from pathlib import Path
 
 import mido
 
+from reproducibility import (
+    ANALYSIS_PROFILES,
+    CANONICALIZATION,
+    DEFAULT_ANALYSIS_PROFILE,
+    fixture_hashes,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_SCHEMA = "whatkey-fixture/1"
 MANIFEST_SCHEMA = "whatkey-manifest/1"
@@ -42,6 +49,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--set", dest="set_name", default="asap-nc-v1")
     parser.add_argument("--out", type=Path, default=Path("build/whatkey-fixtures"))
     parser.add_argument("--context", default="C:maj")
+    parser.add_argument(
+        "--analysis-profile",
+        choices=ANALYSIS_PROFILES,
+        default=DEFAULT_ANALYSIS_PROFILE,
+        help="Chord-ranking policy used before capture segmentation.",
+    )
     parser.add_argument(
         "--max-performances",
         type=int,
@@ -84,7 +97,9 @@ def main() -> int:
         )
         print(f"{perf_path}: {len(snapshots)} snapshots", file=sys.stderr)
 
-    replayed = replay(pieces, args.context, args.segmenter_min_ms)
+    replayed = replay(
+        pieces, args.context, args.segmenter_min_ms, args.analysis_profile
+    )
 
     set_dir = args.out / args.set_name
     set_dir.mkdir(parents=True, exist_ok=True)
@@ -113,6 +128,11 @@ def main() -> int:
             }
         )
 
+    files = [entry["file"] for entry in fixtures_meta]
+    hashes, content_hash = fixture_hashes(set_dir, files)
+    for entry in fixtures_meta:
+        entry["sha256"] = hashes[entry["file"]]
+
     manifest = {
         "schema": MANIFEST_SCHEMA,
         "set": args.set_name,
@@ -127,6 +147,12 @@ def main() -> int:
             "arguments": sys.argv[1:],
         },
         "context": args.context,
+        "analysisProfile": args.analysis_profile,
+        "contentHash": {
+            "algorithm": "sha256",
+            "canonicalization": CANONICALIZATION,
+            "value": content_hash,
+        },
         "segmenterMinMs": args.segmenter_min_ms,
         "source": {
             "type": "asap",
@@ -216,7 +242,10 @@ def sounding_snapshots(midi_path: Path) -> list[dict]:
 
 
 def replay(
-    pieces: list[dict], context: str, segmenter_min_ms: int
+    pieces: list[dict],
+    context: str,
+    segmenter_min_ms: int,
+    analysis_profile: str = DEFAULT_ANALYSIS_PROFILE,
 ) -> dict[str, list[dict]]:
     payload = "".join(
         json.dumps(
@@ -224,6 +253,7 @@ def replay(
                 "id": p["id"],
                 "context": context,
                 "segmenterMinMs": segmenter_min_ms,
+                "analysisProfile": analysis_profile,
                 "snapshots": p["snapshots"],
             }
         )

--- a/tool/whatkey/asap_wir_extract.py
+++ b/tool/whatkey/asap_wir_extract.py
@@ -32,6 +32,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "chord"))
 import asap_extract as asap_x  # noqa: E402
+from reproducibility import (  # noqa: E402
+    ANALYSIS_PROFILES,
+    CANONICALIZATION,
+    DEFAULT_ANALYSIS_PROFILE,
+    fixture_hashes,
+)
 
 REPO_ROOT = asap_x.REPO_ROOT
 
@@ -55,6 +61,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--set", dest="set_name", default="asap-wir-nc-v1")
     parser.add_argument("--out", type=Path, default=Path("build/whatkey-fixtures"))
     parser.add_argument("--context", default="C:maj")
+    parser.add_argument(
+        "--analysis-profile",
+        choices=ANALYSIS_PROFILES,
+        default=DEFAULT_ANALYSIS_PROFILE,
+        help="Chord-ranking policy used before capture segmentation.",
+    )
     return parser.parse_args()
 
 
@@ -137,7 +149,12 @@ def main() -> int:
             file=sys.stderr,
         )
 
-    replayed = asap_x.replay(pieces, args.context, 200)
+    replayed = asap_x.replay(
+        pieces,
+        args.context,
+        200,
+        args.analysis_profile,
+    )
 
     set_dir = args.out / args.set_name
     set_dir.mkdir(parents=True, exist_ok=True)
@@ -171,6 +188,11 @@ def main() -> int:
             }
         )
 
+    files = [entry["file"] for entry in fixtures]
+    hashes, content_hash = fixture_hashes(set_dir, files)
+    for entry in fixtures:
+        entry["sha256"] = hashes[entry["file"]]
+
     manifest = {
         "schema": asap_x.MANIFEST_SCHEMA,
         "set": args.set_name,
@@ -185,6 +207,12 @@ def main() -> int:
             "arguments": sys.argv[1:],
         },
         "context": args.context,
+        "analysisProfile": args.analysis_profile,
+        "contentHash": {
+            "algorithm": "sha256",
+            "canonicalization": CANONICALIZATION,
+            "value": content_hash,
+        },
         "segmenterMinMs": 200,
         "source": {
             "type": "asap+when-in-rome",

--- a/tool/whatkey/fixture_batch.dart
+++ b/tool/whatkey/fixture_batch.dart
@@ -17,13 +17,32 @@ import 'package:whatchord/whatchord.dart';
 
 import '../src/chord_id_engine.dart';
 
-final _analyzer = ChordAnalyzer();
+final _analyzers = <ChordAnalysisProfile, ChordAnalyzer>{
+  for (final profile in ChordAnalysisProfile.values)
+    profile: ChordAnalyzer(analysisProfile: profile),
+};
+
+// Every caller must declare the chord-ranking policy: a silent default would
+// let a fixture set inherit the wrong profile when a request omits the field.
+String _requireProfile(Map<String, dynamic> request) {
+  final profile = request['analysisProfile'] as String?;
+  if (profile == null) {
+    throw ArgumentError(
+      'Request is missing required "analysisProfile" '
+      '(one of ${ChordAnalysisProfile.values.map((p) => p.name).join(', ')})',
+    );
+  }
+  return profile;
+}
 
 void main() {
   stdin.transform(utf8.decoder).transform(const LineSplitter()).listen((line) {
     if (line.trim().isEmpty) return;
 
     final request = jsonDecode(line) as Map<String, dynamic>;
+    final profile = ChordAnalysisProfile.values.byName(
+      _requireProfile(request),
+    );
     final midiNotes = (request['midiNotes'] as List).cast<int>()..sort();
     final tonality = parseTonality(request['context'] as String);
     final keySignature = KeySignature.fromTonality(tonality);
@@ -46,7 +65,11 @@ void main() {
     );
     final voicing = ObservedVoicing.fromMidi(midiNotes);
 
-    final ranked = _analyzer.analyze(input, context: context, voicing: voicing);
+    final ranked = _analyzers[profile]!.analyze(
+      input,
+      context: context,
+      voicing: voicing,
+    );
     final alternativeCount = ChordCandidateRanking.alternativeCount(ranked);
 
     stdout.writeln(

--- a/tool/whatkey/fixture_extract.py
+++ b/tool/whatkey/fixture_extract.py
@@ -30,6 +30,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from statistics import median
 
+from reproducibility import (
+    ANALYSIS_PROFILES,
+    CANONICALIZATION,
+    DEFAULT_ANALYSIS_PROFILE,
+    fixture_hashes,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_SCHEMA = "whatkey-fixture/1"
 MANIFEST_SCHEMA = "whatkey-manifest/1"
@@ -65,6 +72,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--tempo", type=float, default=120.0, help="Beats per minute")
     parser.add_argument("--set", dest="set_name", required=True)
     parser.add_argument("--out", type=Path, required=True, help="Fixture output root")
+    parser.add_argument(
+        "--analysis-profile",
+        choices=ANALYSIS_PROFILES,
+        default=DEFAULT_ANALYSIS_PROFILE,
+        help="Chord-ranking policy used to generate fixture observations.",
+    )
     sub = parser.add_subparsers(dest="source", required=True)
 
     charts = sub.add_parser("charts", help="Hand-authored chord charts")
@@ -95,13 +108,16 @@ def main() -> int:
         print("No fixtures produced.", file=sys.stderr)
         return 1
 
-    attach_candidates(fixtures, args.context)
+    attach_candidates(fixtures, args.context, args.analysis_profile)
 
     set_dir = args.out / args.set_name
     set_dir.mkdir(parents=True, exist_ok=True)
     for fixture in fixtures:
         path = set_dir / f"{fixture['id'].split('/')[-1]}.json"
         path.write_text(json.dumps(fixture, indent=2, sort_keys=True) + "\n")
+
+    files = [f"{fixture['id'].split('/')[-1]}.json" for fixture in fixtures]
+    hashes, content_hash = fixture_hashes(set_dir, files)
 
     manifest = {
         "schema": MANIFEST_SCHEMA,
@@ -116,6 +132,12 @@ def main() -> int:
             "arguments": sys.argv[1:],
         },
         "context": args.context,
+        "analysisProfile": args.analysis_profile,
+        "contentHash": {
+            "algorithm": "sha256",
+            "canonicalization": CANONICALIZATION,
+            "value": content_hash,
+        },
         "tempoBpm": args.tempo,
         "source": source_info,
         "fixtures": [
@@ -123,6 +145,7 @@ def main() -> int:
                 "id": fixture["id"],
                 "title": fixture["title"],
                 "file": f"{fixture['id'].split('/')[-1]}.json",
+                "sha256": hashes[f"{fixture['id'].split('/')[-1]}.json"],
                 "events": len(fixture["events"]),
                 "provenance": fixture.get("provenance"),
             }
@@ -303,7 +326,9 @@ def event_dict(
     }
 
 
-def attach_candidates(fixtures: list[dict], context: str) -> None:
+def attach_candidates(
+    fixtures: list[dict], context: str, analysis_profile: str
+) -> None:
     requests = []
     for fixture in fixtures:
         for event in fixture["events"]:
@@ -312,6 +337,7 @@ def attach_candidates(fixtures: list[dict], context: str) -> None:
                     "id": f"{fixture['id']}#{event['index']}",
                     "midiNotes": event["midiNotes"],
                     "context": context,
+                    "analysisProfile": analysis_profile,
                 }
             )
     payload = "".join(json.dumps(request) + "\n" for request in requests)

--- a/tool/whatkey/harness.dart
+++ b/tool/whatkey/harness.dart
@@ -8,6 +8,7 @@
 // Usage:
 //   dart run tool/whatkey/harness.dart --fixtures <set-dir> \
 //     [--split-file <split.json>] [--split development|test] \
+//     [--recipe whatKeyPaper2026|whatKeyPaper2026Reflex] \
 //     [--detector profile|evidence|progression|hybrid|hmm|bocpd] \
 //     [--profiles krumhanslKessler|temperley|temperleyKostkaPayne|
 //                 albrechtShanahan] \
@@ -38,7 +39,9 @@ import 'dart:io';
 
 import 'package:whatkey/whatkey.dart';
 
+import 'src/detector_recipe.dart';
 import 'src/fixtures.dart';
+import 'src/reproducibility.dart';
 import 'src/scoring.dart';
 
 void main(List<String> arguments) {
@@ -128,6 +131,7 @@ void main(List<String> arguments) {
     'fixtures': {
       'set': fixtureSet.name,
       'directory': options.fixturesDir,
+      'contentSha256': fixtureSet.contentSha256,
       'source': fixtureSet.source,
       'engineCommit': fixtureSet.manifest['engineCommit'],
     },
@@ -135,6 +139,7 @@ void main(List<String> arguments) {
         ? null
         : {'file': options.splitFile, 'name': options.split},
     'detector': detectorInfo,
+    'detectorRecipe': options.recipe?.name,
     'restrictedTo': options.restrictTo,
     'sweep': sweep,
     'posteriorCalibration': calibration,
@@ -154,11 +159,20 @@ void main(List<String> arguments) {
                 ? ''
                 : '-${options.detectorName}'}',
   )..createSync(recursive: true);
+  final claimsArtifact = _claimsArtifact(
+    detectorInfo,
+    fixtures,
+    framesByFixture,
+  );
+  final hashes = resultArtifactHashes(report, claimsArtifact);
   File('${outDir.path}/report.json').writeAsStringSync(
     '${const JsonEncoder.withIndent('  ').convert(report)}\n',
   );
   File('${outDir.path}/claims.json').writeAsStringSync(
-    '${const JsonEncoder.withIndent('  ').convert(_claimsArtifact(detectorInfo, fixtures, framesByFixture))}\n',
+    '${const JsonEncoder.withIndent('  ').convert(claimsArtifact)}\n',
+  );
+  File('${outDir.path}/hashes.json').writeAsStringSync(
+    '${const JsonEncoder.withIndent('  ').convert({'schema': 'whatkey-result-hashes/1', 'algorithm': 'sha256', 'canonicalization': canonicalization, 'fixtureSetSha256': fixtureSet.contentSha256, ...hashes})}\n',
   );
   final text = _textReport(report, pieces);
   File('${outDir.path}/report.txt').writeAsStringSync(text);
@@ -485,6 +499,7 @@ class _Options {
   final String split;
   final String? claimsFile;
   final String? restrictTo;
+  final DetectorRecipe? recipe;
   final List<double> sweepMarginFloors;
   final String detectorName;
   final bool? confidenceWeighted;
@@ -514,6 +529,7 @@ class _Options {
     required this.split,
     required this.claimsFile,
     required this.restrictTo,
+    required this.recipe,
     required this.sweepMarginFloors,
     required this.detectorName,
     required this.confidenceWeighted,
@@ -672,64 +688,126 @@ class _Options {
     if (split != 'development' && split != 'test') {
       throw ArgumentError('--split must be development or test');
     }
+    final recipe = switch (values.remove('recipe')) {
+      null => null,
+      final name => DetectorRecipe.values.byName(name),
+    };
+    const recipeControlledFlags = <String>{
+      'detector',
+      'confidence-weighting',
+      'functional-blend',
+      'progression-blend',
+      'self-transition',
+      'emission-temperature',
+      'hysteresis',
+      'profiles',
+      'weighting',
+      'decay-half-life-seconds',
+      'decay-half-life-events',
+      'min-events',
+      'margin-floor',
+      'mode-tilt',
+      'relative-tilt',
+      'relative-cadence-tilt',
+      'hazard',
+      'max-run-length',
+    };
+    final recipeConflicts = recipe == null
+        ? const <String>[]
+        : [
+            for (final flag in recipeControlledFlags)
+              if (values.containsKey(flag)) '--$flag',
+          ];
+    if (recipeConflicts.isNotEmpty) {
+      throw ArgumentError(
+        '--recipe pins every detector option; remove: '
+        '${recipeConflicts.join(', ')}',
+      );
+    }
+    final claimsFile = values.remove('claims-file');
+    if (recipe != null && claimsFile != null) {
+      throw ArgumentError('--recipe cannot be combined with --claims-file');
+    }
     final options = _Options._(
       fixturesDir: fixturesDir,
       splitFile: splitFile,
       split: split,
-      claimsFile: values.remove('claims-file'),
+      claimsFile: claimsFile,
       restrictTo: values.remove('restrict-to'),
-      detectorName: values.remove('detector') ?? 'profile',
-      confidenceWeighted: switch (values.remove('confidence-weighting')) {
-        null => null,
-        final raw => raw != 'off',
-      },
-      functionalBlend: switch (values.remove('functional-blend')) {
-        null => null,
-        final raw => double.parse(raw),
-      },
-      progressionBlend: switch (values.remove('progression-blend')) {
-        null => null,
-        final raw => double.parse(raw),
-      },
-      selfTransition: double.parse(values.remove('self-transition') ?? '0.9'),
-      emissionTemperature: double.parse(
-        values.remove('emission-temperature') ?? '0.25',
-      ),
-      hysteresis: int.parse(values.remove('hysteresis') ?? '1'),
+      recipe: recipe,
+      detectorName:
+          recipe?.detectorName ?? values.remove('detector') ?? 'profile',
+      confidenceWeighted:
+          recipe?.confidenceWeighted ??
+          switch (values.remove('confidence-weighting')) {
+            null => null,
+            final raw => raw != 'off',
+          },
+      functionalBlend:
+          recipe?.functionalBlend ??
+          switch (values.remove('functional-blend')) {
+            null => null,
+            final raw => double.parse(raw),
+          },
+      progressionBlend:
+          recipe?.progressionBlend ??
+          switch (values.remove('progression-blend')) {
+            null => null,
+            final raw => double.parse(raw),
+          },
+      selfTransition:
+          recipe?.selfTransition ??
+          double.parse(values.remove('self-transition') ?? '0.9'),
+      emissionTemperature:
+          recipe?.emissionTemperature ??
+          double.parse(values.remove('emission-temperature') ?? '0.25'),
+      hysteresis:
+          recipe?.hysteresis ?? int.parse(values.remove('hysteresis') ?? '1'),
       sweepMarginFloors: [
         for (final floor in (values.remove('sweep-margin-floors') ?? '').split(
           ',',
         ))
           if (floor.trim().isNotEmpty) double.parse(floor),
       ],
-      profiles: KeyProfilePair.values.byName(
-        values.remove('profiles') ?? 'albrechtShanahan',
-      ),
-      durationWeighted: (values.remove('weighting') ?? 'duration') != 'flat',
+      profiles:
+          recipe?.profiles ??
+          KeyProfilePair.values.byName(
+            values.remove('profiles') ?? 'albrechtShanahan',
+          ),
+      durationWeighted:
+          recipe?.durationWeighted ??
+          (values.remove('weighting') ?? 'duration') != 'flat',
       decayHalfLifeSeconds: switch (values.remove('decay-half-life-seconds')) {
-        null => null,
+        null => recipe?.decayHalfLifeSeconds,
         final raw => int.parse(raw),
       },
       decayHalfLifeEvents: switch (values.remove('decay-half-life-events')) {
-        null => null,
+        null => recipe?.decayHalfLifeEvents,
         final raw => double.parse(raw),
       },
-      minEvents: int.parse(values.remove('min-events') ?? '3'),
+      minEvents:
+          recipe?.minEvents ?? int.parse(values.remove('min-events') ?? '3'),
       marginFloor: switch (values.remove('margin-floor')) {
-        null => null,
+        null => recipe?.marginFloor,
         final raw => double.parse(raw),
       },
-      modeTilt: double.parse(
-        values.remove('mode-tilt') ?? '${HmmKeyDetector.defaultModeTilt}',
-      ),
-      relativeTilt: double.parse(
-        values.remove('relative-tilt') ??
-            '${HmmKeyDetector.defaultRelativeTilt}',
-      ),
-      relativeCadenceTilt: double.parse(
-        values.remove('relative-cadence-tilt') ??
-            '${HmmKeyDetector.defaultRelativeCadenceTilt}',
-      ),
+      modeTilt:
+          recipe?.modeTilt ??
+          double.parse(
+            values.remove('mode-tilt') ?? '${HmmKeyDetector.defaultModeTilt}',
+          ),
+      relativeTilt:
+          recipe?.relativeTilt ??
+          double.parse(
+            values.remove('relative-tilt') ??
+                '${HmmKeyDetector.defaultRelativeTilt}',
+          ),
+      relativeCadenceTilt:
+          recipe?.relativeCadenceTilt ??
+          double.parse(
+            values.remove('relative-cadence-tilt') ??
+                '${HmmKeyDetector.defaultRelativeCadenceTilt}',
+          ),
       hazard: double.parse(
         values.remove('hazard') ?? '${BocpdKeyDetector.defaultHazard}',
       ),

--- a/tool/whatkey/isophonics_extract.py
+++ b/tool/whatkey/isophonics_extract.py
@@ -32,6 +32,13 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from reproducibility import (
+    ANALYSIS_PROFILES,
+    CANONICALIZATION,
+    DEFAULT_ANALYSIS_PROFILE,
+    fixture_hashes,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_SCHEMA = "whatkey-fixture/1"
 MANIFEST_SCHEMA = "whatkey-manifest/1"
@@ -74,6 +81,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--set", dest="set_name", default="isophonics-nc-v1")
     parser.add_argument("--out", type=Path, default=Path("build/whatkey-fixtures"))
     parser.add_argument("--context", default="C:maj")
+    parser.add_argument(
+        "--analysis-profile",
+        choices=ANALYSIS_PROFILES,
+        default=DEFAULT_ANALYSIS_PROFILE,
+        help="Chord-ranking policy used to generate fixture observations.",
+    )
     parser.add_argument("--max-tracks", type=int, default=0, help="0 means all.")
     return parser.parse_args()
 
@@ -121,7 +134,7 @@ def main() -> int:
         file=sys.stderr,
     )
 
-    attach_candidates(fixtures, args.context)
+    attach_candidates(fixtures, args.context, args.analysis_profile)
 
     set_dir = args.out / args.set_name
     set_dir.mkdir(parents=True, exist_ok=True)
@@ -130,6 +143,8 @@ def main() -> int:
         (set_dir / f"{name}.json").write_text(
             json.dumps(fixture, indent=2, sort_keys=True) + "\n"
         )
+    files = [f"{fixture['id'].split('/')[-1]}.json" for fixture in fixtures]
+    hashes, content_hash = fixture_hashes(set_dir, files)
     manifest = {
         "schema": MANIFEST_SCHEMA,
         "set": args.set_name,
@@ -145,6 +160,12 @@ def main() -> int:
             "arguments": sys.argv[1:],
         },
         "context": args.context,
+        "analysisProfile": args.analysis_profile,
+        "contentHash": {
+            "algorithm": "sha256",
+            "canonicalization": CANONICALIZATION,
+            "value": content_hash,
+        },
         "source": {
             "type": "isophonics-choco",
             "chocoRoot": str(args.choco_root),
@@ -161,6 +182,7 @@ def main() -> int:
                 "id": fixture["id"],
                 "title": fixture["title"],
                 "file": f"{fixture['id'].split('/')[-1]}.json",
+                "sha256": hashes[f"{fixture['id'].split('/')[-1]}.json"],
                 "events": len(fixture["events"]),
             }
             for fixture in fixtures
@@ -302,7 +324,9 @@ def parse_degree(token: str) -> tuple[bool, int] | None:
     return bool(removed), (base + offset) % 12
 
 
-def attach_candidates(fixtures: list[dict], context: str) -> None:
+def attach_candidates(
+    fixtures: list[dict], context: str, analysis_profile: str
+) -> None:
     requests = []
     for fixture in fixtures:
         for event in fixture["events"]:
@@ -311,6 +335,7 @@ def attach_candidates(fixtures: list[dict], context: str) -> None:
                     "id": f"{fixture['id']}#{event['index']}",
                     "midiNotes": event["midiNotes"],
                     "context": context,
+                    "analysisProfile": analysis_profile,
                 }
             )
     payload = "".join(json.dumps(request) + "\n" for request in requests)

--- a/tool/whatkey/prepare_data.py
+++ b/tool/whatkey/prepare_data.py
@@ -16,6 +16,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from reproducibility import CANONICALIZATION, fixture_set_sha256
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_ROOT = REPO_ROOT / "build/whatkey-corpora"
@@ -284,6 +286,22 @@ def verify_fixture_set(set_name: str, split_path: Path | None) -> None:
         fixture_count += 1
         event_count += int(entry["events"])
 
+    content_hash = manifest.get("contentHash")
+    if content_hash is not None:
+        require(
+            content_hash.get("algorithm") == "sha256"
+            and content_hash.get("canonicalization") == CANONICALIZATION,
+            set_name,
+            "manifest uses an unsupported fixture hash contract",
+        )
+        actual_hash = fixture_set_sha256(manifest_path.parent)
+        require(
+            actual_hash == content_hash.get("value"),
+            set_name,
+            f"fixture content hash mismatch: {actual_hash}",
+        )
+        print(f"ok: {set_name} content hash {actual_hash}")
+
     if split_path is not None:
         split = json.loads(split_path.read_text())
         counts = split["counts"]["total"]
@@ -320,6 +338,8 @@ def extract_when_in_rome(bench_root: Path) -> None:
             "when-in-rome-v1",
             "--out",
             str(FIXTURE_ROOT),
+            "--analysis-profile",
+            "whatKeyPaper2026",
             "when-in-rome",
             "--bench-root",
             str(bench_root),
@@ -344,6 +364,8 @@ def extract_asap(asap_root: Path) -> None:
             "asap-nc-v2",
             "--max-performances",
             "60",
+            "--analysis-profile",
+            "whatKeyPaper2026",
         ],
         cwd=REPO_ROOT,
     )
@@ -358,6 +380,8 @@ def extract_isophonics(choco_root: Path) -> None:
             str(choco_root),
             "--set",
             "isophonics-nc-v1",
+            "--analysis-profile",
+            "whatKeyPaper2026",
         ],
         cwd=REPO_ROOT,
     )
@@ -372,6 +396,8 @@ def extract_overlap(asap_root: Path, bench_root: Path) -> None:
             str(asap_root),
             "--bench-root",
             str(bench_root),
+            "--analysis-profile",
+            "whatKeyPaper2026",
         ],
         cwd=REPO_ROOT,
     )
@@ -456,8 +482,8 @@ def run_headline() -> None:
             "research/whatkey/data/splits/isophonics-nc-v1.json",
             "--split",
             "test",
-            "--detector",
-            "hmm",
+            "--recipe",
+            "whatKeyPaper2026",
             "--out",
             str(HEADLINE_ROOT / "test-iso-hmm-shipped"),
         ],
@@ -489,6 +515,28 @@ def run_headline() -> None:
             "--root",
             str(HEADLINE_ROOT),
             "--check",
+        ],
+        cwd=REPO_ROOT,
+    )
+    run(
+        [
+            sys.executable,
+            "tool/whatkey/reproducibility.py",
+            "verify",
+            "--fixture",
+            "isophonics-nc-v1",
+            "--fixture-root",
+            str(FIXTURE_ROOT),
+            "--result",
+            "test-iso-hmm-shipped",
+            "--result",
+            "test-iso-m21-temperleykostkapayne",
+            "--result",
+            "test-iso-m21-krumhanslschmuckler",
+            "--result",
+            "test-iso-m21-aardenessen",
+            "--result-root",
+            str(HEADLINE_ROOT),
         ],
         cwd=REPO_ROOT,
     )

--- a/tool/whatkey/replay_batch.dart
+++ b/tool/whatkey/replay_batch.dart
@@ -24,13 +24,32 @@ import 'package:whatchord/whatchord.dart';
 
 import '../src/chord_id_engine.dart';
 
-final _analyzer = ChordAnalyzer();
+final _analyzers = <ChordAnalysisProfile, ChordAnalyzer>{
+  for (final profile in ChordAnalysisProfile.values)
+    profile: ChordAnalyzer(analysisProfile: profile),
+};
+
+// Every caller must declare the chord-ranking policy: a silent default would
+// let a fixture set inherit the wrong profile when a request omits the field.
+String _requireProfile(Map<String, dynamic> request) {
+  final profile = request['analysisProfile'] as String?;
+  if (profile == null) {
+    throw ArgumentError(
+      'Request is missing required "analysisProfile" '
+      '(one of ${ChordAnalysisProfile.values.map((p) => p.name).join(', ')})',
+    );
+  }
+  return profile;
+}
 
 void main() {
   stdin.transform(utf8.decoder).transform(const LineSplitter()).listen((line) {
     if (line.trim().isEmpty) return;
 
     final request = jsonDecode(line) as Map<String, dynamic>;
+    final profile = ChordAnalysisProfile.values.byName(
+      _requireProfile(request),
+    );
     final tonality = parseTonality(request['context'] as String);
     final keySignature = KeySignature.fromTonality(tonality);
     final context = AnalysisContext(
@@ -53,7 +72,9 @@ void main() {
       lastMs = snapshot['timestampMs'] as int;
       final now = DateTime.fromMillisecondsSinceEpoch(lastMs);
       final midiNotes = (snapshot['midiNotes'] as List).cast<int>()..sort();
-      events.addAll(segmenter.onFrame(_frame(midiNotes, context), now));
+      events.addAll(
+        segmenter.onFrame(_frame(midiNotes, context, profile), now),
+      );
     }
     events.addAll(
       segmenter.flush(DateTime.fromMillisecondsSinceEpoch(lastMs + 1)),
@@ -73,7 +94,11 @@ void main() {
 
 /// Mirrors `_captureFrameProvider`: null below three sounding notes, else the
 /// analyzed chord with its surfaced near-tie alternatives.
-CaptureFrame? _frame(List<int> midiNotes, AnalysisContext context) {
+CaptureFrame? _frame(
+  List<int> midiNotes,
+  AnalysisContext context,
+  ChordAnalysisProfile profile,
+) {
   if (midiNotes.length < 3) return null;
 
   var pcMask = 0;
@@ -86,7 +111,11 @@ CaptureFrame? _frame(List<int> midiNotes, AnalysisContext context) {
     noteCount: midiNotes.length,
   );
   final voicing = ObservedVoicing.fromMidi(midiNotes);
-  final ranked = _analyzer.analyze(input, context: context, voicing: voicing);
+  final ranked = _analyzers[profile]!.analyze(
+    input,
+    context: context,
+    voicing: voicing,
+  );
   if (ranked.isEmpty) return null;
 
   return CaptureFrame(

--- a/tool/whatkey/reproducibility.py
+++ b/tool/whatkey/reproducibility.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Hash and verify WhatKey fixture sets and result artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+
+CANONICALIZATION = "whatkey-canonical-json-v1"
+# The scored paper data; additive diagnostics and run metadata are not locked.
+REPORT_DATA_KEYS = (
+    "schema",
+    "fixtures",
+    "split",
+    "detector",
+    "restrictedTo",
+    "summary",
+    "perPiece",
+)
+
+# Chord-ranking policies the extract scripts may select. The default freezes on
+# the WhatKey paper profile so a regenerated research set does not silently pick
+# up later naming improvements. Shared by every extract script so the choice
+# advances in one place.
+ANALYSIS_PROFILES = ("current", "whatKeyPaper2026")
+DEFAULT_ANALYSIS_PROFILE = "whatKeyPaper2026"
+
+# Python and Dart emit identical plain-decimal text only for finite non-integer
+# magnitudes in [1e-4, 1e16); outside that band one side switches to exponent
+# notation (1e-05 vs 0.00001) and the shared SHA-256 diverges. Reject such
+# values at hash time so a set generated here cannot fail to reproduce in Dart.
+CANONICAL_FLOAT_MIN = 1e-4
+CANONICAL_FLOAT_MAX = 1e16
+
+
+def _assert_canonical_floats(value: object) -> None:
+    if isinstance(value, dict):
+        for item in value.values():
+            _assert_canonical_floats(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _assert_canonical_floats(item)
+    elif isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(
+                f"Non-finite number is not canonically hashable: {value!r}"
+            )
+        magnitude = abs(value)
+        if magnitude != 0 and (
+            magnitude < CANONICAL_FLOAT_MIN or magnitude >= CANONICAL_FLOAT_MAX
+        ):
+            raise ValueError(
+                f"Number {value!r} is outside the canonical-JSON range "
+                f"[{CANONICAL_FLOAT_MIN}, {CANONICAL_FLOAT_MAX}); Python and "
+                "Dart would format it differently and hash to different digests."
+            )
+
+
+def canonical_json(value: object) -> bytes:
+    """Stable UTF-8 JSON encoding shared with the Dart harness."""
+    _assert_canonical_floats(value)
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+
+def canonical_sha256(value: object) -> str:
+    return hashlib.sha256(canonical_json(value)).hexdigest()
+
+
+def fixture_hashes(set_dir: Path, files: list[str]) -> tuple[dict[str, str], str]:
+    """Per-file and aggregate hashes, independent of JSON whitespace."""
+    hashes = {
+        name: canonical_sha256(json.loads((set_dir / name).read_text()))
+        for name in sorted(files)
+    }
+    payload = [{"file": name, "sha256": hashes[name]} for name in sorted(hashes)]
+    return hashes, canonical_sha256(payload)
+
+
+def fixture_set_sha256(set_dir: Path) -> str:
+    manifest = json.loads((set_dir / "manifest.json").read_text())
+    files = [entry["file"] for entry in manifest["fixtures"]]
+    return fixture_hashes(set_dir, files)[1]
+
+
+def result_hashes(result_dir: Path) -> dict[str, str]:
+    claims = json.loads((result_dir / "claims.json").read_text())
+    report = json.loads((result_dir / "report.json").read_text())
+    report_data = {key: report.get(key) for key in REPORT_DATA_KEYS}
+    fixtures = report_data.get("fixtures")
+    if isinstance(fixtures, dict):
+        report_data["fixtures"] = {
+            "set": fixtures.get("set"),
+        }
+    if report_data.get("restrictedTo") is not None:
+        report_data["restrictedTo"] = True
+    return {
+        "claimsSha256": canonical_sha256(claims),
+        "resultDataSha256": canonical_sha256(report_data),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    fixtures = subparsers.add_parser("fixtures")
+    fixtures.add_argument("directories", nargs="+", type=Path)
+
+    results = subparsers.add_parser("results")
+    results.add_argument("directories", nargs="+", type=Path)
+
+    verify = subparsers.add_parser("verify")
+    verify.add_argument(
+        "--lock",
+        type=Path,
+        default=Path("research/whatkey/results/reproduction-v2026.7.14.json"),
+    )
+    verify.add_argument("--fixture", action="append", default=[])
+    verify.add_argument("--result", action="append", default=[])
+    verify.add_argument("--fixture-root", type=Path)
+    verify.add_argument("--result-root", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "fixtures":
+        for directory in args.directories:
+            print(f"{fixture_set_sha256(directory)}  {directory}")
+        return 0
+    if args.command == "results":
+        for directory in args.directories:
+            print(json.dumps({"directory": str(directory), **result_hashes(directory)}))
+        return 0
+    return verify_lock(
+        args.lock,
+        args.fixture,
+        args.result,
+        fixture_root=args.fixture_root,
+        result_root=args.result_root,
+    )
+
+
+def verify_lock(
+    lock_path: Path,
+    fixtures: list[str],
+    results: list[str],
+    *,
+    fixture_root: Path | None = None,
+    result_root: Path | None = None,
+) -> int:
+    lock = json.loads(lock_path.read_text())
+    if (
+        lock.get("algorithm") != "sha256"
+        or lock.get("canonicalization") != CANONICALIZATION
+        or lock.get("resultDataFields") != list(REPORT_DATA_KEYS)
+    ):
+        raise SystemExit(f"{lock_path}: unsupported reproduction lock contract")
+    selected_fixtures = fixtures or sorted(lock["fixtures"])
+    selected_results = results or sorted(lock["results"])
+    failed = False
+
+    for name in selected_fixtures:
+        expected = lock["fixtures"][name]
+        directory = fixture_root / name if fixture_root else Path(expected["path"])
+        actual = fixture_set_sha256(directory)
+        ok = actual == expected["sha256"]
+        print(f"{'ok' if ok else 'MISMATCH'} fixture {name}: {actual}")
+        failed |= not ok
+
+    for name in selected_results:
+        expected = lock["results"][name]
+        directory = result_root / name if result_root else Path(expected["path"])
+        actual = result_hashes(directory)
+        # expected.get: a lock entry missing a hash reports MISMATCH, not KeyError.
+        ok = all(actual[key] == expected.get(key) for key in actual)
+        print(
+            f"{'ok' if ok else 'MISMATCH'} result {name}: "
+            f"claims={actual['claimsSha256']} data={actual['resultDataSha256']}"
+        )
+        failed |= not ok
+
+    return int(failed)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tool/whatkey/src/detector_recipe.dart
+++ b/tool/whatkey/src/detector_recipe.dart
@@ -1,0 +1,84 @@
+import 'package:whatkey/whatkey.dart';
+
+/// A complete detector configuration attached to a published result set.
+///
+/// Recipes deliberately repeat every consequential value instead of referring
+/// to mutable detector defaults. The app's user-facing behavior presets remain
+/// independent of these research contracts.
+enum DetectorRecipe {
+  /// Detector used for the WhatKey paper's frozen v2026.7.14 result set.
+  whatKeyPaper2026(
+    detectorName: 'hmm',
+    confidenceWeighted: false,
+    functionalBlend: 0,
+    progressionBlend: 0,
+    selfTransition: 0.9,
+    emissionTemperature: 0.25,
+    hysteresis: 1,
+    profiles: KeyProfilePair.albrechtShanahan,
+    durationWeighted: true,
+    decayHalfLifeSeconds: 30,
+    decayHalfLifeEvents: null,
+    minEvents: 3,
+    marginFloor: 0.3,
+    modeTilt: 2,
+    relativeTilt: 0,
+    relativeCadenceTilt: 0,
+  ),
+
+  /// Faster-decay comparison reported alongside the shipped paper detector.
+  whatKeyPaper2026Reflex(
+    detectorName: 'hmm',
+    confidenceWeighted: false,
+    functionalBlend: 0.1,
+    progressionBlend: 0,
+    selfTransition: 0.9,
+    emissionTemperature: 0.25,
+    hysteresis: 1,
+    profiles: KeyProfilePair.albrechtShanahan,
+    durationWeighted: true,
+    decayHalfLifeSeconds: 1,
+    decayHalfLifeEvents: null,
+    minEvents: 3,
+    marginFloor: 0.3,
+    modeTilt: 2,
+    relativeTilt: 0,
+    relativeCadenceTilt: 0,
+  );
+
+  const DetectorRecipe({
+    required this.detectorName,
+    required this.confidenceWeighted,
+    required this.functionalBlend,
+    required this.progressionBlend,
+    required this.selfTransition,
+    required this.emissionTemperature,
+    required this.hysteresis,
+    required this.profiles,
+    required this.durationWeighted,
+    required this.decayHalfLifeSeconds,
+    required this.decayHalfLifeEvents,
+    required this.minEvents,
+    required this.marginFloor,
+    required this.modeTilt,
+    required this.relativeTilt,
+    required this.relativeCadenceTilt,
+  });
+
+  final String detectorName;
+  final bool confidenceWeighted;
+  final double functionalBlend;
+  final double progressionBlend;
+  final double selfTransition;
+  final double emissionTemperature;
+  final int hysteresis;
+  final KeyProfilePair profiles;
+  final bool durationWeighted;
+  final int decayHalfLifeSeconds;
+  final double? decayHalfLifeEvents;
+  final int minEvents;
+  final double marginFloor;
+  final double modeTilt;
+  final double relativeTilt;
+  final double relativeCadenceTilt;
+}

--- a/tool/whatkey/src/fixtures.dart
+++ b/tool/whatkey/src/fixtures.dart
@@ -11,13 +11,20 @@ import 'package:whatchord/whatchord.dart';
 import 'package:whatkey/whatkey.dart';
 
 import '../../src/chord_id_engine.dart';
+import 'reproducibility.dart';
 
 class FixtureSet {
   final Directory directory;
   final Map<String, dynamic> manifest;
   final List<LabeledFixture> fixtures;
+  final String contentSha256;
 
-  FixtureSet._(this.directory, this.manifest, this.fixtures);
+  FixtureSet._(
+    this.directory,
+    this.manifest,
+    this.fixtures,
+    this.contentSha256,
+  );
 
   String get name => manifest['set'] as String;
 
@@ -29,14 +36,31 @@ class FixtureSet {
         jsonDecode(File('${directory.path}/manifest.json').readAsStringSync())
             as Map<String, dynamic>;
     final context = parseTonality(manifest['context'] as String);
-    final fixtures = <LabeledFixture>[
-      for (final entry in (manifest['fixtures'] as List).cast<Map>())
-        LabeledFixture._load(
-          File('${directory.path}/${entry['file']}'),
-          context,
-        ),
-    ]..sort((a, b) => a.id.compareTo(b.id));
-    return FixtureSet._(directory, manifest, fixtures);
+    // Read and decode each fixture once, keeping the raw content for hashing so
+    // the aggregate hash does not re-read the corpus from disk.
+    final rawByFile = <String, Object?>{};
+    final fixtures = <LabeledFixture>[];
+    for (final entry in (manifest['fixtures'] as List).cast<Map>()) {
+      final file = entry['file'] as String;
+      final raw = (rawByFile[file] ??= jsonDecode(
+        File('${directory.path}/$file').readAsStringSync(),
+      ))!;
+      fixtures.add(
+        LabeledFixture._fromRaw(raw as Map<String, dynamic>, context),
+      );
+    }
+    fixtures.sort((a, b) => a.id.compareTo(b.id));
+    final contentSha256 = fixtureSetSha256FromContents(rawByFile);
+    final set = FixtureSet._(directory, manifest, fixtures, contentSha256);
+    final expectedHash =
+        ((manifest['contentHash'] as Map?)?['value'] as String?);
+    if (expectedHash != null && expectedHash != contentSha256) {
+      throw StateError(
+        'Fixture content hash mismatch: manifest=$expectedHash '
+        'actual=$contentSha256',
+      );
+    }
+    return set;
   }
 }
 
@@ -59,8 +83,7 @@ class LabeledFixture {
     this.labels,
   );
 
-  static LabeledFixture _load(File file, Tonality context) {
-    final raw = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  static LabeledFixture _fromRaw(Map<String, dynamic> raw, Tonality context) {
     final events = <ChordEvent>[];
     final labels = <EventLabels>[];
     for (final entry in (raw['events'] as List).cast<Map>()) {

--- a/tool/whatkey/src/reproducibility.dart
+++ b/tool/whatkey/src/reproducibility.dart
@@ -1,0 +1,104 @@
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+
+const canonicalization = 'whatkey-canonical-json-v1';
+
+/// The scored report fields locked for reproduction. Kept identical to
+/// Python `REPORT_DATA_KEYS` and the lock's `resultDataFields`; the
+/// reproduction-lock test asserts this list matches the lock so the three
+/// cannot drift.
+const resultDataFields = <String>[
+  'schema',
+  'fixtures',
+  'split',
+  'detector',
+  'restrictedTo',
+  'summary',
+  'perPiece',
+];
+
+String canonicalJsonSha256(Object? value) =>
+    sha256.convert(utf8.encode(jsonEncode(_canonicalize(value)))).toString();
+
+String fixtureSetSha256(Directory directory, Map<String, dynamic> manifest) {
+  // Duplicate keys collapse, matching Python's per-file dict: a basename
+  // collision hashes to the same aggregate on both sides.
+  final contents = <String, Object?>{
+    for (final entry in (manifest['fixtures'] as List).cast<Map>())
+      entry['file'] as String: jsonDecode(
+        File('${directory.path}/${entry['file'] as String}').readAsStringSync(),
+      ),
+  };
+  return fixtureSetSha256FromContents(contents);
+}
+
+/// Aggregate hash over already-parsed fixture files, keyed by file name, so
+/// callers that have decoded the corpus once need not re-read it from disk.
+String fixtureSetSha256FromContents(Map<String, Object?> contentsByFile) {
+  final names = contentsByFile.keys.toList()..sort();
+  final payload = <Map<String, String>>[
+    for (final name in names)
+      {'file': name, 'sha256': canonicalJsonSha256(contentsByFile[name])},
+  ];
+  return canonicalJsonSha256(payload);
+}
+
+Map<String, String> resultArtifactHashes(
+  Map<String, Object?> report,
+  Map<String, Object?> claims,
+) {
+  // Hash the scored paper data, not additive diagnostics or run metadata.
+  final reportData = <String, Object?>{
+    for (final key in resultDataFields) key: report[key],
+  };
+  final fixtures = (reportData['fixtures'] as Map?)?.cast<String, Object?>();
+  if (fixtures != null) {
+    reportData['fixtures'] = {'set': fixtures['set']};
+  }
+  if (reportData['restrictedTo'] != null) {
+    reportData['restrictedTo'] = true;
+  }
+  return {
+    'claimsSha256': canonicalJsonSha256(claims),
+    'resultDataSha256': canonicalJsonSha256(reportData),
+  };
+}
+
+Object? _canonicalize(Object? value) {
+  if (value is Map) {
+    return SplayTreeMap<String, Object?>.from({
+      for (final entry in value.entries)
+        entry.key as String: _canonicalize(entry.value),
+    });
+  }
+  if (value is List) return [for (final item in value) _canonicalize(item)];
+  if (value is double) _assertCanonicalDouble(value);
+  return value;
+}
+
+// Dart and Python emit identical plain-decimal text only for finite
+// non-integer magnitudes in [1e-4, 1e16); outside that band one side switches
+// to exponent notation (e.g. 1e-05 vs 0.00001) and the shared SHA-256 diverges.
+// Reject such values loudly at hash time rather than let a set hash
+// differently across the two implementations. All current fixtures and results
+// stay well inside the band.
+const _canonicalDoubleMin = 1e-4;
+const _canonicalDoubleMax = 1e16;
+
+void _assertCanonicalDouble(double value) {
+  if (!value.isFinite) {
+    throw StateError('Non-finite number is not canonically hashable: $value');
+  }
+  final magnitude = value.abs();
+  if (magnitude != 0 &&
+      (magnitude < _canonicalDoubleMin || magnitude >= _canonicalDoubleMax)) {
+    throw StateError(
+      'Number $value is outside the canonical-JSON range '
+      '[$_canonicalDoubleMin, $_canonicalDoubleMax); Dart and Python would '
+      'format it differently and hash to different digests.',
+    );
+  }
+}


### PR DESCRIPTION
The committed fixtures and result artifacts already reproduced the reported detector claims, but nothing proved a future reader could regenerate those fixtures with the current engine. Two post-release chord-naming improvements (altered/split-sixth pricing, the key-functional seventh tie-breaker) had already shifted freshly generated observations, so regenerating from HEAD would have silently produced different numbers.

Add a whatKeyPaper2026 chord-analysis profile that freezes only those two changes while current app analysis stays the default, plus whatKeyPaper2026 and whatKeyPaper2026Reflex detector recipes that pin the shipped and faster-decay HMM configurations. Fixture extractors request the profile explicitly and record it in their manifests; the batch drivers require the field and reject a request that omits it, so no caller can inherit a profile by accident.

Lock the result with canonical-JSON SHA-256 hashes over every fixture file and the stable scored report fields, computed identically in the Dart harness and the Python verifier and pinned in results/reproduction-v2026.7.14.json. Both encoders reject non-integer numbers outside the range where the two languages format floats identically, so a value that would hash differently fails loudly at generation time instead of producing a set that cannot reproduce.

See
research/whatkey/log/2026-07-20-01-historical-reproduction-contract.md.