### PR TITLE
Scope the chord-symbol webfont to the codepoints it contains

### DIFF
--- a/docs/site/public/css/style.css
+++ b/docs/site/public/css/style.css
@@ -1,17 +1,26 @@
 /* WhatChord site — shared styles */
 
 /* Self-hosted chord-symbol glyphs (accidentals, Delta, degree, half-diminished,
-   minus/plus quality marks). Only these ~11 codepoints live in the font; every
+   minus/plus quality marks). Only these 11 codepoints live in the font; every
    other character falls through to the next family. Prepended to both --font and
    --mono so the glyphs render everywhere. They carry their own proportional
    width, so within monospace code grids the few affected columns are not strictly
-   cell-aligned. */
+   cell-aligned.
+
+   unicode-range must list exactly those 11 codepoints. Without it, mobile
+   WebKit still consults this font when measuring plain Latin runs and lands on
+   an advance width far narrower than what it paints, which shifts every
+   text-anchor="middle" SVG label right of its anchor by about a third of the
+   label width. It also keeps pages with no chord symbols from fetching the
+   font at all. */
 @font-face {
   font-family: "WhatChord Symbols";
   font-style: normal;
   font-weight: 400;
   src: url("../fonts/WhatChordSymbols-Regular.woff2") format("woff2");
   font-display: swap;
+  unicode-range: U+2B, U+B0, U+F8, U+394, U+2212, U+266D-266F, U+1D11E,
+    U+1D12A-1D12B;
 }
 
 @font-face {
@@ -20,6 +29,8 @@
   font-weight: 700;
   src: url("../fonts/WhatChordSymbols-Bold.woff2") format("woff2");
   font-display: swap;
+  unicode-range: U+2B, U+B0, U+F8, U+394, U+2212, U+266D-266F, U+1D11E,
+    U+1D12A-1D12B;
 }
 
 *,


### PR DESCRIPTION
Mobile WebKit consults the first font in the stack when measuring a text run, even for characters that font does not have. "WhatChord Symbols" holds 11 glyphs and no unicode-range, so plain Latin runs measured against it came back about a third of their painted width. In SVG that stale width feeds the text-anchor offset, and every centered label in the state diagram and the key-profile chart sat a third of its own width right of its anchor. The drift showed up on iOS at enlarged accessibility text sizes and cleared on any relayout, which kept it off the desktop.

Declare unicode-range on both faces so the font is only ever selected for the accidentals, Delta, degree, half-diminished, and minus/plus marks it actually carries. Pages with no chord symbols now skip the download.