### PR TITLE
Mention live polychord recognition in product copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ simple note-matching.
 
 - **Live chord identification**\
   Connect a Bluetooth or USB MIDI keyboard and see chords update instantly as
-  you play.
+  you play. Clear polychords played as distinct chordal layers are shown in
+  familiar stacked notation.
 
 - **Automatic key detection**\
   Auto mode listens to your recent live chords, estimates the current key, shows

--- a/docs/marketplace/description.md
+++ b/docs/marketplace/description.md
@@ -11,7 +11,7 @@ WhatChord goes beyond simple note matching. Its musically informed analysis cons
 FEATURES
 
 - Real-time chord recognition  
-  Chord names update immediately as you play.
+  Chord names update immediately as you play, including polychords shown in familiar stacked notation.
 
 - Automatic key detection
   Auto mode estimates the current key from recent live chords, shows confidence across major and minor keys, and can keep the app's key context following your playing.

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -55,7 +55,8 @@ const featuredArticles = (await getCollection("articles"))
                 everything from simple triads to rich extended harmony with the
                 same quick feedback. Chord symbols appear in whichever notation
                 style you prefer, traditional symbols or text (Δ versus maj7,
-                for instance).
+                for instance). When live MIDI reveals two clear chordal layers,
+                it can also display them in familiar stacked polychord notation.
               </p>
             </div>
             <MotionMedia


### PR DESCRIPTION
Update the README, marketplace description, and website homepage to highlight conservative stacked-polychord recognition from live MIDI.