### PR TITLE
Link article headers back to the article index

### DIFF
--- a/docs/site/public/css/style.css
+++ b/docs/site/public/css/style.css
@@ -969,11 +969,18 @@ footer {
   border-bottom: 1px solid var(--border);
 }
 
+.article-header-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
 .article-back {
   display: inline-flex;
   gap: 6px;
   align-items: center;
-  margin-bottom: 28px;
   font-size: 0.82rem;
   color: var(--text-2);
   transition: color 0.15s;
@@ -985,7 +992,7 @@ footer {
 }
 
 .article-header .article-tag {
-  margin-bottom: 20px;
+  margin-bottom: 0;
 }
 
 .article-header h1 {

--- a/docs/site/src/layouts/ArticleLayout.astro
+++ b/docs/site/src/layouts/ArticleLayout.astro
@@ -26,8 +26,10 @@ const related = await getEntries(article.data.related);
   <article>
     <div class="article-wrap">
       <header class="article-header">
-        <a class="article-back" href="/">← WhatChord</a>
-        <div class="article-tag">{article.data.tag}</div>
+        <div class="article-header-meta">
+          <a class="article-back" href="/articles/">← Articles</a>
+          <div class="article-tag">{article.data.tag}</div>
+        </div>
         <h1>{article.data.title}</h1>
         {
           article.data.decks.map((deck) => (


### PR DESCRIPTION
- replace the homepage backlink with a direct Articles backlink
- space article metadata explicitly instead of relying on HTML whitespace