### PR TITLE
Add a Research Projects section to the articles index

### DIFF
--- a/docs/site/articles/index.html
+++ b/docs/site/articles/index.html
@@ -203,6 +203,16 @@
                 </p>
                 <span class="read-more">Read the article →</span>
               </a>
+            </div>
+          </div>
+
+          <div class="article-group">
+            <h2>Research Projects</h2>
+            <p class="article-group-sub">
+              The open, reproducible investigations behind the app’s features,
+              developed and versioned in the source repository.
+            </p>
+            <div class="article-group-grid article-group-grid-narrow">
               <a
                 class="article-card"
                 href="https://github.com/EarthmanMuons/whatchord/tree/main/research/whatkey"
@@ -212,6 +222,18 @@
                   The research project behind automatic key detection: a frozen
                   evaluation protocol, versioned fixtures, external baselines,
                   dated experiment logs, and held-out results.
+                </p>
+                <span class="read-more">Read the research notes →</span>
+              </a>
+              <a
+                class="article-card"
+                href="https://github.com/EarthmanMuons/whatchord/tree/main/research/chord-context"
+              >
+                <h3>Chord Context Research</h3>
+                <p>
+                  The research project testing whether recently played chords,
+                  and the key they imply, sharpen live chord naming, measured
+                  against a strong baseline on two annotated classical corpora.
                 </p>
                 <span class="read-more">Read the research notes →</span>
               </a>

--- a/docs/site/css/style.css
+++ b/docs/site/css/style.css
@@ -874,10 +874,25 @@ section {
   border-top: 1px solid var(--border);
 }
 
+.article-group-sub {
+  max-width: 540px;
+  margin: -14px 0 24px;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--text-2);
+}
+
 .article-group-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 20px;
+}
+
+/* Groups with only a card or two: keep cards at normal width and
+   left-aligned instead of stretching a lone card across the full row. */
+.article-group-grid-narrow {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 340px));
+  justify-content: start;
 }
 
 @media (width <= 520px) {


### PR DESCRIPTION
The Streaming Key Estimation Research item was the only card in the articles index that linked out to the source repository rather than an on-site article, sitting awkwardly at the end of Technical Deep-Dives. Give research its own group with a short intro line, add a card for the Chord Context research, and cap research cards at normal width so a sparse group does not stretch a card across the full row.