### PR TITLE
Polish the Scale Degree Guide wording and section order

### DIFF
--- a/docs/site/articles/scale-degrees.html
+++ b/docs/site/articles/scale-degrees.html
@@ -257,7 +257,7 @@
           <p>
             The names mirror each other around the tonic: each
             <em>sub-</em> degree sits as far below the tonic as its partner sits
-            above.
+            above. The seventh degree is the one place the mirror bends.
           </p>
 
           <div class="degree-mirror">
@@ -359,8 +359,6 @@
             </svg>
           </div>
 
-          <p>The seventh degree is the one place the mirror bends.</p>
-
           <h3>Leading tone or subtonic</h3>
 
           <p>
@@ -372,22 +370,39 @@
             harmonic minor does, restores the leading tone.
           </p>
 
+          <h2>Numbers, Names, and Solfège</h2>
+
+          <p>
+            Numbers are one of several movable systems for the same idea. In
+            major, the technical names give tonic, supertonic, mediant, and so
+            on, while movable-<em>do</em> solfège names the degrees
+            <em>do, re, mi, fa, sol, la, ti</em>. All three describe notes
+            relative to the tonic rather than as absolute pitches, so their
+            relationships transpose from one key to another.
+          </p>
+
           <h2>Scale Formulas</h2>
 
           <p>
             An interval is the distance between two notes. A flat
             (<code>♭</code>) lowers that distance by one semitone; a sharp
-            (<code>♯</code>) raises it by one. A
-            <strong>major third</strong> spans four semitones, while a
-            <strong>minor third</strong> spans three.
+            (<code>♯</code>) raises it by one. A major third interval spans four
+            semitones, while a minor third interval spans three.
           </p>
 
-          <p>
-            Scale degrees count positions within a scale. C is the third note of
-            A minor, so it is the third degree. Scale formulas describe each
-            note’s interval above the tonic. C is a minor third above A, so the
-            formula labels it <code>♭3</code>.
-          </p>
+          <p>Degree and formula describe a note two different ways:</p>
+
+          <ul>
+            <li>
+              <strong>Scale degrees</strong> count positions within a scale. C
+              is the third note of A minor, so it is degree <code>3</code>.
+            </li>
+            <li>
+              <strong>Scale formulas</strong> describe each note’s interval
+              above the tonic. C is a minor third above A, so the formula labels
+              it <code>♭3</code>.
+            </li>
+          </ul>
 
           <p>
             Scale formulas use the parallel major scale as their reference,
@@ -428,20 +443,9 @@
             3; changes to degrees 6 and 7 distinguish them. That fixed reference
             keeps each formula label tied to one interval, so <code>♭3</code>
             always means a minor third above the tonic. The flat does not mark
-            the note as foreign to the scale; it only compares it with its
-            parallel-major counterpart. This convention is used throughout the
-            guide for scale formulas and Roman-numeral degree labels.
-          </p>
-
-          <h2>Numbers, Solfège, and Names</h2>
-
-          <p>
-            Numbers are one of several movable systems for the same idea. In
-            major, movable-<em>do</em> solfège names the degrees
-            <em>do, re, mi, fa, sol, la, ti</em>, and the technical names give
-            tonic, supertonic, mediant, and so on. All three describe notes
-            relative to the tonic rather than as absolute pitches, so their
-            relationships transpose from one key to another.
+            the note as foreign to the scale; it only compares it with that
+            reference. This convention is used throughout the guide for scale
+            formulas and Roman-numeral degree labels.
           </p>
 
           <h2>Harmonizing the Scale</h2>
@@ -611,9 +615,7 @@
 
           <p>
             C major and A natural minor contain the same notes, but changing the
-            tonic reorders the chords and changes their Roman numerals. The
-            <code>♭</code> prefixes keep the minor-key labels relative to the
-            parallel major.
+            tonic reorders the chords and changes their Roman numerals.
           </p>
 
           <p>
@@ -638,11 +640,15 @@
           <h2>Degrees and Spelling</h2>
 
           <p>
-            Because a conventionally spelled diatonic scale uses each letter
-            once, a degree also fixes the letter its chord’s root is spelled
-            with. The chord a third above the tonic in C is some kind of E; the
-            chord a sixth above is some kind of A; whatever accidentals the key
-            adds, the letter stays put. It holds for altered degrees too: the
+            Because a conventionally spelled
+            <a href="https://en.wikipedia.org/wiki/Diatonic_scale"
+              >diatonic scale</a
+            >
+            uses each letter once, a degree also fixes the letter its chord’s
+            root is spelled with. The chord a third above the tonic in C is some
+            kind of E; the chord a sixth above is some kind of A; whatever
+            accidentals the key adds, the letter stays put. It holds for altered
+            degrees too: the
             <code>♭VI</code> in C is written <span class="chord">A♭</span>, not
             <span class="chord not-used">G♯</span>, because it is still the
             sixth degree, built on the letter A. This is the same


### PR DESCRIPTION
Reorder the naming-systems section, move the mirror-bend note ahead of the diagram, and link diatonic scale to Wikipedia.