### PR TITLE
Raise site text and control contrast to WCAG AA, body text to AAA

### DIFF
--- a/docs/site/public/css/style.css
+++ b/docs/site/public/css/style.css
@@ -39,9 +39,9 @@
   --border-mid: rgb(255 255 255 / 11%);
   --border-strong: rgb(255 255 255 / 18%);
   --text: #eaeaf2;
-  --text-2: #9494ae;
-  --text-3: #4e4e65;
-  --accent: #4080ff;
+  --text-2: #a3a3bb;
+  --text-3: #6a6a85;
+  --accent: #3269e0;
   --accent-light: #7aaaff;
   --accent-bg: rgb(64 128 255 / 9%);
   --accent-border: rgb(64 128 255 / 28%);
@@ -287,7 +287,7 @@ img {
 }
 
 .btn-primary:hover {
-  background: #5592ff;
+  background: #2c5fd4;
 }
 
 .btn-ghost {
@@ -1580,7 +1580,7 @@ a.heading-anchor svg {
   align-items: center;
   height: 22px;
   font-size: 1rem;
-  color: var(--text-3);
+  color: var(--text-2);
 }
 
 /* ─── Segmenter state diagram ────────────────────────────────── */
@@ -2029,6 +2029,7 @@ a.heading-anchor svg {
   .article-page .fn,
   .article-page .pf-endpoint,
   .article-page .symbol-part-label,
+  .article-page .symbol-part-join,
   .article-page .symbol-part-opt,
   .article-page .article-table-note,
   .article-page .article-body code.not-used,
@@ -2353,6 +2354,14 @@ a.heading-anchor svg {
     margin-bottom: 18pt;
     font-size: 11pt;
     line-height: 1.45;
+    color: #333;
+  }
+
+  .articles-index-page .article-group-sub {
+    max-width: none;
+    margin: 0 0 10pt;
+    font-size: 10.5pt;
+    line-height: 1.4;
     color: #333;
   }
 

--- a/docs/site/public/css/try.css
+++ b/docs/site/public/css/try.css
@@ -129,7 +129,7 @@
 }
 
 #notes-input::placeholder {
-  color: var(--text-3);
+  color: #7a7a97;
 }
 
 .try-hint {
@@ -521,7 +521,7 @@ select.try-select:focus {
   }
 
   .try-cost::before {
-    color: var(--text-3);
+    color: var(--text-2);
     content: "Cost ";
   }
 

--- a/docs/site/src/pages/try.astro
+++ b/docs/site/src/pages/try.astro
@@ -169,14 +169,14 @@ import BaseLayout from "../layouts/BaseLayout.astro";
             </div>
             <div id="candidates"></div>
             <p class="try-feedback" id="ranking-feedback" hidden>
-              Disagree with the ranking?
+              Disagree with the ranking?{" "}
               <a
                 href="https://github.com/EarthmanMuons/whatchord/blob/main/SUPPORT.md"
                 >Let us know</a
               >
             </p>
             <p class="try-feedback" id="symbol-legend" hidden>
-              New to these symbols?
+              New to these symbols?{" "}
               <a href="articles/chord-symbols.html">Chord symbol guide</a>
             </p>
           </div>


### PR DESCRIPTION
The --text-3 token was serving as both a text color and a graphics color at 2.40:1, below even the 3:1 non-text floor. Split those roles: readable text (generated "Cost " label, pipeline arrow glyph) moves to --text-2, and --text-3 lightens to #6a6a85 for the heading anchors and diagram strokes that remain.

White button labels sat on --accent at 3.65:1, and the hover state lightened the fill to 3.03:1. Darken --accent to #3269e0 so labels read at 4.96:1, and deepen the hover instead of lightening it. The faint accent tints and --accent-light keep their current hue.

Brighten --text-2 to #a3a3bb so the muted prose tier clears AAA on every surface it lands on: body text goes from 6.56:1 to 7.85:1.

The notes input placeholder takes its own dimmer tone rather than following --text-2, so a pre-filled chord reads as an invitation to type rather than as a value already entered.

Also override --text-2 in print for .symbol-part-join and .article-group-sub, which printed on white at 2.96:1 and would have dropped to 2.47:1 with the brighter token.