### PR TITLE
Compile Android app against SDK 37

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -16,7 +16,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "com.earthmanmuons.whatchord"
-    compileSdk = flutter.compileSdkVersion
+    compileSdk = 37 // TODO: revert to flutter.compileSdkVersion once upstream is at least 37
     ndkVersion = flutter.ndkVersion
 
     compileOptions {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -21,10 +21,8 @@ subprojects {
         afterEvaluate {
             extensions.configure<com.android.build.api.dsl.LibraryExtension> {
                 // flutter_pcm_sound 3.3.3 hard-codes API 33, but its resolved
-                // AndroidX dependencies require API 34 or newer. The plugin
-                // permission_handler_android requires Android SDK version 37
-                // or higher.
-                compileSdk = 37
+                // AndroidX dependencies require API 34 or newer.
+                compileSdk = 36
             }
         }
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "9.0.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("com.android.application") version "9.1.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.0" apply false
 }
 
 include(":app")


### PR DESCRIPTION
Upgrade AGP, Gradle, and Kotlin to versions compatible with API 37. Compile the app against API 37 while retaining the API 36 workaround for flutter_pcm_sound.