### PR TITLE
Bump hard-coded compileSdk override to version 37

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -21,8 +21,10 @@ subprojects {
         afterEvaluate {
             extensions.configure<com.android.build.api.dsl.LibraryExtension> {
                 // flutter_pcm_sound 3.3.3 hard-codes API 33, but its resolved
-                // AndroidX dependencies require API 34 or newer.
-                compileSdk = 36
+                // AndroidX dependencies require API 34 or newer. The plugin
+                // permission_handler_android requires Android SDK version 37
+                // or higher.
+                compileSdk = 37
             }
         }
     }


### PR DESCRIPTION
The plugin permission_handler_android requires Android SDK version 37 or higher. We still have to maintain this override due to flutter_pcm_sound not yet integrating the `flutter.compileSdkVersion` fix upstream.

See:

- https://github.com/chipweinberger/flutter_pcm_sound/issues/51